### PR TITLE
[#8] 월간 지출 리포트 집계 서비스 및 위젯 분할 (PR1)

### DIFF
--- a/lib/screens/reports_screen.dart
+++ b/lib/screens/reports_screen.dart
@@ -1,26 +1,15 @@
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+
+import '../data/sample_data.dart';
+import '../services/report_service.dart';
 import '../theme/app_theme.dart';
+import '../widgets/reports/category_pie_chart.dart';
+import '../widgets/reports/month_filter_list_view.dart';
+import '../widgets/reports/monthly_bar_chart.dart';
+import '../widgets/reports/share_action_button.dart';
 
 class ReportsScreen extends StatelessWidget {
   const ReportsScreen({super.key});
-
-  static const _categories = [
-    {'name': '위생', 'amount': 42500, 'color': Color(0xFF0891B2), 'percent': 31},
-    {'name': '필터', 'amount': 35000, 'color': Color(0xFF059669), 'percent': 25},
-    {'name': '세탁', 'amount': 32400, 'color': Color(0xFFD97706), 'percent': 23},
-    {'name': '주방', 'amount': 18700, 'color': Color(0xFF7C3AED), 'percent': 14},
-    {'name': '기타', 'amount': 9800, 'color': Color(0xFFEC4899), 'percent': 7},
-  ];
-
-  static const _monthlyData = [
-    {'month': '11월', 'amount': 125000},
-    {'month': '12월', 'amount': 98000},
-    {'month': '1월', 'amount': 142000},
-    {'month': '2월', 'amount': 110000},
-    {'month': '3월', 'amount': 138400},
-    {'month': '4월', 'amount': 85000},
-  ];
 
   String _formatPrice(int price) {
     final str = price.toString();
@@ -34,15 +23,38 @@ class ReportsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final service = ReportService.fromItems(SampleData.items);
+    final months = service.aggregateRecentMonths();
+    // 요약/파이/상세는 지출이 있는 최신 월을 우선 사용해 "빈 현재 월 → 0원"
+    // UX 회귀를 피한다. 전부 0원이면 months.last로 fallback.
+    final latest =
+        service.latestMonthlyWithSpending() ??
+        (months.isEmpty ? null : months.last);
+    final breakdown = latest == null
+        ? <CategoryBreakdown>[]
+        : service.categoryBreakdownFor(latest.month);
+
+    final latestTitle = latest == null
+        ? '지출 현황'
+        : '${latest.month.month}월 지출 현황';
+    final latestYear = latest == null ? '-' : '${latest.month.year}';
+    final latestTotal = latest?.totalAmount ?? 0;
+
     return SafeArea(
       child: CustomScrollView(
         slivers: [
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-              child: Text(
-                '리포트',
-                style: Theme.of(context).textTheme.headlineMedium,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    '리포트',
+                    style: Theme.of(context).textTheme.headlineMedium,
+                  ),
+                  ShareActionButton(service: service),
+                ],
               ),
             ),
           ),
@@ -61,20 +73,20 @@ class ReportsScreen extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Row(
+                    Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         Text(
-                          '4월 지출 현황',
-                          style: TextStyle(
+                          latestTitle,
+                          style: const TextStyle(
                             fontSize: 16,
                             fontWeight: FontWeight.w600,
                             color: AppColors.text,
                           ),
                         ),
                         Text(
-                          '2026',
-                          style: TextStyle(
+                          latestYear,
+                          style: const TextStyle(
                             fontSize: 13,
                             color: AppColors.textMuted,
                           ),
@@ -83,7 +95,7 @@ class ReportsScreen extends StatelessWidget {
                     ),
                     const SizedBox(height: 6),
                     Text(
-                      _formatPrice(138400),
+                      _formatPrice(latestTotal),
                       style: const TextStyle(
                         fontSize: 28,
                         fontWeight: FontWeight.w700,
@@ -93,71 +105,7 @@ class ReportsScreen extends StatelessWidget {
                     const SizedBox(height: 24),
 
                     // Donut chart
-                    SizedBox(
-                      height: 200,
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: PieChart(
-                              PieChartData(
-                                sectionsSpace: 2,
-                                centerSpaceRadius: 45,
-                                sections: _categories.map((c) {
-                                  return PieChartSectionData(
-                                    value: (c['percent'] as int).toDouble(),
-                                    color: c['color'] as Color,
-                                    radius: 35,
-                                    showTitle: false,
-                                  );
-                                }).toList(),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 20),
-                          Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: _categories.map((c) {
-                              return Padding(
-                                padding: const EdgeInsets.only(bottom: 8),
-                                child: Row(
-                                  children: [
-                                    Container(
-                                      width: 10,
-                                      height: 10,
-                                      decoration: BoxDecoration(
-                                        color: c['color'] as Color,
-                                        borderRadius: BorderRadius.circular(3),
-                                      ),
-                                    ),
-                                    const SizedBox(width: 8),
-                                    SizedBox(
-                                      width: 35,
-                                      child: Text(
-                                        c['name'] as String,
-                                        style: const TextStyle(
-                                          fontSize: 12,
-                                          color: AppColors.textSecondary,
-                                        ),
-                                      ),
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      '${c['percent']}%',
-                                      style: const TextStyle(
-                                        fontSize: 12,
-                                        fontWeight: FontWeight.w600,
-                                        color: AppColors.text,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              );
-                            }).toList(),
-                          ),
-                        ],
-                      ),
-                    ),
+                    CategoryPieChart(data: breakdown),
                   ],
                 ),
               ),
@@ -247,79 +195,7 @@ class ReportsScreen extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 20),
-                    SizedBox(
-                      height: 180,
-                      child: BarChart(
-                        BarChartData(
-                          alignment: BarChartAlignment.spaceAround,
-                          maxY: 160000,
-                          gridData: FlGridData(
-                            show: true,
-                            drawVerticalLine: false,
-                            horizontalInterval: 50000,
-                            getDrawingHorizontalLine: (value) => FlLine(
-                              color: AppColors.border,
-                              strokeWidth: 0.5,
-                            ),
-                          ),
-                          borderData: FlBorderData(show: false),
-                          titlesData: FlTitlesData(
-                            topTitles: const AxisTitles(
-                              sideTitles: SideTitles(showTitles: false),
-                            ),
-                            rightTitles: const AxisTitles(
-                              sideTitles: SideTitles(showTitles: false),
-                            ),
-                            leftTitles: const AxisTitles(
-                              sideTitles: SideTitles(showTitles: false),
-                            ),
-                            bottomTitles: AxisTitles(
-                              sideTitles: SideTitles(
-                                showTitles: true,
-                                getTitlesWidget: (value, meta) {
-                                  if (value.toInt() >= 0 &&
-                                      value.toInt() < _monthlyData.length) {
-                                    return Padding(
-                                      padding: const EdgeInsets.only(top: 8),
-                                      child: Text(
-                                        _monthlyData[value.toInt()]['month']
-                                            as String,
-                                        style: const TextStyle(
-                                          fontSize: 11,
-                                          color: AppColors.textMuted,
-                                        ),
-                                      ),
-                                    );
-                                  }
-                                  return const SizedBox.shrink();
-                                },
-                              ),
-                            ),
-                          ),
-                          barGroups: _monthlyData.asMap().entries.map((entry) {
-                            final isLatest =
-                                entry.key == _monthlyData.length - 1;
-                            return BarChartGroupData(
-                              x: entry.key,
-                              barRods: [
-                                BarChartRodData(
-                                  toY: (entry.value['amount'] as int)
-                                      .toDouble(),
-                                  width: 28,
-                                  color: isLatest
-                                      ? AppColors.primary
-                                      : AppColors.primary.withOpacity(0.3),
-                                  borderRadius: const BorderRadius.only(
-                                    topLeft: Radius.circular(6),
-                                    topRight: Radius.circular(6),
-                                  ),
-                                ),
-                              ],
-                            );
-                          }).toList(),
-                        ),
-                      ),
-                    ),
+                    MonthlyBarChart(data: months),
                   ],
                 ),
               ),
@@ -343,10 +219,12 @@ class ReportsScreen extends StatelessWidget {
           SliverPadding(
             padding: const EdgeInsets.symmetric(horizontal: 20),
             sliver: SliverList.separated(
-              itemCount: _categories.length,
+              itemCount: breakdown.length,
               separatorBuilder: (_, __) => const SizedBox(height: 8),
               itemBuilder: (context, index) {
-                final c = _categories[index];
+                final c = breakdown[index];
+                final color = colorForCategory(c.category);
+                final percent = (c.ratio * 100).round();
                 return Container(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 16,
@@ -363,7 +241,7 @@ class ReportsScreen extends StatelessWidget {
                         width: 38,
                         height: 38,
                         decoration: BoxDecoration(
-                          color: (c['color'] as Color).withOpacity(0.12),
+                          color: color.withOpacity(0.12),
                           borderRadius: BorderRadius.circular(10),
                         ),
                         child: Center(
@@ -371,7 +249,7 @@ class ReportsScreen extends StatelessWidget {
                             width: 12,
                             height: 12,
                             decoration: BoxDecoration(
-                              color: c['color'] as Color,
+                              color: color,
                               borderRadius: BorderRadius.circular(4),
                             ),
                           ),
@@ -383,7 +261,7 @@ class ReportsScreen extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              c['name'] as String,
+                              c.category,
                               style: const TextStyle(
                                 fontSize: 14,
                                 fontWeight: FontWeight.w500,
@@ -394,11 +272,11 @@ class ReportsScreen extends StatelessWidget {
                             ClipRRect(
                               borderRadius: BorderRadius.circular(3),
                               child: LinearProgressIndicator(
-                                value: (c['percent'] as int) / 100,
+                                value: c.ratio,
                                 minHeight: 4,
                                 backgroundColor: AppColors.border,
                                 valueColor: AlwaysStoppedAnimation<Color>(
-                                  c['color'] as Color,
+                                  color,
                                 ),
                               ),
                             ),
@@ -410,7 +288,7 @@ class ReportsScreen extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: [
                           Text(
-                            _formatPrice(c['amount'] as int),
+                            _formatPrice(c.amount),
                             style: const TextStyle(
                               fontSize: 14,
                               fontWeight: FontWeight.w600,
@@ -418,7 +296,7 @@ class ReportsScreen extends StatelessWidget {
                             ),
                           ),
                           Text(
-                            '${c['percent']}%',
+                            '$percent%',
                             style: const TextStyle(
                               fontSize: 12,
                               color: AppColors.textMuted,
@@ -431,6 +309,9 @@ class ReportsScreen extends StatelessWidget {
                 );
               },
             ),
+          ),
+          SliverToBoxAdapter(
+            child: MonthFilterListView(selectedMonth: null, service: service),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 24)),
         ],

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -1,0 +1,139 @@
+import '../models/item.dart';
+
+/// 월간 지출 리포트 집계 서비스.
+///
+/// 주의(Supabase 호환성, Issue #1):
+///   현재 구현은 **동기 in-memory**다. 향후 Supabase 연동 시 async 변형이
+///   추가될 수 있으며, 이때 본 클래스의 시그니처는 breaking change를
+///   동반할 수 있다. 소비자는 repository 주입 형태로 리팩토링될 가능성을
+///   전제로 호출부를 얇게 유지할 것.
+///
+/// 카테고리 의미론 (스냅샷):
+///   과거 `PurchaseRecord` 시점의 카테고리는 별도 저장되지 않으므로,
+///   모든 집계는 **현재 `ConsumableItem.category`로 스냅샷 귀속**된다.
+///   즉, 아이템의 카테고리가 바뀌면 과거 지출도 새 카테고리로 재귀속된다.
+class ReportService {
+  ReportService({required this.source});
+
+  factory ReportService.fromItems(List<ConsumableItem> items) =>
+      ReportService(source: items);
+
+  final List<ConsumableItem> source;
+
+  static DateTime _monthKey(DateTime d) => DateTime(d.year, d.month, 1);
+
+  /// 최근 N개월 집계(기본 6). 오래된 → 최신 순. `now`는 테스트 주입용.
+  List<MonthlySpending> aggregateRecentMonths({int months = 6, DateTime? now}) {
+    final latest = _monthKey(now ?? DateTime.now());
+
+    final buckets = <DateTime>[
+      for (var i = months - 1; i >= 0; i--)
+        DateTime(latest.year, latest.month - i, 1),
+    ];
+
+    return buckets.map((bucket) {
+      var total = 0;
+      final byCategory = <String, int>{};
+      final itemsInBucket = <ConsumableItem>[];
+
+      for (final item in source) {
+        var matched = false;
+        for (final pr in item.purchaseHistory) {
+          if (_monthKey(pr.date) == bucket) {
+            total += pr.price;
+            byCategory[item.category] =
+                (byCategory[item.category] ?? 0) + pr.price;
+            matched = true;
+          }
+        }
+        if (matched) itemsInBucket.add(item);
+      }
+
+      return MonthlySpending(
+        month: bucket,
+        totalAmount: total,
+        byCategory: byCategory,
+        items: itemsInBucket,
+      );
+    }).toList();
+  }
+
+  /// 특정 월의 카테고리 breakdown (ratio 포함). 데이터 없으면 빈 리스트.
+  List<CategoryBreakdown> categoryBreakdownFor(DateTime month) {
+    final key = _monthKey(month);
+    var total = 0;
+    final byCategory = <String, int>{};
+
+    for (final item in source) {
+      for (final pr in item.purchaseHistory) {
+        if (_monthKey(pr.date) == key) {
+          total += pr.price;
+          byCategory[item.category] =
+              (byCategory[item.category] ?? 0) + pr.price;
+        }
+      }
+    }
+
+    if (total == 0) return const <CategoryBreakdown>[];
+
+    return byCategory.entries
+        .map(
+          (e) => CategoryBreakdown(
+            category: e.key,
+            amount: e.value,
+            ratio: e.value / total,
+          ),
+        )
+        .toList()
+      ..sort((a, b) => b.amount.compareTo(a.amount));
+  }
+
+  /// 최근 N개월 창에서 지출이 있는 가장 최신 월. 모두 0원이면 `null`.
+  ///
+  /// 현재 월에 아직 구매가 없으면 `aggregateRecentMonths().last`는 0원 버킷이
+  /// 되어 요약 화면이 "0원"으로 깨진다. 화면은 이 값으로 "의미 있는 최신 월"을
+  /// 고르고, null이면 빈 상태 UI로 fallback한다.
+  MonthlySpending? latestMonthlyWithSpending({int months = 6, DateTime? now}) {
+    final buckets = aggregateRecentMonths(months: months, now: now);
+    for (var i = buckets.length - 1; i >= 0; i--) {
+      if (buckets[i].totalAmount > 0) return buckets[i];
+    }
+    return null;
+  }
+
+  /// 특정 월의 구매 이력을 가진 아이템들.
+  List<ConsumableItem> itemsOfMonth(DateTime month) {
+    final key = _monthKey(month);
+    return source
+        .where(
+          (item) => item.purchaseHistory.any((pr) => _monthKey(pr.date) == key),
+        )
+        .toList();
+  }
+}
+
+class MonthlySpending {
+  final DateTime month; // 해당 월의 1일 (local time, year+month만 의미 있음)
+  final int totalAmount; // 해당 월 총 지출(원)
+  final Map<String, int> byCategory; // 카테고리명 → 합계(원)
+  final List<ConsumableItem> items; // 해당 월 구매 이력을 가진 아이템
+
+  const MonthlySpending({
+    required this.month,
+    required this.totalAmount,
+    required this.byCategory,
+    required this.items,
+  });
+}
+
+class CategoryBreakdown {
+  final String category;
+  final int amount;
+  final double ratio; // 0.0~1.0, 합 = 1.0 ± 0.001
+
+  const CategoryBreakdown({
+    required this.category,
+    required this.amount,
+    required this.ratio,
+  });
+}

--- a/lib/widgets/reports/category_pie_chart.dart
+++ b/lib/widgets/reports/category_pie_chart.dart
@@ -1,0 +1,106 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+
+const Map<String, Color> _categoryPalette = <String, Color>{
+  '위생': Color(0xFF0891B2),
+  '필터': Color(0xFF059669),
+  '세탁': Color(0xFFD97706),
+  '주방': Color(0xFF7C3AED),
+  '기타': Color(0xFFEC4899),
+};
+
+/// 카테고리명 → 표시 색상. 매핑이 없으면 muted 색상으로 폴백.
+Color colorForCategory(String name) =>
+    _categoryPalette[name] ?? AppColors.textMuted;
+
+/// 카테고리별 지출 도넛 차트 + 범례.
+class CategoryPieChart extends StatelessWidget {
+  const CategoryPieChart({super.key, required this.data});
+
+  final List<CategoryBreakdown> data;
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.isEmpty) {
+      return const SizedBox(
+        height: 200,
+        child: Center(
+          child: Text(
+            '데이터 없음',
+            style: TextStyle(fontSize: 13, color: AppColors.textMuted),
+          ),
+        ),
+      );
+    }
+
+    return SizedBox(
+      height: 200,
+      child: Row(
+        children: [
+          Expanded(
+            child: PieChart(
+              PieChartData(
+                sectionsSpace: 2,
+                centerSpaceRadius: 45,
+                sections: data.map((c) {
+                  return PieChartSectionData(
+                    value: c.ratio * 100,
+                    color: colorForCategory(c.category),
+                    radius: 35,
+                    showTitle: false,
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+          const SizedBox(width: 20),
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: data.map((c) {
+              final percent = (c.ratio * 100).round();
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 10,
+                      height: 10,
+                      decoration: BoxDecoration(
+                        color: colorForCategory(c.category),
+                        borderRadius: BorderRadius.circular(3),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    SizedBox(
+                      width: 35,
+                      child: Text(
+                        c.category,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: AppColors.textSecondary,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '$percent%',
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.text,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/reports/month_filter_list_view.dart
+++ b/lib/widgets/reports/month_filter_list_view.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+import '../../services/report_service.dart';
+
+/// PR2에서 실 구현 예정. 현재는 placeholder.
+class MonthFilterListView extends StatelessWidget {
+  const MonthFilterListView({
+    super.key,
+    required this.selectedMonth,
+    required this.service,
+  });
+
+  final DateTime? selectedMonth;
+  final ReportService service;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/lib/widgets/reports/monthly_bar_chart.dart
+++ b/lib/widgets/reports/monthly_bar_chart.dart
@@ -1,0 +1,110 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+
+/// 월별 지출 막대 차트.
+class MonthlyBarChart extends StatelessWidget {
+  const MonthlyBarChart({
+    super.key,
+    required this.data,
+    this.onMonthTap,
+    this.selectedMonth,
+  });
+
+  final List<MonthlySpending> data;
+  final void Function(DateTime month)? onMonthTap;
+  final DateTime? selectedMonth;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxTotal = data.isEmpty
+        ? 0
+        : data.map((e) => e.totalAmount).reduce((a, b) => a > b ? a : b);
+    final rounded = ((maxTotal / 10000).ceil() * 10000).toDouble();
+    final computedMaxY = rounded < 160000.0 ? 160000.0 : rounded;
+
+    return SizedBox(
+      height: 180,
+      child: BarChart(
+        BarChartData(
+          alignment: BarChartAlignment.spaceAround,
+          maxY: computedMaxY,
+          gridData: FlGridData(
+            show: true,
+            drawVerticalLine: false,
+            horizontalInterval: 50000,
+            getDrawingHorizontalLine: (value) =>
+                FlLine(color: AppColors.border, strokeWidth: 0.5),
+          ),
+          borderData: FlBorderData(show: false),
+          titlesData: FlTitlesData(
+            topTitles: const AxisTitles(
+              sideTitles: SideTitles(showTitles: false),
+            ),
+            rightTitles: const AxisTitles(
+              sideTitles: SideTitles(showTitles: false),
+            ),
+            leftTitles: const AxisTitles(
+              sideTitles: SideTitles(showTitles: false),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                getTitlesWidget: (value, meta) {
+                  final index = value.toInt();
+                  if (index >= 0 && index < data.length) {
+                    return Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Text(
+                        '${data[index].month.month}월',
+                        style: const TextStyle(
+                          fontSize: 11,
+                          color: AppColors.textMuted,
+                        ),
+                      ),
+                    );
+                  }
+                  return const SizedBox.shrink();
+                },
+              ),
+            ),
+          ),
+          barTouchData: BarTouchData(
+            enabled: true,
+            touchCallback: (event, response) {
+              if (!event.isInterestedForInteractions) return;
+              if (response == null || response.spot == null) return;
+              final index = response.spot!.touchedBarGroupIndex;
+              if (index < 0 || index >= data.length) return;
+              onMonthTap?.call(data[index].month);
+            },
+          ),
+          barGroups: data.asMap().entries.map((entry) {
+            final isLatest = entry.key == data.length - 1;
+            final isSelected =
+                selectedMonth != null && entry.value.month == selectedMonth;
+            final highlighted = isSelected || isLatest;
+            return BarChartGroupData(
+              x: entry.key,
+              barRods: [
+                BarChartRodData(
+                  toY: entry.value.totalAmount.toDouble(),
+                  width: 28,
+                  color: highlighted
+                      ? AppColors.primary
+                      : AppColors.primary.withOpacity(0.3),
+                  borderRadius: const BorderRadius.only(
+                    topLeft: Radius.circular(6),
+                    topRight: Radius.circular(6),
+                  ),
+                ),
+              ],
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/reports/share_action_button.dart
+++ b/lib/widgets/reports/share_action_button.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+import '../../services/report_service.dart';
+
+/// PR3에서 실 구현 예정. 현재는 placeholder.
+class ShareActionButton extends StatelessWidget {
+  const ShareActionButton({super.key, required this.service});
+
+  final ReportService service;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/test/services/report_service_test.dart
+++ b/test/services/report_service_test.dart
@@ -1,0 +1,313 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/models/item.dart';
+import 'package:buylog/services/report_service.dart';
+
+void main() {
+  group('ReportService.aggregateRecentMonths', () {
+    test('6 buckets, 오래된→최신 순, 각 월별 합계 검증', () {
+      final fixture = <ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '아이템 A',
+          brand: 'brand',
+          category: '위생',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2025, 11, 10),
+              price: 10000,
+              store: 's',
+            ),
+            PurchaseRecord(date: DateTime(2026, 1, 5), price: 5000, store: 's'),
+            PurchaseRecord(date: DateTime(2026, 4, 1), price: 3000, store: 's'),
+          ],
+        ),
+        ConsumableItem(
+          id: 'b',
+          name: '아이템 B',
+          brand: 'brand',
+          category: '필터',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2025, 12, 20),
+              price: 7000,
+              store: 's',
+            ),
+            PurchaseRecord(
+              date: DateTime(2026, 3, 15),
+              price: 8500,
+              store: 's',
+            ),
+          ],
+        ),
+      ];
+
+      final service = ReportService.fromItems(fixture);
+      final months = service.aggregateRecentMonths(now: DateTime(2026, 4, 15));
+
+      expect(months.length, 6);
+      // 오래된 → 최신
+      expect(months[0].month, DateTime(2025, 11, 1));
+      expect(months[1].month, DateTime(2025, 12, 1));
+      expect(months[2].month, DateTime(2026, 1, 1));
+      expect(months[3].month, DateTime(2026, 2, 1));
+      expect(months[4].month, DateTime(2026, 3, 1));
+      expect(months[5].month, DateTime(2026, 4, 1));
+
+      // 월별 합계
+      expect(months[0].totalAmount, 10000); // Nov 2025
+      expect(months[1].totalAmount, 7000); // Dec 2025
+      expect(months[2].totalAmount, 5000); // Jan 2026
+      expect(months[3].totalAmount, 0); // Feb 2026
+      expect(months[4].totalAmount, 8500); // Mar 2026
+      expect(months[5].totalAmount, 3000); // Apr 2026
+
+      // 빈 달은 empty map/items
+      expect(months[3].byCategory, isEmpty);
+      expect(months[3].items, isEmpty);
+
+      // 카테고리 귀속
+      expect(months[0].byCategory, {'위생': 10000});
+      expect(months[1].byCategory, {'필터': 7000});
+      expect(months[4].byCategory, {'필터': 8500});
+    });
+
+    test('empty source → 6 buckets, all totals = 0', () {
+      final service = ReportService.fromItems(const []);
+      final months = service.aggregateRecentMonths(now: DateTime(2026, 4, 15));
+      expect(months.length, 6);
+      for (final m in months) {
+        expect(m.totalAmount, 0);
+        expect(m.byCategory, isEmpty);
+        expect(m.items, isEmpty);
+      }
+    });
+  });
+
+  group('ReportService.categoryBreakdownFor', () {
+    test('2026-03-01 breakdown: ratio 합 ≈ 1.0, amount 내림차순 정렬', () {
+      final fixture = <ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '세탁',
+          brand: 'x',
+          category: '세탁',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 3, 1),
+              price: 15900,
+              store: 's',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'b',
+          name: '주방',
+          brand: 'x',
+          category: '주방',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 3, 20),
+              price: 4500,
+              store: 's',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'c',
+          name: '필터',
+          brand: 'x',
+          category: '필터',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 3, 15),
+              price: 8500,
+              store: 's',
+            ),
+          ],
+        ),
+      ];
+
+      final service = ReportService.fromItems(fixture);
+      final breakdown = service.categoryBreakdownFor(DateTime(2026, 3, 1));
+
+      expect(breakdown.length, 3);
+      // 내림차순 정렬: 세탁(15900) > 필터(8500) > 주방(4500)
+      expect(breakdown[0].category, '세탁');
+      expect(breakdown[1].category, '필터');
+      expect(breakdown[2].category, '주방');
+
+      // ratio sum ≈ 1.0
+      final ratioSum = breakdown.fold<double>(0, (s, c) => s + c.ratio);
+      expect((ratioSum - 1.0).abs(), lessThan(1e-3));
+    });
+
+    test('데이터 없는 월 → empty list', () {
+      final service = ReportService.fromItems(const []);
+      final breakdown = service.categoryBreakdownFor(DateTime(2026, 3, 1));
+      expect(breakdown, isEmpty);
+    });
+  });
+
+  group('ReportService.itemsOfMonth', () {
+    test('여러 월에 걸친 아이템은 각 월에 모두 포함된다', () {
+      final sharedItem = ConsumableItem(
+        id: 'shared',
+        name: '주방세제',
+        brand: 'p',
+        category: '주방',
+        icon: Icons.circle,
+        daysRemaining: 0,
+        cycleDays: 30,
+        progress: 0.5,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 2, 18), price: 4200, store: 's'),
+          PurchaseRecord(date: DateTime(2026, 3, 20), price: 4500, store: 's'),
+        ],
+      );
+
+      final service = ReportService.fromItems([sharedItem]);
+      final feb = service.itemsOfMonth(DateTime(2026, 2, 1));
+      final mar = service.itemsOfMonth(DateTime(2026, 3, 1));
+
+      expect(feb.map((e) => e.id), ['shared']);
+      expect(mar.map((e) => e.id), ['shared']);
+    });
+  });
+
+  group('ReportService.latestMonthlyWithSpending', () {
+    // 회귀: 현재 월 구매가 없으면 months.last가 0원 버킷이 되어 요약 화면이
+    // "0원"으로 무너지는 문제(Codex adversarial review Finding 2). 이 메서드는
+    // 지출이 있는 가장 최신 월을 대신 돌려줘야 한다.
+    test('4월 구매가 없고 3월 구매가 있으면 3월 버킷을 반환한다', () {
+      final fixture = <ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '세제',
+          brand: 'x',
+          category: '세탁',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 3, 15),
+              price: 15000,
+              store: 's',
+            ),
+          ],
+        ),
+      ];
+
+      final service = ReportService.fromItems(fixture);
+      final latest = service.latestMonthlyWithSpending(
+        now: DateTime(2026, 4, 15),
+      );
+
+      expect(latest, isNotNull);
+      expect(latest!.month, DateTime(2026, 3, 1));
+      expect(latest.totalAmount, 15000);
+    });
+
+    test('모든 버킷이 0원이면 null을 반환한다', () {
+      final service = ReportService.fromItems(const []);
+      final latest = service.latestMonthlyWithSpending(
+        now: DateTime(2026, 4, 15),
+      );
+      expect(latest, isNull);
+    });
+
+    test('현재 월에 구매가 있으면 현재 월 버킷을 반환한다', () {
+      final fixture = <ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '주방',
+          brand: 'x',
+          category: '주방',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 4, 10),
+              price: 5000,
+              store: 's',
+            ),
+            PurchaseRecord(
+              date: DateTime(2026, 3, 10),
+              price: 7000,
+              store: 's',
+            ),
+          ],
+        ),
+      ];
+
+      final service = ReportService.fromItems(fixture);
+      final latest = service.latestMonthlyWithSpending(
+        now: DateTime(2026, 4, 15),
+      );
+
+      expect(latest!.month, DateTime(2026, 4, 1));
+      expect(latest.totalAmount, 5000);
+    });
+  });
+
+  group('ReportService 카테고리 스냅샷 의미론', () {
+    // 현재 카테고리 스냅샷 귀속: PurchaseRecord 시점의 카테고리가 아니라
+    // ConsumableItem.category(현재 값)가 기준. 따라서 동일 아이템의 모든
+    // 구매 기록은, 해당 시점에 아이템이 무슨 카테고리였든, 현재 값으로 집계된다.
+    // 이 테스트는 현재 카테고리를 '필터'로 둔 아이템의 Feb/Mar 구매 기록이
+    // 모두 '필터' 버킷에 귀속되는지(즉, '위생'으로 흘러들지 않는지) 검증한다.
+    test('현재 카테고리가 필터면, 과거 구매 기록도 필터로 귀속된다', () {
+      final item = ConsumableItem(
+        id: 'snapshot',
+        name: '스냅샷 테스트',
+        brand: 'x',
+        category: '필터', // 현재 카테고리 — 원래 '위생'이었다는 외부 가정
+        icon: Icons.circle,
+        daysRemaining: 0,
+        cycleDays: 30,
+        progress: 0.5,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 2, 10), price: 1000, store: 's'),
+          PurchaseRecord(date: DateTime(2026, 3, 10), price: 2000, store: 's'),
+        ],
+      );
+
+      final service = ReportService.fromItems([item]);
+      final feb = service.categoryBreakdownFor(DateTime(2026, 2, 1));
+      final mar = service.categoryBreakdownFor(DateTime(2026, 3, 1));
+
+      expect(feb.length, 1);
+      expect(feb.first.category, '필터');
+      expect(feb.first.amount, 1000);
+
+      expect(mar.length, 1);
+      expect(mar.first.category, '필터');
+      expect(mar.first.amount, 2000);
+    });
+  });
+}


### PR DESCRIPTION
## 변경 사항

- `lib/services/report_service.dart` 신규 — `ReportService` + `MonthlySpending` + `CategoryBreakdown` 공개 API 도입 (int 금액, `ConsumableItem` 기반, `factory ReportService.fromItems`, Supabase async 전환 경고 및 카테고리 스냅샷 의미론 docstring 포함)
- `ReportService.latestMonthlyWithSpending({months=6, now})` 추가 — 현재 월에 구매가 없을 때 요약이 "0원"으로 깨지는 UX 회귀 방지
- `lib/widgets/reports/` 신설 — `MonthlyBarChart`(`onMonthTap` 콜백 공개), `CategoryPieChart`, `MonthFilterListView`(PR2용 placeholder), `ShareActionButton`(PR3용 placeholder). placeholder는 `final` 필드 바인딩으로 `avoid_unused_constructor_parameters`/`unused_field` 린트 0건 유지
- `lib/screens/reports_screen.dart` 리팩터 — 하드코딩 `_categories`/`_monthlyData`/PieChart/BarChart 블록 제거, `ReportService.fromItems(SampleData.items)` 결과를 4개 위젯에 주입. `StatelessWidget` 유지, 상태 필드 없음
- `test/services/report_service_test.dart` — 집계·breakdown·월별 아이템·카테고리 스냅샷·빈 월 회귀 총 9개 테스트

## 변경 이유

Issue #8의 Task 1·2·3(월별 집계 reduce / 카테고리 파이 / 6개월 바 차트) 구현과 동시에, PR2(월 필터)와 PR3(공유)가 서로 다른 위젯 파일을 독점 소유하도록 화면을 위젯 단위로 분할해 **진정한 병렬 개발 기반**을 마련.

Refs #8 — Task 1,2,3 완료. Task 4(PR2), Task 5(PR3)는 후속 PR.

## 스크린샷 (UI 변경 시)

| Before | After |
|--------|-------|
| 하드코딩된 `_categories`/`_monthlyData` 기반 정적 차트 | `SampleData.items` 기반 실데이터 집계 차트 (UI 레이아웃·색상 동일 유지) |

*시각적 레이아웃은 기존과 동일하며, 데이터 소스만 실데이터로 교체됨. PR 리뷰 시 `flutter run` 후 리포트 탭 확인 권장.*

## 참고 사항

- **플랜 근거**: 본 PR은 ralplan 합의 플랜 v3(Planner → Architect → Critic APPROVE)에 기반. 파일 소유권 계약, `ReportService` 공개 API freeze, `reports_screen.dart` 편집 경계(PR2 ≤15줄, PR3 ≤5줄)가 모두 반영됨
- **후속 PR 계약**: PR1 머지 후 `feature/issue8-month-filter`(PR2)와 `feature/issue8-export`(PR3)가 develop에서 각각 분기, 서로 다른 위젯 파일을 소유하므로 병렬 개발 가능
- **알려진 제약**:
  - `ReportService`는 동기 in-memory 기반. Issue #1(Supabase 연동) 완료 시 async 변형 follow-up 예정 (ADR Follow-ups 참조)
  - 카테고리 집계는 현재 `ConsumableItem.category`로 스냅샷 귀속 (과거 `PurchaseRecord`에 카테고리 미보존). 장기적으로 모델 변경 필요 — Codex adversarial review에서도 재확인됨
- **로컬 검증**:
  - `dart format --set-exit-if-changed .` → exit 0
  - `flutter analyze` → 0 warnings / 0 errors (17 infos, 기존 스타일 일관)
  - `flutter test` → 22/22 pass (신규 9개 포함)
  - `pubspec.yaml`/`pubspec.lock`/`lib/models`/`lib/data` — develop 대비 변경 없음

## 리뷰 포인트

- `ReportService` 공개 API가 **PR2/PR3에서 변경 없이 재사용 가능**한 형태인지 — 특히 `MonthlySpending`, `CategoryBreakdown` 필드 타입(`int` 금액, `double` ratio)과 `latestMonthlyWithSpending` 시그니처
- placeholder 위젯(`MonthFilterListView`, `ShareActionButton`)의 공개 생성자 파라미터가 PR2/PR3 작업에 충분한지 — PR2는 `selectedMonth`+`service`, PR3는 `service`만 받도록 설계
- `latestMonthlyWithSpending` fallback 동작(전부 0원 → `months.last` → 빈 상태) 의미론이 UX 의도와 부합하는지
- 카테고리 스냅샷 의미론(docstring + 전용 테스트)이 팀 합의 가능한 수준인지

🤖 Generated with [Claude Code](https://claude.com/claude-code)