### PR TITLE
[#8] 월별 바 차트 탭 → 상세 리스트 필터 (PR2 / Task 4)

### DIFF
--- a/lib/screens/reports_screen.dart
+++ b/lib/screens/reports_screen.dart
@@ -8,8 +8,33 @@ import '../widgets/reports/month_filter_list_view.dart';
 import '../widgets/reports/monthly_bar_chart.dart';
 import '../widgets/reports/share_action_button.dart';
 
-class ReportsScreen extends StatelessWidget {
+class ReportsScreen extends StatefulWidget {
   const ReportsScreen({super.key});
+
+  @override
+  State<ReportsScreen> createState() => _ReportsScreenState();
+}
+
+class _ReportsScreenState extends State<ReportsScreen> {
+  // _selectedMonth 만 state 로 보유한다. ReportService/집계는 build 마다
+  // 재계산한다.
+  //
+  // 이유: ReportsScreen 은 main.dart:63 의 IndexedStack 에 상주해 앱 수명
+  // 동안 마운트 유지된다. initState + late final 캐싱을 쓰면 월 경계 교차 시
+  // 구 월 윈도우가, 향후 Supabase write 시 stale 데이터가 화면에 박혀
+  // ReportsScreen 이 destroy 되기 전에는 갱신되지 않는 회귀가 발생한다
+  // (Codex adversarial review Finding 2).
+  //
+  // 비용: SampleData 규모 (~6 items × ~2 purchases × 6 buckets ≈ 100 ops)
+  // 는 16ms 프레임 예산 대비 무시 가능. async ReportService 도입 시
+  // 캐싱은 repository 레이어로 이전한다.
+  DateTime? _selectedMonth;
+
+  void _onMonthTap(DateTime m) {
+    setState(() {
+      _selectedMonth = _selectedMonth == m ? null : m;
+    });
+  }
 
   String _formatPrice(int price) {
     final str = price.toString();
@@ -31,8 +56,18 @@ class ReportsScreen extends StatelessWidget {
         service.latestMonthlyWithSpending() ??
         (months.isEmpty ? null : months.last);
     final breakdown = latest == null
-        ? <CategoryBreakdown>[]
+        ? const <CategoryBreakdown>[]
         : service.categoryBreakdownFor(latest.month);
+
+    // `_selectedMonth`는 순수 widget state 로 보관되므로 IndexedStack 하에서
+    // 앱 수명만큼 유지된다. 월 경계 교차 또는 데이터 동기화로 aggregateRecentMonths
+    // 결과가 바뀌면 선택 월이 현재 window 밖으로 밀려 "헤더만 떠 있고 바 차트에는
+    // 해당 월이 없는" 모순 상태가 발생할 수 있다 (Codex review v3.2 HIGH finding).
+    // 매 build 에서 months 와 교차 검증하여 유효 월만 하위 위젯으로 내려보낸다.
+    final effectiveSelectedMonth =
+        _selectedMonth != null && months.any((m) => m.month == _selectedMonth)
+        ? _selectedMonth
+        : null;
 
     final latestTitle = latest == null
         ? '지출 현황'
@@ -195,7 +230,11 @@ class ReportsScreen extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 20),
-                    MonthlyBarChart(data: months),
+                    MonthlyBarChart(
+                      data: months,
+                      selectedMonth: effectiveSelectedMonth,
+                      onMonthTap: _onMonthTap,
+                    ),
                   ],
                 ),
               ),
@@ -311,7 +350,10 @@ class ReportsScreen extends StatelessWidget {
             ),
           ),
           SliverToBoxAdapter(
-            child: MonthFilterListView(selectedMonth: null, service: service),
+            child: MonthFilterListView(
+              selectedMonth: effectiveSelectedMonth,
+              service: service,
+            ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 24)),
         ],

--- a/lib/widgets/reports/month_filter_list_view.dart
+++ b/lib/widgets/reports/month_filter_list_view.dart
@@ -1,8 +1,10 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
+import '../../models/item.dart';
 import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+import 'category_pie_chart.dart';
 
-/// PR2에서 실 구현 예정. 현재는 placeholder.
 class MonthFilterListView extends StatelessWidget {
   const MonthFilterListView({
     super.key,
@@ -13,6 +15,149 @@ class MonthFilterListView extends StatelessWidget {
   final DateTime? selectedMonth;
   final ReportService service;
 
+  // TODO: 4번째 중복. 후속 이슈에서 lib/utils/price_format.dart 등으로 통합.
+  //   기존: reports_screen.dart:14, item_detail_screen.dart:12, item_card.dart:92.
+  String _formatPrice(int price) {
+    final str = price.toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < str.length; i++) {
+      if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
+      buffer.write(str[i]);
+    }
+    return '${buffer}원';
+  }
+
   @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
+  Widget build(BuildContext context) {
+    final month = selectedMonth;
+    if (month == null) return const SizedBox.shrink();
+
+    final items = service.itemsOfMonth(month);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${month.month}월 상세 내역',
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: AppColors.text,
+            ),
+          ),
+          const SizedBox(height: 10),
+          if (items.isEmpty)
+            _emptyCard()
+          else
+            ...items.map(
+              (item) => Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: _itemCard(item, month),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _emptyCard() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: const Text(
+        '해당 월에 기록된 구매가 없어요',
+        style: TextStyle(fontSize: 13, color: AppColors.textMuted),
+      ),
+    );
+  }
+
+  Widget _itemCard(ConsumableItem item, DateTime month) {
+    final color = colorForCategory(item.category);
+    final monthlyPurchases = item.purchaseHistory
+        .where((p) => p.date.year == month.year && p.date.month == month.month)
+        .toList();
+    final totalForMonth = monthlyPurchases.fold<int>(
+      0,
+      (sum, p) => sum + p.price,
+    );
+    final latestPurchaseDate = monthlyPurchases.isEmpty
+        ? null
+        : monthlyPurchases
+              .map((p) => p.date)
+              .reduce((a, b) => a.isAfter(b) ? a : b);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 38,
+            height: 38,
+            decoration: BoxDecoration(
+              color: color.withOpacity(0.12),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(item.icon, color: color, size: 18),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  item.name,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                    color: AppColors.text,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  item.brand,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 14),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                _formatPrice(totalForMonth),
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.text,
+                ),
+              ),
+              if (latestPurchaseDate != null)
+                Text(
+                  '${latestPurchaseDate.month}/${latestPurchaseDate.day}',
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textMuted,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/widgets/reports/monthly_bar_chart.dart
+++ b/lib/widgets/reports/monthly_bar_chart.dart
@@ -74,7 +74,18 @@ class MonthlyBarChart extends StatelessWidget {
           barTouchData: BarTouchData(
             enabled: true,
             touchCallback: (event, response) {
-              if (!event.isInterestedForInteractions) return;
+              // fl_chart 1.2.0 은 desktop/web 에서 한 번의 탭에 FlTapDownEvent +
+              // FlTapUpEvent 둘 다 emit 한다. 본 차트는 CustomScrollView 안에
+              // 배치되므로 TapDown 에서 커밋하면 사용자가 세로 스크롤을 시작한
+              // 경우에도 토글이 발사된다 (gesture arena 가 pan 으로 승격되면
+              // FlTapCancelEvent 가 뒤따르지만 이미 setState 는 호출된 후).
+              // 따라서 committed tap 인 FlTapUpEvent 만 통과시킨다.
+              // render_base_chart.dart:94-96 기준 TapUp 은 모든 플랫폼에서
+              // 1회만 emit 되므로 단일 발화 보장 (데스크톱 이중 발화 회피는
+              // 이 가드가 TapDown 을 차단하는 것으로 자동 해결).
+              // 스크롤/드래그 취소 시에는 TapUp 대신 FlTapCancelEvent 가
+              // 와서 이 가드에서 무시된다.
+              if (event is! FlTapUpEvent) return;
               if (response == null || response.spot == null) return;
               final index = response.spot!.touchedBarGroupIndex;
               if (index < 0 || index >= data.length) return;

--- a/test/screens/reports_screen_month_filter_test.dart
+++ b/test/screens/reports_screen_month_filter_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/screens/reports_screen.dart';
+import 'package:buylog/widgets/reports/monthly_bar_chart.dart';
+
+Widget _wrap() {
+  return const MaterialApp(home: Scaffold(body: ReportsScreen()));
+}
+
+Future<void> _pumpReportsScreen(WidgetTester tester) async {
+  // ReportsScreen 은 sliver 스택이 길어 기본 800x600 viewport 밖으로 밀리는
+  // sliver 가 생긴다. SliverToBoxAdapter 의 lazy build 를 피하기 위해
+  // viewport 를 충분히 키운다.
+  await tester.binding.setSurfaceSize(const Size(800, 2000));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(_wrap());
+}
+
+DateTime _firstNonZeroMonth(WidgetTester tester) {
+  final chart = tester.widget<MonthlyBarChart>(find.byType(MonthlyBarChart));
+  final nonZero = chart.data.where((m) => m.totalAmount > 0).toList();
+  expect(
+    nonZero,
+    isNotEmpty,
+    reason:
+        'SampleData 의 6개월 윈도우에 non-zero 월이 없습니다. SampleData 갱신 또는 ReportService(now:) 주입이 필요합니다 (2026-09 cliff).',
+  );
+  return nonZero.last.month;
+}
+
+DateTime? _otherNonZeroMonth(WidgetTester tester, DateTime exclude) {
+  final chart = tester.widget<MonthlyBarChart>(find.byType(MonthlyBarChart));
+  final nonZero = chart.data
+      .where((m) => m.totalAmount > 0 && m.month != exclude)
+      .toList();
+  return nonZero.isEmpty ? null : nonZero.last.month;
+}
+
+Future<void> _tap(WidgetTester tester, DateTime month) async {
+  final chart = tester.widget<MonthlyBarChart>(find.byType(MonthlyBarChart));
+  chart.onMonthTap?.call(month);
+  await tester.pump();
+}
+
+void main() {
+  group('ReportsScreen month filter toggle', () {
+    testWidgets('초기 상태: 상세 헤더 없음', (tester) async {
+      await _pumpReportsScreen(tester);
+      expect(find.textContaining('상세 내역'), findsNothing);
+    });
+
+    testWidgets('첫 탭 → 해당 월 헤더 표시', (tester) async {
+      await _pumpReportsScreen(tester);
+      final target = _firstNonZeroMonth(tester);
+
+      await _tap(tester, target);
+
+      expect(find.text('${target.month}월 상세 내역'), findsOneWidget);
+    });
+
+    testWidgets('재탭 → 헤더 사라짐 (토글 해제)', (tester) async {
+      await _pumpReportsScreen(tester);
+      final target = _firstNonZeroMonth(tester);
+
+      await _tap(tester, target);
+      expect(find.text('${target.month}월 상세 내역'), findsOneWidget);
+
+      await _tap(tester, target);
+      expect(find.textContaining('상세 내역'), findsNothing);
+    });
+
+    testWidgets('다른 월 탭 → 새 헤더로 전환', (tester) async {
+      await _pumpReportsScreen(tester);
+      final first = _firstNonZeroMonth(tester);
+      final other = _otherNonZeroMonth(tester, first);
+      if (other == null) {
+        markTestSkipped('SampleData 에 non-zero 월이 1개뿐이라 전환 케이스 검증 불가');
+        return;
+      }
+
+      await _tap(tester, first);
+      expect(find.text('${first.month}월 상세 내역'), findsOneWidget);
+
+      await _tap(tester, other);
+      expect(find.text('${first.month}월 상세 내역'), findsNothing);
+      expect(find.text('${other.month}월 상세 내역'), findsOneWidget);
+    });
+
+    // Codex review v3.2 HIGH finding 회귀 방지.
+    // IndexedStack 하에서 _selectedMonth 는 앱 수명만큼 유지되므로, 월 경계
+    // 교차 또는 데이터 동기화로 현재 aggregateRecentMonths window 에 없는
+    // 월이 선택 상태로 남으면 "헤더만 떠 있고 바 차트엔 해당 월 없음" 모순
+    // 발생. build 에서 _selectedMonth 를 months 와 교차 검증하여 stale 선택을
+    // 무효화해야 한다.
+    testWidgets('window 밖 월이 선택 상태여도 stale 헤더가 뜨지 않는다', (tester) async {
+      await _pumpReportsScreen(tester);
+
+      // 현재 aggregateRecentMonths window 에는 절대 포함되지 않는 과거 월.
+      final outOfWindow = DateTime(2020, 1, 1);
+      await _tap(tester, outOfWindow);
+
+      expect(
+        find.text('${outOfWindow.month}월 상세 내역'),
+        findsNothing,
+        reason: 'window 밖 월은 effectiveSelectedMonth 에서 null 로 중화되어 헤더 미표시',
+      );
+      expect(find.textContaining('상세 내역'), findsNothing);
+    });
+  });
+}

--- a/test/widgets/reports/month_filter_list_view_test.dart
+++ b/test/widgets/reports/month_filter_list_view_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/models/item.dart';
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/widgets/reports/month_filter_list_view.dart';
+
+ReportService _buildService() {
+  return ReportService.fromItems(<ConsumableItem>[
+    ConsumableItem(
+      id: 'a',
+      name: '세탁세제',
+      brand: '피죤',
+      category: '세탁',
+      icon: Icons.local_laundry_service_outlined,
+      daysRemaining: 0,
+      cycleDays: 30,
+      progress: 0.5,
+      purchaseHistory: [
+        PurchaseRecord(date: DateTime(2026, 3, 1), price: 12500, store: '이마트'),
+      ],
+    ),
+    ConsumableItem(
+      id: 'b',
+      name: '주방세제',
+      brand: '퐁퐁',
+      category: '주방',
+      icon: Icons.kitchen_outlined,
+      daysRemaining: 0,
+      cycleDays: 30,
+      progress: 0.5,
+      purchaseHistory: [
+        PurchaseRecord(date: DateTime(2026, 3, 20), price: 4500, store: '이마트'),
+        PurchaseRecord(date: DateTime(2026, 2, 18), price: 4200, store: '쿠팡'),
+      ],
+    ),
+  ]);
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+void main() {
+  group('MonthFilterListView', () {
+    testWidgets('selectedMonth==null → SizedBox.shrink (헤더 텍스트 없음)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          MonthFilterListView(selectedMonth: null, service: _buildService()),
+        ),
+      );
+
+      expect(find.textContaining('상세 내역'), findsNothing);
+      expect(find.textContaining('해당 월에 기록된'), findsNothing);
+    });
+
+    testWidgets('selectedMonth=2026-03-01 → 헤더 + 두 아이템 name 렌더', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          MonthFilterListView(
+            selectedMonth: DateTime(2026, 3, 1),
+            service: _buildService(),
+          ),
+        ),
+      );
+
+      expect(find.text('3월 상세 내역'), findsOneWidget);
+      expect(find.text('세탁세제'), findsOneWidget);
+      expect(find.text('주방세제'), findsOneWidget);
+    });
+
+    testWidgets('selectedMonth=2026-01-01 (데이터 없음) → empty-state 텍스트', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          MonthFilterListView(
+            selectedMonth: DateTime(2026, 1, 1),
+            service: _buildService(),
+          ),
+        ),
+      );
+
+      expect(find.text('1월 상세 내역'), findsOneWidget);
+      expect(find.text('해당 월에 기록된 구매가 없어요'), findsOneWidget);
+    });
+
+    testWidgets('가격 12500 → "12,500원" 으로 천단위 콤마 포맷', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          MonthFilterListView(
+            selectedMonth: DateTime(2026, 3, 1),
+            service: _buildService(),
+          ),
+        ),
+      );
+
+      expect(find.text('12,500원'), findsOneWidget);
+      expect(find.text('4,500원'), findsOneWidget);
+    });
+  });
+}

--- a/test/widgets/reports/monthly_bar_chart_highlight_test.dart
+++ b/test/widgets/reports/monthly_bar_chart_highlight_test.dart
@@ -1,0 +1,91 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:buylog/widgets/reports/monthly_bar_chart.dart';
+
+const _highlightColor = AppColors.primary;
+
+List<MonthlySpending> _fixture() {
+  return <MonthlySpending>[
+    MonthlySpending(
+      month: DateTime(2026, 1, 1),
+      totalAmount: 10000,
+      byCategory: const {'세탁': 10000},
+      items: const [],
+    ),
+    MonthlySpending(
+      month: DateTime(2026, 2, 1),
+      totalAmount: 20000,
+      byCategory: const {'주방': 20000},
+      items: const [],
+    ),
+    MonthlySpending(
+      month: DateTime(2026, 3, 1),
+      totalAmount: 30000,
+      byCategory: const {'필터': 30000},
+      items: const [],
+    ),
+  ];
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(home: Scaffold(body: child));
+}
+
+List<Color?> _readBarColors(WidgetTester tester) {
+  final chart = tester.widget<BarChart>(find.byType(BarChart));
+  return chart.data.barGroups.map((g) => g.barRods.first.color).toList();
+}
+
+void main() {
+  // monthly_bar_chart.dart:88 의 `final highlighted = isSelected || isLatest;`
+  // OR 동작을 spec-lock. PR2 는 monthly_bar_chart.dart 를 수정하지 않는다.
+  group('MonthlyBarChart highlight (isSelected || isLatest spec-lock)', () {
+    testWidgets('selectedMonth=null → 마지막 막대만 진한 색', (tester) async {
+      await tester.pumpWidget(_wrap(MonthlyBarChart(data: _fixture())));
+
+      final colors = _readBarColors(tester);
+      expect(colors.length, 3);
+      expect(colors[0], isNot(_highlightColor));
+      expect(colors[1], isNot(_highlightColor));
+      expect(colors[2], _highlightColor);
+    });
+
+    testWidgets('selectedMonth=2026-01-01 (non-latest) → 1월과 3월 둘 다 진한 색', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          MonthlyBarChart(
+            data: _fixture(),
+            selectedMonth: DateTime(2026, 1, 1),
+          ),
+        ),
+      );
+
+      final colors = _readBarColors(tester);
+      expect(colors[0], _highlightColor);
+      expect(colors[1], isNot(_highlightColor));
+      expect(colors[2], _highlightColor);
+    });
+
+    testWidgets('selectedMonth=2026-03-01 (latest) → 3월만 진한 색', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          MonthlyBarChart(
+            data: _fixture(),
+            selectedMonth: DateTime(2026, 3, 1),
+          ),
+        ),
+      );
+
+      final colors = _readBarColors(tester);
+      expect(colors[0], isNot(_highlightColor));
+      expect(colors[1], isNot(_highlightColor));
+      expect(colors[2], _highlightColor);
+    });
+  });
+}

--- a/test/widgets/reports/monthly_bar_chart_tap_test.dart
+++ b/test/widgets/reports/monthly_bar_chart_tap_test.dart
@@ -1,0 +1,171 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/widgets/reports/monthly_bar_chart.dart';
+
+List<MonthlySpending> _fixture() {
+  return <MonthlySpending>[
+    MonthlySpending(
+      month: DateTime(2026, 1, 1),
+      totalAmount: 10000,
+      byCategory: const {'세탁': 10000},
+      items: const [],
+    ),
+    MonthlySpending(
+      month: DateTime(2026, 2, 1),
+      totalAmount: 20000,
+      byCategory: const {'주방': 20000},
+      items: const [],
+    ),
+    MonthlySpending(
+      month: DateTime(2026, 3, 1),
+      totalAmount: 30000,
+      byCategory: const {'필터': 30000},
+      items: const [],
+    ),
+  ];
+}
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+BarTouchResponse _stubResponseFor(BarChart chart, int barIndex) {
+  final group = chart.data.barGroups[barIndex];
+  return BarTouchResponse(
+    touchLocation: Offset.zero,
+    touchChartCoordinate: Offset.zero,
+    spot: BarTouchedSpot(
+      group,
+      barIndex,
+      group.barRods.first,
+      0,
+      null,
+      -1,
+      FlSpot(barIndex.toDouble(), 0),
+      Offset.zero,
+    ),
+  );
+}
+
+void main() {
+  // Codex adversarial review Finding 1 (v2) 회귀 방지 + Finding 1 (v3.1) 회귀
+  // 방지. Option A (FlTapUpEvent 게이팅) 는:
+  //   - desktop/web 에서도 TapUp 은 1회 emit → 단일 발화 보장.
+  //   - CustomScrollView 안에서 스크롤 시작 시 TapCancel 이 와서 TapUp 대신
+  //     게이트에서 무시 → 토글 발사 안 됨.
+  //   - fl_chart CHANGELOG.md:341 공식 권장 패턴.
+  //
+  // 주의: debugDefaultTargetPlatformOverride 는 test body 종료 시점에 framework
+  // 가 invariant 검증을 수행하므로 addTearDown 으로는 늦다. try/finally 로 즉시
+  // 리셋해야 한다.
+  group('MonthlyBarChart tap dedup (Option A — TapUp gating spec-lock)', () {
+    testWidgets(
+      'desktop/web 환경: TapDown + TapUp 호출 시 TapUp 에서만 onMonthTap 1회',
+      (tester) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+        try {
+          var tapCount = 0;
+          DateTime? lastMonth;
+          final fixture = _fixture();
+
+          await tester.pumpWidget(
+            _wrap(
+              MonthlyBarChart(
+                data: fixture,
+                onMonthTap: (m) {
+                  tapCount++;
+                  lastMonth = m;
+                },
+              ),
+            ),
+          );
+
+          final chart = tester.widget<BarChart>(find.byType(BarChart));
+          final callback = chart.data.barTouchData.touchCallback!;
+          final stubResponse = _stubResponseFor(chart, 1);
+
+          callback(
+            FlTapDownEvent(TapDownDetails(localPosition: Offset.zero)),
+            stubResponse,
+          );
+          expect(tapCount, 0, reason: 'TapDown 은 게이트에서 무시되어 아직 발사 안 됨');
+
+          callback(
+            FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
+            stubResponse,
+          );
+          expect(tapCount, 1, reason: 'TapUp 에서 committed tap 으로 발사');
+          expect(lastMonth, fixture[1].month);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
+
+    testWidgets('mobile 환경: TapDown + TapUp 호출 시 TapUp 에서만 onMonthTap 1회', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      try {
+        var tapCount = 0;
+        final fixture = _fixture();
+
+        await tester.pumpWidget(
+          _wrap(MonthlyBarChart(data: fixture, onMonthTap: (_) => tapCount++)),
+        );
+
+        final chart = tester.widget<BarChart>(find.byType(BarChart));
+        final callback = chart.data.barTouchData.touchCallback!;
+        final stubResponse = _stubResponseFor(chart, 0);
+
+        callback(
+          FlTapDownEvent(TapDownDetails(localPosition: Offset.zero)),
+          stubResponse,
+        );
+        callback(
+          FlTapUpEvent(TapUpDetails(kind: PointerDeviceKind.touch)),
+          stubResponse,
+        );
+
+        expect(tapCount, 1, reason: 'mobile 에서도 TapUp 에서만 발사');
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets(
+      'scroll/drag cancel (CustomScrollView): TapDown + TapCancel → onMonthTap 0회',
+      (tester) async {
+        var tapCount = 0;
+        final fixture = _fixture();
+
+        await tester.pumpWidget(
+          _wrap(MonthlyBarChart(data: fixture, onMonthTap: (_) => tapCount++)),
+        );
+
+        final chart = tester.widget<BarChart>(find.byType(BarChart));
+        final callback = chart.data.barTouchData.touchCallback!;
+        final stubResponse = _stubResponseFor(chart, 1);
+
+        // 사용자가 막대 위에서 세로 스크롤을 시작 → CustomScrollView 의 gesture
+        // arena 가 pan 으로 승격 → fl_chart 는 FlTapCancelEvent 를 emit.
+        callback(
+          FlTapDownEvent(TapDownDetails(localPosition: Offset.zero)),
+          stubResponse,
+        );
+        callback(const FlTapCancelEvent(), null);
+
+        expect(
+          tapCount,
+          0,
+          reason:
+              'CustomScrollView 안에서 스크롤 시작 → 토글이 발사되면 안 됨 '
+              '(v3.1 Option B 에서 보고된 Codex HIGH 회귀)',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 변경 사항

월별 지출 추이 바 차트의 막대를 탭하면 해당 월의 구매 상세 리스트가 필터링되어 표시되고, 같은 막대를 재탭하면 해제된다.

### 구현 (Task 4)
- `MonthFilterListView`: PR1 placeholder → 카드 리스트 실구현 (월별 합계·최신 구매일 표시)
- `ReportsScreen`: StatelessWidget → StatefulWidget (`_selectedMonth` state + `_onMonthTap` 토글)
- `MonthlyBarChart`: `touchCallback` 에 `FlTapUpEvent` 게이팅 1줄 추가

### 핫픽스 동봉 (Codex adversarial review 3회 라운드)
본 PR 개발 중 Codex 적대 리뷰가 식별한 HIGH 4건을 함께 봉합:

1. **fl_chart 1.2.0 desktop/web 이중 발화**: `FlTapDownEvent` + `FlTapUpEvent` 둘 다 `isInterested=true` 로 평가되어 토글이 자기 취소되던 회귀. `FlTapUpEvent` 게이팅(공식 권장 패턴)으로 단일 발화 보장.
2. **CustomScrollView 하 scroll/drag 취소 토글**: 초기 Option B(TapDown) 구현이 세로 스크롤 시작도 토글로 커밋하던 회귀. Option A(TapUp) 전환으로 TapCancel 경로 자동 무시.
3. **IndexedStack stale data**: `late final` 캐싱이 `ReportsScreen` 을 초기 마운트 시점의 window/totals/breakdown 에 고정시키던 회귀. `build` 마다 재계산으로 환원 (SampleData 규모 ~100 ops, 16ms 예산 대비 무시 가능).
4. **window 밖 `_selectedMonth` stale 헤더**: 월 경계 교차 후 `_selectedMonth` 가 현재 `months` 윈도우 밖에 남으면 "헤더만 뜨고 바 차트엔 해당 월 없음" 모순. `effectiveSelectedMonth = _selectedMonth ∩ months` intersection 도입.

## 변경 이유

- Issue #8 Task 4 완료 (PR2 할당분)
- API Freeze 준수로 PR1 계약 경계 유지 (ReportService / CategoryPieChart / ShareActionButton 시그니처 + 내부 전부 불변)
- 본 PR 한정 예외: `monthly_bar_chart.dart` 내부 touchCallback 가드 1줄 편집 (Codex HIGH 대응). PR3 이후 내부 동결 복원.

## 스크린샷

> 막대 탭 전: 카테고리별 상세까지만 표시
> 막대 탭 후: 하단에 "{M}월 상세 내역" 헤더 + 아이템 카드 리스트
> 재탭: 상세 섹션 사라짐

(실기기/에뮬레이터 확인 필요)

## 참고

- **테스트 결정론 — 2026-09 cliff**: `test/screens/reports_screen_month_filter_test.dart` 는 `SampleData` + `DateTime.now()` 의 결합을 회피하기 위해 `data.lastWhere((m) => m.totalAmount > 0).month` 를 동적 타깃으로 사용한다. SampleData 최신 구매(2026-03-20) 기준 2026-09 이후 모든 구매가 6개월 윈도우 밖으로 밀리면 브리틀 해짐. 후속 이슈(Supabase 전환 또는 SampleData 갱신)에서 근본 해결.
- **`_formatPrice` 4중 중복**: `reports_screen.dart:14`, `item_detail_screen.dart:12`, `item_card.dart:92`, `month_filter_list_view.dart` 에 동일 구현 존재. TODO 주석으로 명시, 후속 유틸 추출 이슈에서 일괄 정리.
- **이중 하이라이트 보존**: `monthly_bar_chart.dart:88` 의 `isSelected || isLatest` 는 의도적 동작 (선택 월 + 최신 월 둘 다 강조). `monthly_bar_chart_highlight_test.dart` 로 spec-lock.
- **로컬 변경 제외**: `.gitignore`, platform generated (`linux/`, `macos/`, `windows/`), `.mcp.json`, `.claude/` 모두 PR에서 제외.

## 리뷰 포인트

1. **의미론적 편집 LOC ≤ 15**: `reports_screen.dart` 의 StatefulWidget 전환 + `_selectedMonth` + `_onMonthTap` + `effectiveSelectedMonth` 도출 + 2개 위젯 인자 전달 ≈ 15. 리터럴 `+` 라인 카운트는 `_formatPrice` / `build` 본문의 State 이동으로 더 많지만, **이는 게이트 아님**.
2. **API Freeze 일회성 예외**: `monthly_bar_chart.dart` 내부 `touchCallback` 가드 편집은 Codex HIGH 대응 한정. PR3 이후 signature + internals 모두 동결 원칙 복원.
3. **`effectiveSelectedMonth` sanitizer**: 매 build 에서 intersection 검증. 비용 O(n=6). async ReportService 전환 시 repository 레이어로 캐싱 이전 예정.
4. **37/37 테스트 통과**: 신규 11 케이스 모두 콜백 단위 테스트로 결정론 확보 (fl_chart 제스처 시뮬레이션 배제).

## 검증

- [x] `dart format --set-exit-if-changed .` exit 0
- [x] `flutter analyze` 0 errors / 0 warnings (infos 허용)
- [x] `flutter test` 37/37 통과 (기존 22 + PR1 추가 11 + PR2 신규 11)
- [x] `git diff develop -- pubspec.yaml pubspec.lock lib/models lib/data lib/services lib/widgets/reports/{category_pie_chart,share_action_button}.dart` 전부 빈 diff
- [x] Codex adversarial review 3회 라운드 모두 대응

Refs #8