### PR TITLE
Feature/issue4 리스트 인피니트 스크롤 적용

### DIFF
--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../services/ai/prediction_service.dart';
 
 class ConsumableItem {
   final String id;
@@ -36,35 +37,50 @@ class ConsumableItem {
         .map((p) => PurchaseRecord.fromJson(p as Map<String, dynamic>))
         .toList();
 
-    // DB에서 주기 가져오기 (없으면 기본 30일)
-    final int cycle = json['replacement_cycle_days'] ?? 30;
+    // 구매 날짜 리스트 추출
+    List<DateTime> purchaseDates = history.map((p) => p.date).toList();
 
-    int calculatedDays;
-    double progress;
+    // DB에서 기본 주기 및 등록일 가져오기
+    final int defaultCycle = json['replacement_cycle_days'] ?? 30;
+    // 등록일이 없으면 현재 시간으로 처리
+    final DateTime registeredAt = json['created_at'] != null
+        ? DateTime.parse(json['created_at'])
+        : DateTime.now();
 
-    if (history.isNotEmpty) {
-      // 최근 구매일 기준 D-Day 계산 로직
-      final lastPurchase = history.first.date;
-      final nextReplacement = lastPurchase.add(Duration(days: cycle));
-      calculatedDays = nextReplacement.difference(DateTime.now()).inDays;
+    final prediction = predictCycle(
+      purchaseDates: purchaseDates,
+      categoryDefaultDays: defaultCycle,
+    );
 
-      // 잔량 게이지 계산 (남은날짜 / 전체주기)
-      progress = (calculatedDays / cycle).clamp(0.0, 1.0);
-    } else {
-      // 구매 기록 없으면 새 제품으로 간주
-      calculatedDays = cycle;
-      progress = 1.0;
-    }
+    // 예측 주기를 바탕으로 D-Day 계산
+    final int calculatedDays = calcDday(
+      purchaseDates: purchaseDates,
+      predictedCycleDays: prediction.predictedCycleDays,
+      registeredAt: registeredAt,
+    );
+
+    // 잔여량
+    final double progress = calcRemainingPercent(
+      purchaseDates: purchaseDates,
+      predictedCycleDays: prediction.predictedCycleDays,
+      registeredAt: registeredAt,
+    );
 
     return ConsumableItem(
       id: json['id'].toString(),
       name: json['name'] ?? '이름 없음',
       brand: json['brand'] ?? '브랜드 없음',
-      category: '기타', // 나중에 category_id로 이름 가져오는 로직 추가 가능
+      category: '기타',
       icon: Icons.inventory_2_outlined,
+
       daysRemaining: calculatedDays,
-      cycleDays: cycle,
+      cycleDays: prediction.predictedCycleDays,
       progress: progress,
+
+      // Phase에 따른 정밀한 예측일수와 신뢰도 반영
+      aiPredictedDays: prediction.predictedCycleDays,
+      aiConfidence: prediction.confidence,
+
       imageUrl: json['image_url'],
       purchaseHistory: history,
     );
@@ -76,7 +92,7 @@ class PurchaseRecord {
   final int price; // 구매 가격
   final String store; // 구매처
 
-  PurchaseRecord({
+  const PurchaseRecord({
     required this.date,
     required this.price,
     required this.store,
@@ -85,7 +101,6 @@ class PurchaseRecord {
   // JSON -> PurchaseRecord 객체 변환
   factory PurchaseRecord.fromJson(Map<String, dynamic> json) {
     return PurchaseRecord(
-      // DB의 'purchase_date' 컬럼이 문자열이라고 가정하고 DateTime
       date: json['purchase_date'] != null
           ? DateTime.parse(json['purchase_date'])
           : (json['created_at'] != null

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart'; // [Issue 4] Supabase 연동을 위한 임포트
+import 'package:supabase_flutter/supabase_flutter.dart';
 import '../theme/app_theme.dart';
 import '../widgets/item_card.dart';
-import '../models/item.dart'; // [Issue 4] DB 데이터를 담을 모델 클래스 임포트
+import '../models/item.dart';
 import 'item_detail_screen.dart';
 
-// [Issue 4] 실시간 데이터 반영 및 상태 관리를 위해 StatefulWidget으로 전환
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
@@ -14,54 +13,101 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  // [Issue 4] Supabase 클라이언트 및 로컬 상태 변수 선언
   final _supabase = Supabase.instance.client;
+
+  // 인피니티 스크롤 전용 컨트롤 및 변수
+  final ScrollController _scrollController = ScrollController();
   List<ConsumableItem> _items = [];
-  bool _isLoading = true;
+  bool _isLoading = true; // 첫 로딩 상태
+  bool _isMoreLoading = false; // 추가 페이지 로딩 상태
+  bool _hasNextPage = true; // 더 가져올 데이터가 있는지 여부
+  int _currentPage = 0; // 현재 페이지 번호
+  final int _pageSize = 10; // 한 번에 가져올 아이템 수
 
   @override
   void initState() {
     super.initState();
-    // [Issue 4] 샘플 데이터 대신 실제 DB 데이터를 가져오도록 수정
-    _fetchDbData();
+    _fetchDbData(isInitial: true);
+
+    // 스크롤 리스너 등록: 사용자가 끝까지 내렸는지 확인
+    _scrollController.addListener(() {
+      if (_scrollController.position.pixels >=
+              _scrollController.position.maxScrollExtent * 0.9 &&
+          !_isMoreLoading &&
+          _hasNextPage) {
+        _fetchDbData(); // 다음 페이지 호출
+      }
+    });
   }
 
-  // [Issue 4] Supabase에서 product_items와 purchases를 Join하여 가져오는 핵심 함수
-  Future<void> _fetchDbData() async {
-    // 데이터를 새로 불러올 때 로딩 상태를 확실히 하기 위해 true로 설정
-    if (!_isLoading) setState(() => _isLoading = true);
+  @override
+  void dispose() {
+    _scrollController.dispose(); // 메모리 누수 방지
+    super.dispose();
+  }
+
+  // Supabase 페이지네이션 쿼리 함수
+  Future<void> _fetchDbData({bool isInitial = false}) async {
+    if (isInitial) {
+      setState(() {
+        _isLoading = true;
+        _currentPage = 0;
+        _hasNextPage = true;
+        _items = [];
+      });
+    } else {
+      setState(() => _isMoreLoading = true);
+    }
 
     try {
+      // 시작 지점(from)과 끝 지점(to) 계산
+      final from = _currentPage * _pageSize;
+      final to = from + _pageSize - 1;
+
       final response = await _supabase
           .from('product_items')
-          .select('*, purchases(*)') // 릴레이션 조인으로 하위 구매이력 동시 조회
-          .order('created_at', ascending: false);
+          .select('*, purchases(*)')
+          .order('created_at', ascending: false)
+          .range(from, to);
 
       final List<dynamic> data = response;
+      final newItems = data
+          .map((json) => ConsumableItem.fromJson(json))
+          .toList();
 
       setState(() {
-        // JSON -> 객체 변환
-        _items = data.map((json) => ConsumableItem.fromJson(json)).toList();
+        _items.addAll(newItems);
         _isLoading = false;
+        _isMoreLoading = false;
+
+        // 가져온 데이터가 요청한 개수보다 적으면 '마지막 페이지'로 간주
+        if (newItems.length < _pageSize) {
+          _hasNextPage = false;
+        } else {
+          _currentPage++;
+        }
       });
     } catch (e) {
       debugPrint('데이터 로딩 에러: $e');
-      setState(() => _isLoading = false);
+      setState(() {
+        _isLoading = false;
+        _isMoreLoading = false;
+      });
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    // D-Day 순 정렬
     final upcoming = List.of(_items)
       ..sort((a, b) => a.daysRemaining.compareTo(b.daysRemaining));
 
     return SafeArea(
-      // [Issue 4] 데이터 로딩 상태에 따른 조건부 렌더링 (로딩 인디케이터 표시)
       child: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : CustomScrollView(
+              controller: _scrollController, // 컨트롤러 연결
               slivers: [
-                // Header
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
@@ -69,7 +115,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          '안녕하세요, 재현님',
+                          '안녕하세요, 사용자님',
                           style: Theme.of(context).textTheme.headlineMedium,
                         ),
                         const SizedBox(height: 4),
@@ -82,7 +128,6 @@ class _HomeScreenState extends State<HomeScreen> {
                   ),
                 ),
 
-                // Upcoming Replacements
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(20, 28, 20, 14),
@@ -108,7 +153,6 @@ class _HomeScreenState extends State<HomeScreen> {
                 SliverToBoxAdapter(
                   child: SizedBox(
                     height: 185,
-                    // [Issue 4] DB 데이터 유무에 따른 예외 처리
                     child: upcoming.isEmpty
                         ? const Center(child: Text('등록된 아이템이 없습니다.'))
                         : ListView.separated(
@@ -117,52 +161,45 @@ class _HomeScreenState extends State<HomeScreen> {
                             itemCount: upcoming.length,
                             separatorBuilder: (_, __) =>
                                 const SizedBox(width: 12),
-                            itemBuilder: (context, index) {
-                              final item = upcoming[index];
-                              return ItemCard(
-                                item: item,
-                                onTap: () => Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (_) =>
-                                        ItemDetailScreen(item: item),
-                                  ),
+                            itemBuilder: (context, index) => ItemCard(
+                              item: upcoming[index],
+                              onTap: () => Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) =>
+                                      ItemDetailScreen(item: upcoming[index]),
                                 ),
-                              );
-                            },
+                              ),
+                            ),
                           ),
                   ),
                 ),
 
-                // Recent Purchases
+                // 최근 구매 리스트 영역
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: const EdgeInsets.fromLTRB(20, 28, 20, 14),
                     child: Text(
-                      '최근 구매',
+                      '전체 품목 리스트',
                       style: Theme.of(context).textTheme.titleLarge,
-                    ),
+                    ), // 인피니트 스크롤 확인을 위해 전체 리스트로 표시
                   ),
                 ),
-                // [Issue 4] 구매 내역 필터링 및 리스트 렌더링
+
                 _items.isEmpty
                     ? const SliverToBoxAdapter(
-                        child: Center(child: Text('최근 구매 내역이 없습니다.')),
+                        child: Center(child: Text('내역이 없습니다.')),
                       )
                     : SliverPadding(
                         padding: const EdgeInsets.symmetric(horizontal: 20),
                         sliver: SliverList.separated(
-                          itemCount: _items
-                              .where((i) => i.purchaseHistory.isNotEmpty)
-                              .length,
+                          itemCount: _items.length,
                           separatorBuilder: (_, __) =>
                               const SizedBox(height: 10),
                           itemBuilder: (context, index) {
-                            final purchasedItems = _items
-                                .where((i) => i.purchaseHistory.isNotEmpty)
-                                .toList();
-                            final item = purchasedItems[index];
+                            final item = _items[index];
                             return PurchaseListItem(
+                              // 리스트 형태의 아이템 위젯
                               item: item,
                               onTap: () => Navigator.push(
                                 context,
@@ -174,7 +211,18 @@ class _HomeScreenState extends State<HomeScreen> {
                           },
                         ),
                       ),
-                const SliverToBoxAdapter(child: SizedBox(height: 24)),
+
+                // 스크롤 하단 로딩 인디케이터
+                if (_isMoreLoading)
+                  const SliverToBoxAdapter(
+                    child: Padding(
+                      padding: EdgeInsets.symmetric(vertical: 20),
+                      child: Center(child: CircularProgressIndicator()),
+                    ),
+                  ),
+
+                // 마지막 여백
+                const SliverToBoxAdapter(child: SizedBox(height: 50)),
               ],
             ),
     );


### PR DESCRIPTION
## 💡 작업 내용
- `home_screen.dart`에 `ScrollController`를 추가하여 스크롤 하단 감지 로직을 구현했습니다.
- Supabase의 `range()` 메서드를 활용해 한 번에 10개씩 데이터를 불러오도록 최적화했습니다.
- 데이터를 추가로 불러오는 동안 하단에 로딩 인디케이터가 뜨고, 중복 API 호출을 막는 방어 로직을 추가했습니다.

## ✅ 테스트/확인 사항
- 테스트 데이터 100개를 넣고 스크롤 시 10개씩 부드럽게 추가 로딩되는 것을 확인했습니다.
- 더 이상 불러올 데이터가 없을 때(`_hasNextPage == false`) API 호출이 멈추는 것을 확인했습니다.