### PR TITLE
Intentional failing PR to verify develop blocking

### DIFF
--- a/test/failing_pr_test.dart
+++ b/test/failing_pr_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('intentional failure to verify PR blocking behavior', () {
+    expect(1, 2);
+  });
+}


### PR DESCRIPTION
## What changed

Add a single intentionally failing test on an isolated branch.

## Why

This PR is only for validating how develop-targeted protections behave when CI should block a merge. It should remain unmerged.

## Test checklist

- [x] `dart format -o none --set-exit-if-changed test/failing_pr_test.dart` passes
- [x] `flutter analyze` reports no issues
- [x] `flutter test` fails intentionally

## Main risk

If merged accidentally, the repository test suite would be broken. This PR must stay closed or be reverted.

## Notes for AI review

This failure is intentional. Focus on whether the PR is correctly blocked by CI / required checks rather than asking for a code fix.