### PR TITLE
feat: Supabase 실연동 및 제품 이미지 업로드/표시 구현

### DIFF
--- a/issue3-개발내역.md
+++ b/issue3-개발내역.md
@@ -1,0 +1,245 @@
+# Issue3 브랜치 개발 내역
+
+> **브랜치**: `issue3`
+> **작업 범위**: Firebase 제거 → Supabase 실연동 + 이미지 업로드/표시 기능 구현
+
+---
+
+## 목차
+
+1. [개요](#개요)
+2. [주요 변경 사항](#주요-변경-사항)
+3. [아키텍처](#아키텍처)
+4. [기능별 상세 설명](#기능별-상세-설명)
+5. [로컬 실행 방법](#로컬-실행-방법)
+6. [Supabase 프로젝트 정보](#supabase-프로젝트-정보)
+
+---
+
+## 개요
+
+기존에 Firebase 연동 준비용 Stub 코드로 작성되어 있던 서비스 레이어를 **Supabase 실연동**으로 교체하고, 이와 함께 **제품 이미지 업로드 및 표시** 기능을 구현했습니다.
+
+### 커밋 목록
+
+| 커밋 | 내용 |
+|------|------|
+| `63ef2c5` | 제품 수동 등록 및 반응형 UI 구현 |
+| `0fc674c` | Firebase Stub → Supabase 실연동 교체 |
+| `883b701` | 인증 방식 변경: 익명 로그인 대신 RLS 비활성 모드로 전환 |
+| `5003cd6` | 제품 이미지 업로드 기능 추가 (image_picker + Supabase Storage) |
+| `ee5f542` | 아이템 세부 화면 이미지 표시 구현 |
+
+---
+
+## 주요 변경 사항
+
+### 삭제된 파일
+- `lib/services/firebase_service.dart` — Firebase Stub 코드 전면 제거
+
+### 신규 파일
+- `lib/services/supabase_service.dart` — Supabase 실연동 서비스
+
+### 수정된 파일
+- `lib/main.dart` — Supabase 초기화 로직 추가
+- `lib/models/item.dart` — `fromSupabase()` 팩토리 메서드 추가, `PurchaseRecord`에 `id` 필드 추가
+- `lib/services/item_store.dart` — 비동기 CRUD (Supabase 동기화)
+- `lib/screens/add_item_screen.dart` — 이미지 선택 및 업로드 UI
+- `lib/screens/item_detail_screen.dart` — 이미지 배너 표시
+- `pubspec.yaml` — 패키지 추가: `supabase_flutter`, `image_picker`
+
+---
+
+## 아키텍처
+
+```
+앱 시작 (main.dart)
+  └─ SupabaseService.initialize()   // Supabase 클라이언트 초기화
+  └─ ItemStore.instance.initialize() // DB에서 제품 목록 로드
+  └─ runApp()
+
+데이터 흐름
+  ItemStore (ValueNotifier<List<ConsumableItem>>)
+    ├─ loadItems()   ← Supabase DB (product_items, purchases, categories, ai_predictions)
+    ├─ add()         → Supabase DB upsert
+    ├─ update()      → Supabase DB upsert
+    └─ delete()      → Supabase DB delete (CASCADE로 purchases 자동 삭제)
+
+이미지 흐름
+  사용자가 갤러리에서 이미지 선택 (image_picker)
+    └─ Uint8List 형태로 메모리에 보관
+    └─ 제품 저장 시 → SupabaseService.uploadItemImage()
+         └─ _adminClient (service role key) → Storage 업로드
+         └─ 공개 URL 반환 → product_items.image_url 에 저장
+```
+
+### 두 개의 Supabase 클라이언트
+
+| 클라이언트 | 키 종류 | 용도 |
+|-----------|---------|------|
+| `_db` (Supabase.instance.client) | anon key | DB CRUD (RLS 비활성이므로 사용 가능) |
+| `_adminClient` | service role key | Storage 업로드 (anon key로는 403 발생) |
+
+> **보안 주의**: service role key는 `--dart-define=SUPABASE_SERVICE_KEY=...` 로 주입하며, 소스코드에 직접 커밋하지 않습니다.
+
+---
+
+## 기능별 상세 설명
+
+### 1. Supabase DB 연동 (`supabase_service.dart`)
+
+#### 연결 정보
+- **프로젝트 ID**: `fervijwxdgkwjtcpzskx`
+- **URL**: `https://fervijwxdgkwjtcpzskx.supabase.co`
+
+#### 사용 테이블
+
+| 테이블 | 역할 |
+|--------|------|
+| `product_items` | 제품 기본 정보 (name, brand, image_url, replacement_cycle_days 등) |
+| `purchases` | 구매 이력 (purchase_date, price, store_name) |
+| `categories` | 카테고리 (name, icon, color) |
+| `ai_predictions` | AI 교체 주기 예측 (predicted_cycle_days, confidence) |
+
+#### 주요 메서드
+
+```dart
+// 전체 제품 로드 (JOIN 쿼리로 한 번에 가져옴)
+static Future<List<ConsumableItem>> loadItems()
+
+// 제품 저장 (신규 / 수정 모두 처리)
+static Future<void> saveItem(ConsumableItem item)
+
+// 제품 삭제 (purchases는 DB CASCADE로 자동 삭제)
+static Future<void> deleteItem(String itemId)
+
+// UUID v4 생성 (dart:math 사용, 외부 패키지 불필요)
+static String generateUuid()
+```
+
+#### 인증 방식
+익명 로그인이 Supabase 프로젝트에서 비활성화되어 있어, **RLS(Row Level Security)가 비활성 상태**인 점을 활용하여 개발용 고정 `user_id`를 사용합니다.
+
+```dart
+static const _devUserId = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8';
+```
+
+> 프로덕션 전환 시 실제 인증 및 RLS 정책 적용 필요.
+
+---
+
+### 2. 카테고리 자동 생성
+
+`_ensureCategory(String name)` 메서드가 카테고리 이름으로 UUID를 조회하고, 없으면 자동 생성합니다. 앱 세션 동안 결과를 캐싱하여 불필요한 DB 조회를 방지합니다.
+
+```dart
+static final Map<String, String> _categoryCache = {};
+```
+
+---
+
+### 3. 이미지 업로드 (`add_item_screen.dart`)
+
+#### 흐름
+
+1. 사용자가 이미지 영역을 탭
+2. `image_picker`로 갤러리에서 이미지 선택 (최대 1024×1024, 품질 85%)
+3. `Uint8List`로 메모리에 로드 → 미리보기 표시 (`Image.memory`)
+4. "저장" 버튼 클릭 시 `SupabaseService.uploadItemImage()` 호출
+5. 반환된 공개 URL을 `ConsumableItem.imageUrl`에 저장
+
+#### 이미지 선택 상태 관리
+
+```dart
+Uint8List? _imageBytes; // 새로 선택한 이미지 바이트
+
+// 이미지가 선택된 상태인지 (신규 선택 또는 기존 URL 존재)
+bool get _hasImageSelected =>
+    _imageBytes != null || (_isEditing && widget.editItem!.imageUrl != null);
+```
+
+#### Storage 버킷
+- **버킷명**: `product-images`
+- **공개 여부**: Public (별도 인증 없이 URL로 접근 가능)
+- **저장 경로**: `items/{itemId}.jpg`
+
+---
+
+### 4. 이미지 표시 (`item_detail_screen.dart`)
+
+세부 화면 상단의 제품 헤더 카드에 이미지 유무에 따라 다른 레이아웃을 적용합니다.
+
+#### 이미지 있을 때
+```
+┌──────────────────────────────────┐
+│                                  │
+│     220px 전체 너비 이미지 배너    │
+│                                  │
+├──────────────────────────────────┤
+│  [카테고리 태그]                   │
+│  제품명                  [D-day   │
+│  브랜드명                  링]    │
+└──────────────────────────────────┘
+```
+
+#### 이미지 없을 때
+```
+┌──────────────────────────────────┐
+│  [아이콘]  [카테고리 태그]          │
+│            제품명       [D-day    │
+│            브랜드명       링]     │
+└──────────────────────────────────┘
+```
+
+- 로딩 중: `CircularProgressIndicator` 표시
+- 로드 실패: `broken_image` 아이콘 표시
+
+---
+
+### 5. 반응형 상태 관리 (`item_store.dart`)
+
+`ItemStore`는 `ValueNotifier<List<ConsumableItem>>`를 상속하여, 데이터 변경 시 모든 리스너(화면)에 자동으로 알립니다.
+
+```dart
+// 낙관적 업데이트: 로컬 상태를 먼저 반영 후 DB 동기화
+Future<void> add(ConsumableItem item) async {
+  value = [item, ...value]; // UI 즉시 반영
+  await SupabaseService.saveItem(item); // DB 저장
+}
+```
+
+---
+
+## 로컬 실행 방법
+
+### 1. 패키지 설치
+```bash
+flutter pub get
+```
+
+### 2. 앱 실행 (service role key 주입 필수)
+```bash
+flutter run -d chrome --web-port 3000 \
+  --dart-define=SUPABASE_SERVICE_KEY=<서비스_롤_키>
+```
+
+> 서비스 롤 키는 팀 노션 또는 팀장에게 문의하세요.
+
+### 3. 이미지 업로드 없이 실행할 경우
+```bash
+flutter run -d chrome --web-port 3000
+```
+이미지 업로드 시 오류가 발생하지만 나머지 기능은 정상 동작합니다.
+
+---
+
+## Supabase 프로젝트 정보
+
+| 항목 | 값 |
+|------|-----|
+| 프로젝트 ID | `fervijwxdgkwjtcpzskx` |
+| 대시보드 | https://supabase.com/dashboard/project/fervijwxdgkwjtcpzskx |
+| Storage 버킷 | `product-images` (public) |
+| RLS 상태 | 전체 테이블 비활성 (개발 환경) |
+| anon key | `sb_publishable_FO7WmA_Pu4RsGgsfRJzssQ_f0orCu7w` |
+| service role key | 별도 보관 (소스코드 미포함) |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,20 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'theme/app_theme.dart';
 import 'screens/home_screen.dart';
 import 'screens/group_screen.dart';
 import 'screens/scan_screen.dart';
 import 'screens/reports_screen.dart';
 import 'screens/settings_screen.dart';
-import 'package:supabase_flutter/supabase_flutter.dart'; // [Issue 4] Supabase 연동을 위한 임포트
+import 'screens/add_item_screen.dart';
+import 'services/supabase_service.dart';
+import 'services/item_store.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
-  await Supabase.initialize(
-    url: 'https://fervijwxdgkwjtcpzskx.supabase.co',
-    anonKey: 'sb_publishable_FO7WmA_Pu4RsGgsfRJzssQ_f0orCu7w',
-  );
 
   SystemChrome.setSystemUIOverlayStyle(
     const SystemUiOverlayStyle(
@@ -22,6 +20,13 @@ void main() async {
       statusBarIconBrightness: Brightness.dark,
     ),
   );
+
+  // Supabase 초기화 (익명 로그인 포함)
+  await SupabaseService.initialize();
+
+  // 제품 목록 초기 로드
+  await ItemStore.instance.initialize();
+
   runApp(const BuylogApp());
 }
 
@@ -34,6 +39,17 @@ class BuylogApp extends StatelessWidget {
       title: 'Buylog',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.lightTheme,
+      // 한국어 Date Picker 및 기타 위젯 지원
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('ko', 'KR'),
+        Locale('en', 'US'),
+      ],
+      locale: const Locale('ko', 'KR'),
       home: const MainNavigation(),
     );
   }
@@ -57,10 +73,27 @@ class _MainNavigationState extends State<MainNavigation> {
     SettingsScreen(),
   ];
 
+  void _openAddItem() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const AddItemScreen()),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: IndexedStack(index: _currentIndex, children: _screens),
+      // 홈 탭에서만 FAB 표시
+      floatingActionButton: _currentIndex == 0
+          ? FloatingActionButton(
+              onPressed: _openAddItem,
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              tooltip: '제품 직접 등록',
+              child: const Icon(Icons.add),
+            )
+          : null,
       bottomNavigationBar: Container(
         decoration: const BoxDecoration(
           color: AppColors.surface,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,10 +45,7 @@ class BuylogApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: const [
-        Locale('ko', 'KR'),
-        Locale('en', 'US'),
-      ],
+      supportedLocales: const [Locale('ko', 'KR'), Locale('en', 'US')],
       locale: const Locale('ko', 'KR'),
       home: const MainNavigation(),
     );

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -45,8 +45,11 @@ class ConsumableItem {
 
     // 구매일 내림차순 정렬
     final sorted = List<Map<String, dynamic>>.from(purchases)
-      ..sort((a, b) => DateTime.parse(b['purchase_date'])
-          .compareTo(DateTime.parse(a['purchase_date'])));
+      ..sort(
+        (a, b) => DateTime.parse(
+          b['purchase_date'],
+        ).compareTo(DateTime.parse(a['purchase_date'])),
+      );
 
     final lastDate = sorted.isNotEmpty
         ? DateTime.parse(sorted.first['purchase_date'])
@@ -69,13 +72,28 @@ class ConsumableItem {
       aiPredictedDays: aiPrediction?['predicted_cycle_days'] as int?,
       aiConfidence: (aiPrediction?['confidence'] as num?)?.toDouble(),
       purchaseHistory: sorted
-          .map((p) => PurchaseRecord(
-                id: p['id'] as String?,
-                date: DateTime.parse(p['purchase_date']),
-                price: (p['price'] as int?) ?? 0,
-                store: (p['store_name'] as String?) ?? '',
-              ))
+          .map(
+            (p) => PurchaseRecord(
+              id: p['id'] as String?,
+              date: DateTime.parse(p['purchase_date']),
+              price: (p['price'] as int?) ?? 0,
+              store: (p['store_name'] as String?) ?? '',
+            ),
+          )
           .toList(),
+    );
+  }
+
+  /// home_screen의 `select('*, purchases(*)')` 쿼리 결과로 생성
+  factory ConsumableItem.fromJson(Map<String, dynamic> json) {
+    final purchases =
+        (json['purchases'] as List<dynamic>?)?.cast<Map<String, dynamic>>() ??
+        [];
+
+    return ConsumableItem.fromSupabase(
+      data: json,
+      categoryName: '기타',
+      purchases: purchases,
     );
   }
 

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../services/ai/prediction_service.dart';
 
 class ConsumableItem {
   final String id;
@@ -30,86 +29,81 @@ class ConsumableItem {
     this.imageUrl,
   });
 
-  factory ConsumableItem.fromJson(Map<String, dynamic> json) {
-    // 구매 이력 추출
-    var purchasesJson = json['purchases'] as List<dynamic>? ?? [];
-    List<PurchaseRecord> history = purchasesJson
-        .map((p) => PurchaseRecord.fromJson(p as Map<String, dynamic>))
-        .toList();
+  /// Supabase product_items 행 + 관련 데이터로 ConsumableItem 생성
+  ///
+  /// [data]         product_items 행
+  /// [categoryName] categories.name (FK join)
+  /// [purchases]    purchases 행 목록 (FK join)
+  /// [aiPrediction] ai_predictions 최신 행 (nullable)
+  factory ConsumableItem.fromSupabase({
+    required Map<String, dynamic> data,
+    required String categoryName,
+    required List<Map<String, dynamic>> purchases,
+    Map<String, dynamic>? aiPrediction,
+  }) {
+    final cycleDays = (data['replacement_cycle_days'] as int?) ?? 30;
 
-    // 구매 날짜 리스트 추출
-    List<DateTime> purchaseDates = history.map((p) => p.date).toList();
+    // 구매일 내림차순 정렬
+    final sorted = List<Map<String, dynamic>>.from(purchases)
+      ..sort((a, b) => DateTime.parse(b['purchase_date'])
+          .compareTo(DateTime.parse(a['purchase_date'])));
 
-    // DB에서 기본 주기 및 등록일 가져오기
-    final int defaultCycle = json['replacement_cycle_days'] ?? 30;
-    // 등록일이 없으면 현재 시간으로 처리
-    final DateTime registeredAt = json['created_at'] != null
-        ? DateTime.parse(json['created_at'])
-        : DateTime.now();
+    final lastDate = sorted.isNotEmpty
+        ? DateTime.parse(sorted.first['purchase_date'])
+        : null;
 
-    final prediction = predictCycle(
-      purchaseDates: purchaseDates,
-      categoryDefaultDays: defaultCycle,
-    );
-
-    // 예측 주기를 바탕으로 D-Day 계산
-    final int calculatedDays = calcDday(
-      purchaseDates: purchaseDates,
-      predictedCycleDays: prediction.predictedCycleDays,
-      registeredAt: registeredAt,
-    );
-
-    // 잔여량
-    final double progress = calcRemainingPercent(
-      purchaseDates: purchaseDates,
-      predictedCycleDays: prediction.predictedCycleDays,
-      registeredAt: registeredAt,
-    );
+    final daysSince = lastDate != null
+        ? DateTime.now().difference(lastDate).inDays
+        : cycleDays;
 
     return ConsumableItem(
-      id: json['id'].toString(),
-      name: json['name'] ?? '이름 없음',
-      brand: json['brand'] ?? '브랜드 없음',
-      category: '기타',
-      icon: Icons.inventory_2_outlined,
-
-      daysRemaining: calculatedDays,
-      cycleDays: prediction.predictedCycleDays,
-      progress: progress,
-
-      // Phase에 따른 정밀한 예측일수와 신뢰도 반영
-      aiPredictedDays: prediction.predictedCycleDays,
-      aiConfidence: prediction.confidence,
-
-      imageUrl: json['image_url'],
-      purchaseHistory: history,
+      id: data['id'] as String,
+      name: data['name'] as String? ?? '',
+      brand: data['brand'] as String? ?? '',
+      category: categoryName,
+      icon: iconForCategory(categoryName),
+      daysRemaining: cycleDays - daysSince,
+      cycleDays: cycleDays,
+      progress: (daysSince / cycleDays).clamp(0.0, 1.0),
+      imageUrl: data['image_url'] as String?,
+      aiPredictedDays: aiPrediction?['predicted_cycle_days'] as int?,
+      aiConfidence: (aiPrediction?['confidence'] as num?)?.toDouble(),
+      purchaseHistory: sorted
+          .map((p) => PurchaseRecord(
+                id: p['id'] as String?,
+                date: DateTime.parse(p['purchase_date']),
+                price: (p['price'] as int?) ?? 0,
+                store: (p['store_name'] as String?) ?? '',
+              ))
+          .toList(),
     );
+  }
+
+  static IconData iconForCategory(String category) {
+    return switch (category) {
+      '욕실/위생' => Icons.bathroom_outlined,
+      '주방/세제' => Icons.kitchen_outlined,
+      '세탁/청소' => Icons.local_laundry_service_outlined,
+      '헤어/바디' => Icons.shower_outlined,
+      '가전/필터' => Icons.air_outlined,
+      _ => Icons.category_outlined,
+    };
   }
 }
 
 class PurchaseRecord {
-  final DateTime date; // 구매 날짜
-  final int price; // 구매 가격
-  final String store; // 구매처
+  /// Supabase purchases.id (신규 이력은 null — 저장 후 채워짐)
+  final String? id;
+  final DateTime date;
+  final int price;
+  final String store;
 
   const PurchaseRecord({
+    this.id,
     required this.date,
     required this.price,
     required this.store,
   });
-
-  // JSON -> PurchaseRecord 객체 변환
-  factory PurchaseRecord.fromJson(Map<String, dynamic> json) {
-    return PurchaseRecord(
-      date: json['purchase_date'] != null
-          ? DateTime.parse(json['purchase_date'])
-          : (json['created_at'] != null
-                ? DateTime.parse(json['created_at'])
-                : DateTime.now()),
-      price: json['price'] ?? 0,
-      store: json['store_name'] ?? '알 수 없음',
-    );
-  }
 }
 
 class GroupMember {

--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -56,10 +56,11 @@ class _AddItemScreenState extends State<AddItemScreen> {
   final List<_PurchaseEntry> _purchases = [];
 
   // 이미지 상태
-  Uint8List? _imageBytes;   // 새로 선택한 이미지 bytes
+  Uint8List? _imageBytes; // 새로 선택한 이미지 bytes
   bool _isSaving = false;
 
-  bool get _hasImageSelected => _imageBytes != null || (_isEditing && widget.editItem!.imageUrl != null);
+  bool get _hasImageSelected =>
+      _imageBytes != null || (_isEditing && widget.editItem!.imageUrl != null);
 
   bool get _isEditing => widget.editItem != null;
 
@@ -222,7 +223,8 @@ class _AddItemScreenState extends State<AddItemScreen> {
           .map(
             (e) => PurchaseRecord(
               date: e.date,
-              price: int.tryParse(
+              price:
+                  int.tryParse(
                     e.priceCtrl.text.replaceAll(RegExp(r'[^0-9]'), ''),
                   ) ??
                   0,
@@ -232,13 +234,12 @@ class _AddItemScreenState extends State<AddItemScreen> {
           .toList();
 
       final cycleDays =
-          int.tryParse(_cycleDaysCtrl.text) ?? getDefaultDays(_selectedCategory);
+          int.tryParse(_cycleDaysCtrl.text) ??
+          getDefaultDays(_selectedCategory);
 
       // 편집 시 기존 purchases (id 있음) + 새 purchases (id 없음) 합치기
       final existingPurchases = _isEditing
-          ? widget.editItem!.purchaseHistory
-              .where((r) => r.id != null)
-              .toList()
+          ? widget.editItem!.purchaseHistory.where((r) => r.id != null).toList()
           : <PurchaseRecord>[];
 
       final item = ConsumableItem(
@@ -267,9 +268,9 @@ class _AddItemScreenState extends State<AddItemScreen> {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(_isEditing
-                ? '${item.name} 수정 완료!'
-                : '${item.name} 등록 완료!'),
+            content: Text(
+              _isEditing ? '${item.name} 수정 완료!' : '${item.name} 등록 완료!',
+            ),
             behavior: SnackBarBehavior.floating,
             backgroundColor: AppColors.success,
           ),
@@ -301,8 +302,8 @@ class _AddItemScreenState extends State<AddItemScreen> {
           widget.isOcrReview
               ? 'OCR 결과 검수'
               : _isEditing
-                  ? '제품 수정'
-                  : '제품 등록',
+              ? '제품 수정'
+              : '제품 등록',
         ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new, size: 20),
@@ -409,7 +410,9 @@ class _AddItemScreenState extends State<AddItemScreen> {
         width: double.infinity,
         clipBehavior: Clip.antiAlias,
         decoration: BoxDecoration(
-          color: _hasImageSelected ? AppColors.primaryLight2 : AppColors.surfaceAlt,
+          color: _hasImageSelected
+              ? AppColors.primaryLight2
+              : AppColors.surfaceAlt,
           borderRadius: BorderRadius.circular(14),
           border: Border.all(
             color: _hasImageSelected ? AppColors.primary : AppColors.border,
@@ -438,52 +441,52 @@ class _AddItemScreenState extends State<AddItemScreen> {
                 ],
               )
             : existingUrl != null
-                // 기존 등록된 이미지 URL 프리뷰
-                ? Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      Image.network(existingUrl, fit: BoxFit.cover),
-                      Positioned(
-                        bottom: 0,
-                        left: 0,
-                        right: 0,
-                        child: Container(
-                          color: Colors.black45,
-                          padding: const EdgeInsets.symmetric(vertical: 6),
-                          child: const Text(
-                            '탭하여 변경',
-                            textAlign: TextAlign.center,
-                            style: TextStyle(fontSize: 12, color: Colors.white),
-                          ),
-                        ),
+            // 기존 등록된 이미지 URL 프리뷰
+            ? Stack(
+                fit: StackFit.expand,
+                children: [
+                  Image.network(existingUrl, fit: BoxFit.cover),
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: Container(
+                      color: Colors.black45,
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: const Text(
+                        '탭하여 변경',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(fontSize: 12, color: Colors.white),
                       ),
-                    ],
-                  )
-                // 미선택 상태
-                : const Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Icon(
-                        Icons.add_photo_alternate_outlined,
-                        size: 36,
-                        color: AppColors.textMuted,
-                      ),
-                      SizedBox(height: 10),
-                      Text(
-                        '제품 이미지 선택',
-                        style: TextStyle(
-                          fontSize: 14,
-                          color: AppColors.textSecondary,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                      SizedBox(height: 2),
-                      Text(
-                        '탭하여 갤러리에서 선택 (선택 사항)',
-                        style: TextStyle(fontSize: 12, color: AppColors.textMuted),
-                      ),
-                    ],
+                    ),
                   ),
+                ],
+              )
+            // 미선택 상태
+            : const Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.add_photo_alternate_outlined,
+                    size: 36,
+                    color: AppColors.textMuted,
+                  ),
+                  SizedBox(height: 10),
+                  Text(
+                    '제품 이미지 선택',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: AppColors.textSecondary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  SizedBox(height: 2),
+                  Text(
+                    '탭하여 갤러리에서 선택 (선택 사항)',
+                    style: TextStyle(fontSize: 12, color: AppColors.textMuted),
+                  ),
+                ],
+              ),
       ),
     );
   }
@@ -670,8 +673,8 @@ class _AddItemScreenState extends State<AddItemScreen> {
     return Column(
       children: [
         ..._purchases.asMap().entries.map(
-              (entry) => _buildPurchaseEntry(entry.key),
-            ),
+          (entry) => _buildPurchaseEntry(entry.key),
+        ),
         const SizedBox(height: 10),
         SizedBox(
           width: double.infinity,
@@ -873,12 +876,9 @@ class _AddItemScreenState extends State<AddItemScreen> {
             _isSaving
                 ? '저장 중...'
                 : _isEditing
-                    ? '수정 완료'
-                    : '등록 완료',
-            style: const TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-            ),
+                ? '수정 완료'
+                : '등록 완료',
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
           ),
           style: FilledButton.styleFrom(
             backgroundColor: AppColors.primary,
@@ -979,4 +979,3 @@ class _PurchaseEntry {
     );
   }
 }
-

--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -1,0 +1,982 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:image_picker/image_picker.dart';
+import '../models/item.dart';
+import '../services/ai/category_defaults.dart';
+import '../services/supabase_service.dart';
+import '../services/item_store.dart';
+import '../theme/app_theme.dart';
+
+/// OCR 스캔 결과에서 전달받는 사전 입력 데이터
+class OcrPrefillData {
+  final String? productName;
+  final int? price;
+  final String? storeName;
+  final DateTime? purchaseDate;
+
+  const OcrPrefillData({
+    this.productName,
+    this.price,
+    this.storeName,
+    this.purchaseDate,
+  });
+}
+
+/// 수동 제품 등록 및 구매 이력 입력 화면
+///
+/// [prefillData]  OCR 스캔 결과에서 전달받은 사전 입력 데이터 (선택)
+/// [editItem]     편집할 기존 제품 (null이면 신규 등록 모드)
+/// [isOcrReview]  true이면 AppBar 타이틀이 'OCR 결과 검수'로 표시됨
+class AddItemScreen extends StatefulWidget {
+  final OcrPrefillData? prefillData;
+  final ConsumableItem? editItem;
+  final bool isOcrReview;
+
+  const AddItemScreen({
+    super.key,
+    this.prefillData,
+    this.editItem,
+    this.isOcrReview = false,
+  });
+
+  @override
+  State<AddItemScreen> createState() => _AddItemScreenState();
+}
+
+class _AddItemScreenState extends State<AddItemScreen> {
+  final _formKey = GlobalKey<FormState>();
+
+  // 기본 정보 컨트롤러
+  late final TextEditingController _nameCtrl;
+  late final TextEditingController _brandCtrl;
+  late final TextEditingController _cycleDaysCtrl;
+  String _selectedCategory = categoryDefaultDays.keys.first;
+
+  // 구매 이력 목록
+  final List<_PurchaseEntry> _purchases = [];
+
+  // 이미지 상태
+  Uint8List? _imageBytes;   // 새로 선택한 이미지 bytes
+  bool _isSaving = false;
+
+  bool get _hasImageSelected => _imageBytes != null || (_isEditing && widget.editItem!.imageUrl != null);
+
+  bool get _isEditing => widget.editItem != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final edit = widget.editItem;
+    final p = widget.prefillData;
+
+    if (edit != null) {
+      // 편집 모드: 기존 제품 데이터로 초기화
+      _nameCtrl = TextEditingController(text: edit.name);
+      _brandCtrl = TextEditingController(text: edit.brand);
+      // 기존 카테고리가 드롭다운 목록에 없으면 첫 번째 항목으로 폴백
+      _selectedCategory = categoryDefaultDays.containsKey(edit.category)
+          ? edit.category
+          : categoryDefaultDays.keys.first;
+      _cycleDaysCtrl = TextEditingController(text: edit.cycleDays.toString());
+      for (final r in edit.purchaseHistory) {
+        _purchases.add(
+          _PurchaseEntry(
+            date: r.date,
+            priceCtrl: TextEditingController(text: r.price.toString()),
+            storeCtrl: TextEditingController(text: r.store),
+          ),
+        );
+      }
+    } else {
+      // 신규 등록 모드: OCR 데이터 또는 빈 값으로 초기화
+      _nameCtrl = TextEditingController(text: p?.productName ?? '');
+      _brandCtrl = TextEditingController();
+      _cycleDaysCtrl = TextEditingController(
+        text: getDefaultDays(_selectedCategory).toString(),
+      );
+      // 구매 이력 1건 기본 표시 (가격 입력 유도)
+      _purchases.add(
+        _PurchaseEntry(
+          date: p?.purchaseDate ?? DateTime.now(),
+          priceCtrl: TextEditingController(text: p?.price?.toString() ?? ''),
+          storeCtrl: TextEditingController(text: p?.storeName ?? ''),
+        ),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _brandCtrl.dispose();
+    _cycleDaysCtrl.dispose();
+    for (final e in _purchases) {
+      e.priceCtrl.dispose();
+      e.storeCtrl.dispose();
+    }
+    super.dispose();
+  }
+
+  // ---------------------------------------------------------------------------
+  // 카테고리 변경 시 교체 주기 기본값 자동 입력
+  // ---------------------------------------------------------------------------
+  void _onCategoryChanged(String? value) {
+    if (value == null) return;
+    setState(() {
+      _selectedCategory = value;
+      _cycleDaysCtrl.text = getDefaultDays(value).toString();
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // 날짜 선택기 (Flutter 내장 showDatePicker - 웹/모바일 공통 지원)
+  // ---------------------------------------------------------------------------
+  Future<void> _pickDate(int index) async {
+    final entry = _purchases[index];
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: entry.date,
+      firstDate: DateTime(2000),
+      lastDate: DateTime.now(),
+      builder: (context, child) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            colorScheme: const ColorScheme.light(
+              primary: AppColors.primary,
+              onPrimary: Colors.white,
+              surface: AppColors.surface,
+            ),
+          ),
+          child: child!,
+        );
+      },
+    );
+    if (picked != null) {
+      setState(() => _purchases[index] = entry.copyWith(date: picked));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // 구매 이력 추가 / 삭제
+  // ---------------------------------------------------------------------------
+  void _addPurchaseEntry() {
+    setState(() {
+      _purchases.add(
+        _PurchaseEntry(
+          date: DateTime.now(),
+          priceCtrl: TextEditingController(),
+          storeCtrl: TextEditingController(),
+        ),
+      );
+    });
+  }
+
+  void _removePurchaseEntry(int index) {
+    setState(() {
+      final entry = _purchases.removeAt(index);
+      entry.priceCtrl.dispose();
+      entry.storeCtrl.dispose();
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // 이미지 선택 (image_picker — 웹/모바일 공통)
+  // ---------------------------------------------------------------------------
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final xFile = await picker.pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 1024,
+      maxHeight: 1024,
+      imageQuality: 85,
+    );
+    if (xFile == null) return;
+    final bytes = await xFile.readAsBytes();
+    setState(() => _imageBytes = bytes);
+  }
+
+  // ---------------------------------------------------------------------------
+  // 등록 완료 제출
+  // ---------------------------------------------------------------------------
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _isSaving = true);
+
+    try {
+      // 편집 모드면 기존 id 유지, 신규면 Supabase용 UUID 생성
+      final itemId = _isEditing
+          ? widget.editItem!.id
+          : SupabaseService.generateUuid();
+
+      // 새로 선택한 이미지가 있으면 Supabase Storage에 업로드
+      String? imageUrl = _isEditing ? widget.editItem!.imageUrl : null;
+      if (_imageBytes != null) {
+        imageUrl = await SupabaseService.uploadItemImage(
+          imageBytes: _imageBytes!,
+          itemId: itemId,
+        );
+      }
+
+      final purchases = _purchases
+          .where((e) => e.priceCtrl.text.trim().isNotEmpty)
+          .map(
+            (e) => PurchaseRecord(
+              date: e.date,
+              price: int.tryParse(
+                    e.priceCtrl.text.replaceAll(RegExp(r'[^0-9]'), ''),
+                  ) ??
+                  0,
+              store: e.storeCtrl.text.trim(),
+            ),
+          )
+          .toList();
+
+      final cycleDays =
+          int.tryParse(_cycleDaysCtrl.text) ?? getDefaultDays(_selectedCategory);
+
+      // 편집 시 기존 purchases (id 있음) + 새 purchases (id 없음) 합치기
+      final existingPurchases = _isEditing
+          ? widget.editItem!.purchaseHistory
+              .where((r) => r.id != null)
+              .toList()
+          : <PurchaseRecord>[];
+
+      final item = ConsumableItem(
+        id: itemId,
+        name: _nameCtrl.text.trim(),
+        brand: _brandCtrl.text.trim(),
+        category: _selectedCategory,
+        icon: _categoryIcon(_selectedCategory),
+        daysRemaining: cycleDays,
+        cycleDays: cycleDays,
+        progress: _isEditing ? widget.editItem!.progress : 0.0,
+        aiPredictedDays: _isEditing ? widget.editItem!.aiPredictedDays : null,
+        aiConfidence: _isEditing ? widget.editItem!.aiConfidence : null,
+        imageUrl: imageUrl,
+        purchaseHistory: [...existingPurchases, ...purchases],
+      );
+
+      // Supabase 저장 + 인메모리 스토어 반영
+      if (_isEditing) {
+        await ItemStore.instance.update(item);
+      } else {
+        await ItemStore.instance.add(item);
+      }
+
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(_isEditing
+                ? '${item.name} 수정 완료!'
+                : '${item.name} 등록 완료!'),
+            behavior: SnackBarBehavior.floating,
+            backgroundColor: AppColors.success,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('저장 실패: $e'),
+            behavior: SnackBarBehavior.floating,
+            backgroundColor: AppColors.danger,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSaving = false);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Build
+  // ---------------------------------------------------------------------------
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          widget.isOcrReview
+              ? 'OCR 결과 검수'
+              : _isEditing
+                  ? '제품 수정'
+                  : '제품 등록',
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new, size: 20),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 8, 20, 100),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (widget.isOcrReview) ...[
+                _buildOcrBanner(),
+                const SizedBox(height: 20),
+              ],
+              _sectionTitle('제품 이미지'),
+              const SizedBox(height: 12),
+              _buildImagePicker(),
+              const SizedBox(height: 24),
+              _sectionTitle('기본 정보'),
+              const SizedBox(height: 12),
+              _buildBasicInfoSection(),
+              const SizedBox(height: 24),
+              _sectionTitle('구매 이력'),
+              const SizedBox(height: 4),
+              Text(
+                '구매 이력을 추가하면 AI 교체 예측 정확도가 높아집니다.',
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: AppColors.textMuted,
+                ),
+              ),
+              const SizedBox(height: 12),
+              _buildPurchaseSection(),
+              const SizedBox(height: 32),
+            ],
+          ),
+        ),
+      ),
+      bottomNavigationBar: _buildBottomBar(),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 섹션 공통 위젯
+  // ---------------------------------------------------------------------------
+
+  Widget _sectionTitle(String title) {
+    return Text(
+      title,
+      style: const TextStyle(
+        fontSize: 16,
+        fontWeight: FontWeight.w700,
+        color: AppColors.text,
+      ),
+    );
+  }
+
+  Widget _buildOcrBanner() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.primaryLight2,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.primaryLight, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.document_scanner_outlined,
+            size: 18,
+            color: AppColors.primary,
+          ),
+          const SizedBox(width: 8),
+          const Expanded(
+            child: Text(
+              'OCR로 추출된 정보입니다. 내용을 확인 후 수정해주세요.',
+              style: TextStyle(
+                fontSize: 13,
+                color: AppColors.primaryDark,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 이미지 선택 영역
+  // ---------------------------------------------------------------------------
+
+  Widget _buildImagePicker() {
+    // 표시 우선순위: 새로 선택한 bytes > 기존 URL > 빈 상태
+    final existingUrl = _isEditing ? widget.editItem!.imageUrl : null;
+
+    return GestureDetector(
+      onTap: _pickImage,
+      child: Container(
+        height: 160,
+        width: double.infinity,
+        clipBehavior: Clip.antiAlias,
+        decoration: BoxDecoration(
+          color: _hasImageSelected ? AppColors.primaryLight2 : AppColors.surfaceAlt,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(
+            color: _hasImageSelected ? AppColors.primary : AppColors.border,
+          ),
+        ),
+        child: _imageBytes != null
+            // 새로 선택한 이미지 프리뷰
+            ? Stack(
+                fit: StackFit.expand,
+                children: [
+                  Image.memory(_imageBytes!, fit: BoxFit.cover),
+                  Positioned(
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    child: Container(
+                      color: Colors.black45,
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: const Text(
+                        '탭하여 변경',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(fontSize: 12, color: Colors.white),
+                      ),
+                    ),
+                  ),
+                ],
+              )
+            : existingUrl != null
+                // 기존 등록된 이미지 URL 프리뷰
+                ? Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      Image.network(existingUrl, fit: BoxFit.cover),
+                      Positioned(
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        child: Container(
+                          color: Colors.black45,
+                          padding: const EdgeInsets.symmetric(vertical: 6),
+                          child: const Text(
+                            '탭하여 변경',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(fontSize: 12, color: Colors.white),
+                          ),
+                        ),
+                      ),
+                    ],
+                  )
+                // 미선택 상태
+                : const Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.add_photo_alternate_outlined,
+                        size: 36,
+                        color: AppColors.textMuted,
+                      ),
+                      SizedBox(height: 10),
+                      Text(
+                        '제품 이미지 선택',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: AppColors.textSecondary,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      SizedBox(height: 2),
+                      Text(
+                        '탭하여 갤러리에서 선택 (선택 사항)',
+                        style: TextStyle(fontSize: 12, color: AppColors.textMuted),
+                      ),
+                    ],
+                  ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 기본 정보 섹션
+  // ---------------------------------------------------------------------------
+
+  Widget _buildBasicInfoSection() {
+    return Column(
+      children: [
+        _labeledField(
+          label: '제품명 *',
+          controller: _nameCtrl,
+          hint: '예) 정수기 필터',
+          validator: (v) =>
+              (v == null || v.trim().isEmpty) ? '제품명을 입력해주세요' : null,
+        ),
+        const SizedBox(height: 14),
+        _labeledField(
+          label: '브랜드명',
+          controller: _brandCtrl,
+          hint: '예) 코웨이 (선택)',
+        ),
+        const SizedBox(height: 14),
+        _buildCategoryDropdown(),
+        const SizedBox(height: 14),
+        _buildCycleDaysField(),
+      ],
+    );
+  }
+
+  Widget _labeledField({
+    required String label,
+    required TextEditingController controller,
+    String? hint,
+    String? Function(String?)? validator,
+    TextInputType keyboardType = TextInputType.text,
+    List<TextInputFormatter>? inputFormatters,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: AppColors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 6),
+        TextFormField(
+          controller: controller,
+          keyboardType: keyboardType,
+          inputFormatters: inputFormatters,
+          validator: validator,
+          style: const TextStyle(fontSize: 15, color: AppColors.text),
+          decoration: _inputDecoration(hint: hint),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCategoryDropdown() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '카테고리 *',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: AppColors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 6),
+        // DropdownButton을 FormField로 감싸 deprecated value 파라미터 사용 회피
+        InputDecorator(
+          decoration: _inputDecoration(),
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<String>(
+              value: _selectedCategory,
+              isDense: true,
+              isExpanded: true,
+              items: categoryDefaultDays.keys
+                  .map(
+                    (cat) => DropdownMenuItem(
+                      value: cat,
+                      child: Row(
+                        children: [
+                          Icon(
+                            _categoryIcon(cat),
+                            size: 18,
+                            color: AppColors.primary,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            cat,
+                            style: const TextStyle(
+                              fontSize: 15,
+                              color: AppColors.text,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  )
+                  .toList(),
+              onChanged: _onCategoryChanged,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCycleDaysField() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          '교체 주기 *',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: AppColors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: TextFormField(
+                controller: _cycleDaysCtrl,
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                validator: (v) {
+                  if (v == null || v.isEmpty) return '교체 주기를 입력해주세요';
+                  final n = int.tryParse(v);
+                  if (n == null || n <= 0) return '1일 이상 입력해주세요';
+                  return null;
+                },
+                style: const TextStyle(fontSize: 15, color: AppColors.text),
+                decoration: _inputDecoration(hint: '30'),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Container(
+              height: 48,
+              padding: const EdgeInsets.symmetric(horizontal: 18),
+              decoration: BoxDecoration(
+                color: AppColors.surfaceAlt,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: AppColors.border),
+              ),
+              alignment: Alignment.center,
+              child: const Text(
+                '일',
+                style: TextStyle(
+                  fontSize: 15,
+                  color: AppColors.textSecondary,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        const Text(
+          '카테고리 선택 시 기본값이 자동 입력됩니다.',
+          style: TextStyle(fontSize: 12, color: AppColors.textMuted),
+        ),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 구매 이력 섹션
+  // ---------------------------------------------------------------------------
+
+  Widget _buildPurchaseSection() {
+    return Column(
+      children: [
+        ..._purchases.asMap().entries.map(
+              (entry) => _buildPurchaseEntry(entry.key),
+            ),
+        const SizedBox(height: 10),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: _addPurchaseEntry,
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('구매 이력 추가'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: AppColors.primary,
+              side: const BorderSide(color: AppColors.primary),
+              padding: const EdgeInsets.symmetric(vertical: 13),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPurchaseEntry(int index) {
+    final entry = _purchases[index];
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 이력 헤더
+          Row(
+            children: [
+              Text(
+                '구매 이력 ${index + 1}',
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              const Spacer(),
+              GestureDetector(
+                onTap: () => _removePurchaseEntry(index),
+                child: const Icon(
+                  Icons.close,
+                  size: 18,
+                  color: AppColors.textMuted,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+
+          // 구매일 (Date Picker - Flutter 내장, 웹/모바일 공통)
+          const Text(
+            '구매일',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: AppColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 5),
+          InkWell(
+            onTap: () => _pickDate(index),
+            borderRadius: BorderRadius.circular(10),
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(color: AppColors.border),
+              ),
+              child: Row(
+                children: [
+                  const Icon(
+                    Icons.calendar_today_outlined,
+                    size: 16,
+                    color: AppColors.primary,
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    _formatDate(entry.date),
+                    style: const TextStyle(fontSize: 15, color: AppColors.text),
+                  ),
+                  const Spacer(),
+                  const Icon(
+                    Icons.keyboard_arrow_down,
+                    size: 18,
+                    color: AppColors.textMuted,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+
+          // 가격 + 매장명
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                flex: 3,
+                child: _compactField(
+                  label: '가격 (원)',
+                  controller: entry.priceCtrl,
+                  hint: '0',
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                flex: 4,
+                child: _compactField(
+                  label: '매장명',
+                  controller: entry.storeCtrl,
+                  hint: '예) 쿠팡',
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _compactField({
+    required String label,
+    required TextEditingController controller,
+    String? hint,
+    TextInputType keyboardType = TextInputType.text,
+    List<TextInputFormatter>? inputFormatters,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
+            color: AppColors.textMuted,
+          ),
+        ),
+        const SizedBox(height: 5),
+        TextFormField(
+          controller: controller,
+          keyboardType: keyboardType,
+          inputFormatters: inputFormatters,
+          style: const TextStyle(fontSize: 14, color: AppColors.text),
+          decoration: _inputDecoration(
+            hint: hint,
+            compact: true,
+            fillColor: AppColors.surfaceAlt,
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 하단 등록 버튼
+  // ---------------------------------------------------------------------------
+
+  Widget _buildBottomBar() {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+        20,
+        12,
+        20,
+        MediaQuery.of(context).padding.bottom + 12,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.surface,
+        border: Border(top: BorderSide(color: AppColors.border, width: 0.5)),
+      ),
+      child: SizedBox(
+        width: double.infinity,
+        child: FilledButton.icon(
+          onPressed: _isSaving ? null : _submit,
+          icon: _isSaving
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    color: Colors.white,
+                    strokeWidth: 2,
+                  ),
+                )
+              : const Icon(Icons.check_circle_outline, size: 20),
+          label: Text(
+            _isSaving
+                ? '저장 중...'
+                : _isEditing
+                    ? '수정 완료'
+                    : '등록 완료',
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          style: FilledButton.styleFrom(
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+            disabledBackgroundColor: AppColors.textMuted,
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(14),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 공통 InputDecoration
+  // ---------------------------------------------------------------------------
+
+  InputDecoration _inputDecoration({
+    String? hint,
+    bool compact = false,
+    Color fillColor = AppColors.surface,
+  }) {
+    return InputDecoration(
+      hintText: hint,
+      hintStyle: const TextStyle(color: AppColors.textMuted),
+      isDense: true,
+      contentPadding: EdgeInsets.symmetric(
+        horizontal: 14,
+        vertical: compact ? 10 : 12,
+      ),
+      filled: true,
+      fillColor: fillColor,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: AppColors.border),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: AppColors.border),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: AppColors.primary, width: 1.5),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: AppColors.danger),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(10),
+        borderSide: const BorderSide(color: AppColors.danger, width: 1.5),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // 헬퍼
+  // ---------------------------------------------------------------------------
+
+  String _formatDate(DateTime dt) {
+    return '${dt.year}.${dt.month.toString().padLeft(2, '0')}.${dt.day.toString().padLeft(2, '0')}';
+  }
+
+  IconData _categoryIcon(String category) {
+    return switch (category) {
+      '욕실/위생' => Icons.bathroom_outlined,
+      '주방/세제' => Icons.kitchen_outlined,
+      '세탁/청소' => Icons.local_laundry_service_outlined,
+      '헤어/바디' => Icons.shower_outlined,
+      '가전/필터' => Icons.air_outlined,
+      _ => Icons.category_outlined,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 구매 이력 항목 내부 모델
+// ---------------------------------------------------------------------------
+
+class _PurchaseEntry {
+  final DateTime date;
+  final TextEditingController priceCtrl;
+  final TextEditingController storeCtrl;
+
+  _PurchaseEntry({
+    required this.date,
+    required this.priceCtrl,
+    required this.storeCtrl,
+  });
+
+  _PurchaseEntry copyWith({DateTime? date}) {
+    return _PurchaseEntry(
+      date: date ?? this.date,
+      priceCtrl: priceCtrl,
+      storeCtrl: storeCtrl,
+    );
+  }
+}
+

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -1,13 +1,86 @@
 import 'package:flutter/material.dart';
 import '../data/sample_data.dart';
 import '../models/item.dart';
+import '../services/item_store.dart';
 import '../theme/app_theme.dart';
 import '../widgets/countdown_ring.dart';
+import 'add_item_screen.dart';
 
-class ItemDetailScreen extends StatelessWidget {
+class ItemDetailScreen extends StatefulWidget {
   final ConsumableItem item;
 
   const ItemDetailScreen({super.key, required this.item});
+
+  @override
+  State<ItemDetailScreen> createState() => _ItemDetailScreenState();
+}
+
+class _ItemDetailScreenState extends State<ItemDetailScreen> {
+  late ConsumableItem _item;
+
+  @override
+  void initState() {
+    super.initState();
+    _item = widget.item;
+    ItemStore.instance.addListener(_onStoreChanged);
+  }
+
+  @override
+  void dispose() {
+    ItemStore.instance.removeListener(_onStoreChanged);
+    super.dispose();
+  }
+
+  // 스토어 변경 시 현재 아이템 갱신 (삭제됐으면 자동으로 뒤로 이동)
+  void _onStoreChanged() {
+    final found = ItemStore.instance.findById(_item.id);
+    if (found == null) {
+      if (mounted) Navigator.of(context).pop();
+      return;
+    }
+    if (mounted) setState(() => _item = found);
+  }
+
+  // 편집 화면으로 이동
+  void _openEdit() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => AddItemScreen(editItem: _item),
+      ),
+    );
+  }
+
+  // 삭제 확인 다이얼로그
+  Future<void> _confirmDelete() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('제품 삭제'),
+        content: Text(
+          '\'${_item.name}\'을(를) 삭제하시겠습니까?\n삭제 후 복구할 수 없습니다.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.danger,
+            ),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      await ItemStore.instance.delete(_item.id);
+      // _onStoreChanged가 자동으로 pop 처리
+    }
+  }
 
   String _formatPrice(int price) {
     final str = price.toString();
@@ -16,7 +89,7 @@ class ItemDetailScreen extends StatelessWidget {
       if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
       buffer.write(str[i]);
     }
-    return '${buffer}원';
+    return '$buffer원';
   }
 
   @override
@@ -24,10 +97,18 @@ class ItemDetailScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: AppColors.background,
       appBar: AppBar(
-        title: Text(item.name),
+        title: Text(_item.name),
         actions: [
-          IconButton(icon: const Icon(Icons.edit_outlined), onPressed: () {}),
-          IconButton(icon: const Icon(Icons.share_outlined), onPressed: () {}),
+          IconButton(
+            icon: const Icon(Icons.edit_outlined),
+            tooltip: '편집',
+            onPressed: _openEdit,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline, color: AppColors.danger),
+            tooltip: '삭제',
+            onPressed: _confirmDelete,
+          ),
         ],
       ),
       body: SingleChildScrollView(
@@ -35,24 +116,17 @@ class ItemDetailScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Product header + D-day ring
-            _buildProductHeader(context),
+            _buildProductHeader(),
             const SizedBox(height: 24),
-
-            // Replacement cycle
-            _buildReplacementCycle(context),
+            _buildReplacementCycle(),
             const SizedBox(height: 20),
-
-            // AI Price comparison
-            _buildPriceComparison(context),
+            _buildPriceComparison(),
             const SizedBox(height: 20),
-
-            // Purchase history
-            _buildPurchaseHistory(context),
-            const SizedBox(height: 24),
-
-            // Action buttons
-            _buildActionButtons(context),
+            if (_item.purchaseHistory.isNotEmpty) ...[
+              _buildPurchaseHistory(),
+              const SizedBox(height: 20),
+            ],
+            _buildActionButtons(),
             const SizedBox(height: 20),
           ],
         ),
@@ -60,79 +134,113 @@ class ItemDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildProductHeader(BuildContext context) {
+  Widget _buildProductHeader() {
+    final hasImage = _item.imageUrl != null && _item.imageUrl!.isNotEmpty;
+
     return Container(
-      padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
         color: AppColors.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: AppColors.border, width: 0.5),
       ),
-      child: Row(
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            width: 64,
-            height: 64,
-            decoration: BoxDecoration(
-              color: AppColors.primaryLight2,
-              borderRadius: BorderRadius.circular(16),
-            ),
-            child: Icon(item.icon, color: AppColors.primary, size: 32),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 3,
-                  ),
-                  decoration: BoxDecoration(
+          // 이미지 배너 (imageUrl이 있을 때만)
+          if (hasImage)
+            SizedBox(
+              width: double.infinity,
+              height: 220,
+              child: Image.network(
+                _item.imageUrl!,
+                fit: BoxFit.cover,
+                loadingBuilder: (_, child, progress) {
+                  if (progress == null) return child;
+                  return Container(
                     color: AppColors.primaryLight2,
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                  child: Text(
-                    item.category,
-                    style: const TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.primary,
+                    child: const Center(
+                      child: CircularProgressIndicator(strokeWidth: 2),
                     ),
+                  );
+                },
+                errorBuilder: (_, error, stack) => Container(
+                  color: AppColors.primaryLight2,
+                  child: const Center(
+                    child: Icon(Icons.broken_image_outlined,
+                        size: 48, color: AppColors.textMuted),
                   ),
                 ),
-                const SizedBox(height: 6),
-                Text(
-                  item.name,
-                  style: const TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.text,
+              ),
+            ),
+          // 제품 정보 행
+          Padding(
+            padding: const EdgeInsets.all(20),
+            child: Row(
+              children: [
+                if (!hasImage)
+                  Container(
+                    width: 64,
+                    height: 64,
+                    decoration: BoxDecoration(
+                      color: AppColors.primaryLight2,
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Icon(_item.icon, color: AppColors.primary, size: 32),
+                  ),
+                if (!hasImage) const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 3),
+                        decoration: BoxDecoration(
+                          color: AppColors.primaryLight2,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: Text(
+                          _item.category,
+                          style: const TextStyle(
+                            fontSize: 11,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.primary,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        _item.name,
+                        style: const TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.text,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        _item.brand,
+                        style: const TextStyle(
+                            fontSize: 14, color: AppColors.textMuted),
+                      ),
+                    ],
                   ),
                 ),
-                const SizedBox(height: 2),
-                Text(
-                  item.brand,
-                  style: const TextStyle(
-                    fontSize: 14,
-                    color: AppColors.textMuted,
-                  ),
+                CountdownRing(
+                  daysRemaining: _item.daysRemaining,
+                  totalDays: _item.cycleDays,
+                  size: 100,
                 ),
               ],
             ),
-          ),
-          CountdownRing(
-            daysRemaining: item.daysRemaining,
-            totalDays: item.cycleDays,
-            size: 100,
           ),
         ],
       ),
     );
   }
 
-  Widget _buildReplacementCycle(BuildContext context) {
+  Widget _buildReplacementCycle() {
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
@@ -154,26 +262,26 @@ class ItemDetailScreen extends StatelessWidget {
           const SizedBox(height: 16),
           _cycleRow(
             '사용자 설정',
-            '${item.cycleDays}일',
+            '${_item.cycleDays}일',
             Icons.person_outline,
             AppColors.textSecondary,
           ),
-          if (item.aiPredictedDays != null) ...[
+          if (_item.aiPredictedDays != null) ...[
             const SizedBox(height: 12),
             _cycleRow(
               'AI 예측',
-              '${item.aiPredictedDays}일',
+              '${_item.aiPredictedDays}일',
               Icons.auto_awesome_outlined,
               AppColors.primary,
             ),
-            if (item.aiConfidence != null) ...[
+            if (_item.aiConfidence != null) ...[
               const SizedBox(height: 8),
               Padding(
                 padding: const EdgeInsets.only(left: 36),
                 child: Row(
                   children: [
                     Text(
-                      '신뢰도 ${(item.aiConfidence! * 100).toInt()}%',
+                      '신뢰도 ${(_item.aiConfidence! * 100).toInt()}%',
                       style: const TextStyle(
                         fontSize: 12,
                         color: AppColors.textMuted,
@@ -184,7 +292,7 @@ class ItemDetailScreen extends StatelessWidget {
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(3),
                         child: LinearProgressIndicator(
-                          value: item.aiConfidence!,
+                          value: _item.aiConfidence!,
                           minHeight: 4,
                           backgroundColor: AppColors.border,
                           valueColor: const AlwaysStoppedAnimation<Color>(
@@ -208,10 +316,9 @@ class ItemDetailScreen extends StatelessWidget {
       children: [
         Icon(icon, size: 20, color: color),
         const SizedBox(width: 12),
-        Text(
-          label,
-          style: const TextStyle(fontSize: 14, color: AppColors.textSecondary),
-        ),
+        Text(label,
+            style: const TextStyle(
+                fontSize: 14, color: AppColors.textSecondary)),
         const Spacer(),
         Text(
           value,
@@ -225,7 +332,7 @@ class ItemDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildPriceComparison(BuildContext context) {
+  Widget _buildPriceComparison() {
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
@@ -238,11 +345,8 @@ class ItemDetailScreen extends StatelessWidget {
         children: [
           const Row(
             children: [
-              Icon(
-                Icons.auto_awesome_outlined,
-                size: 18,
-                color: AppColors.primary,
-              ),
+              Icon(Icons.auto_awesome_outlined,
+                  size: 18, color: AppColors.primary),
               SizedBox(width: 8),
               Text(
                 'AI 가격 비교',
@@ -261,11 +365,8 @@ class ItemDetailScreen extends StatelessWidget {
               child: Row(
                 children: [
                   if (p.isLowest)
-                    const Icon(
-                      Icons.check_circle,
-                      size: 16,
-                      color: AppColors.success,
-                    )
+                    const Icon(Icons.check_circle,
+                        size: 16, color: AppColors.success)
                   else
                     const SizedBox(width: 16),
                   const SizedBox(width: 10),
@@ -273,9 +374,8 @@ class ItemDetailScreen extends StatelessWidget {
                     p.store,
                     style: TextStyle(
                       fontSize: 14,
-                      fontWeight: p.isLowest
-                          ? FontWeight.w600
-                          : FontWeight.w400,
+                      fontWeight:
+                          p.isLowest ? FontWeight.w600 : FontWeight.w400,
                       color: p.isLowest
                           ? AppColors.text
                           : AppColors.textSecondary,
@@ -286,10 +386,10 @@ class ItemDetailScreen extends StatelessWidget {
                     _formatPrice(p.price),
                     style: TextStyle(
                       fontSize: 15,
-                      fontWeight: p.isLowest
-                          ? FontWeight.w700
-                          : FontWeight.w400,
-                      color: p.isLowest ? AppColors.success : AppColors.text,
+                      fontWeight:
+                          p.isLowest ? FontWeight.w700 : FontWeight.w400,
+                      color:
+                          p.isLowest ? AppColors.success : AppColors.text,
                     ),
                   ),
                 ],
@@ -301,7 +401,7 @@ class ItemDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildPurchaseHistory(BuildContext context) {
+  Widget _buildPurchaseHistory() {
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
@@ -321,16 +421,15 @@ class ItemDetailScreen extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 16),
-          ...item.purchaseHistory.asMap().entries.map((entry) {
+          ..._item.purchaseHistory.asMap().entries.map((entry) {
             final i = entry.key;
             final record = entry.value;
-            final isLast = i == item.purchaseHistory.length - 1;
+            final isLast = i == _item.purchaseHistory.length - 1;
 
             return IntrinsicHeight(
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Timeline
                   Column(
                     children: [
                       Container(
@@ -338,17 +437,19 @@ class ItemDetailScreen extends StatelessWidget {
                         height: 10,
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
-                          color: i == 0 ? AppColors.primary : AppColors.border,
+                          color: i == 0
+                              ? AppColors.primary
+                              : AppColors.border,
                         ),
                       ),
                       if (!isLast)
                         Expanded(
-                          child: Container(width: 1.5, color: AppColors.border),
+                          child: Container(
+                              width: 1.5, color: AppColors.border),
                         ),
                     ],
                   ),
                   const SizedBox(width: 14),
-                  // Content
                   Expanded(
                     child: Padding(
                       padding: const EdgeInsets.only(bottom: 20),
@@ -397,14 +498,14 @@ class ItemDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildActionButtons(BuildContext context) {
+  Widget _buildActionButtons() {
     return Row(
       children: [
         Expanded(
           child: FilledButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.add_shopping_cart, size: 18),
-            label: const Text('구매 기록'),
+            onPressed: _openEdit,
+            icon: const Icon(Icons.edit_outlined, size: 18),
+            label: const Text('정보 수정'),
             style: FilledButton.styleFrom(
               backgroundColor: AppColors.primary,
               foregroundColor: Colors.white,
@@ -418,12 +519,12 @@ class ItemDetailScreen extends StatelessWidget {
         const SizedBox(width: 12),
         Expanded(
           child: OutlinedButton.icon(
-            onPressed: () {},
-            icon: const Icon(Icons.group_add_outlined, size: 18),
-            label: const Text('그룹 공유'),
+            onPressed: _confirmDelete,
+            icon: const Icon(Icons.delete_outline, size: 18),
+            label: const Text('삭제'),
             style: OutlinedButton.styleFrom(
-              foregroundColor: AppColors.primary,
-              side: const BorderSide(color: AppColors.primary),
+              foregroundColor: AppColors.danger,
+              side: const BorderSide(color: AppColors.danger),
               padding: const EdgeInsets.symmetric(vertical: 14),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -45,9 +45,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
   void _openEdit() {
     Navigator.push(
       context,
-      MaterialPageRoute(
-        builder: (_) => AddItemScreen(editItem: _item),
-      ),
+      MaterialPageRoute(builder: (_) => AddItemScreen(editItem: _item)),
     );
   }
 
@@ -57,9 +55,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('제품 삭제'),
-        content: Text(
-          '\'${_item.name}\'을(를) 삭제하시겠습니까?\n삭제 후 복구할 수 없습니다.',
-        ),
+        content: Text('\'${_item.name}\'을(를) 삭제하시겠습니까?\n삭제 후 복구할 수 없습니다.'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx, false),
@@ -67,9 +63,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
           ),
           FilledButton(
             onPressed: () => Navigator.pop(ctx, true),
-            style: FilledButton.styleFrom(
-              backgroundColor: AppColors.danger,
-            ),
+            style: FilledButton.styleFrom(backgroundColor: AppColors.danger),
             child: const Text('삭제'),
           ),
         ],
@@ -167,8 +161,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                 errorBuilder: (_, error, stack) => Container(
                   color: AppColors.primaryLight2,
                   child: const Center(
-                    child: Icon(Icons.broken_image_outlined,
-                        size: 48, color: AppColors.textMuted),
+                    child: Icon(
+                      Icons.broken_image_outlined,
+                      size: 48,
+                      color: AppColors.textMuted,
+                    ),
                   ),
                 ),
               ),
@@ -195,7 +192,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                     children: [
                       Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 8, vertical: 3),
+                          horizontal: 8,
+                          vertical: 3,
+                        ),
                         decoration: BoxDecoration(
                           color: AppColors.primaryLight2,
                           borderRadius: BorderRadius.circular(6),
@@ -222,7 +221,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                       Text(
                         _item.brand,
                         style: const TextStyle(
-                            fontSize: 14, color: AppColors.textMuted),
+                          fontSize: 14,
+                          color: AppColors.textMuted,
+                        ),
                       ),
                     ],
                   ),
@@ -316,9 +317,10 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
       children: [
         Icon(icon, size: 20, color: color),
         const SizedBox(width: 12),
-        Text(label,
-            style: const TextStyle(
-                fontSize: 14, color: AppColors.textSecondary)),
+        Text(
+          label,
+          style: const TextStyle(fontSize: 14, color: AppColors.textSecondary),
+        ),
         const Spacer(),
         Text(
           value,
@@ -345,8 +347,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
         children: [
           const Row(
             children: [
-              Icon(Icons.auto_awesome_outlined,
-                  size: 18, color: AppColors.primary),
+              Icon(
+                Icons.auto_awesome_outlined,
+                size: 18,
+                color: AppColors.primary,
+              ),
               SizedBox(width: 8),
               Text(
                 'AI 가격 비교',
@@ -365,8 +370,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
               child: Row(
                 children: [
                   if (p.isLowest)
-                    const Icon(Icons.check_circle,
-                        size: 16, color: AppColors.success)
+                    const Icon(
+                      Icons.check_circle,
+                      size: 16,
+                      color: AppColors.success,
+                    )
                   else
                     const SizedBox(width: 16),
                   const SizedBox(width: 10),
@@ -374,8 +382,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                     p.store,
                     style: TextStyle(
                       fontSize: 14,
-                      fontWeight:
-                          p.isLowest ? FontWeight.w600 : FontWeight.w400,
+                      fontWeight: p.isLowest
+                          ? FontWeight.w600
+                          : FontWeight.w400,
                       color: p.isLowest
                           ? AppColors.text
                           : AppColors.textSecondary,
@@ -386,10 +395,10 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                     _formatPrice(p.price),
                     style: TextStyle(
                       fontSize: 15,
-                      fontWeight:
-                          p.isLowest ? FontWeight.w700 : FontWeight.w400,
-                      color:
-                          p.isLowest ? AppColors.success : AppColors.text,
+                      fontWeight: p.isLowest
+                          ? FontWeight.w700
+                          : FontWeight.w400,
+                      color: p.isLowest ? AppColors.success : AppColors.text,
                     ),
                   ),
                 ],
@@ -437,15 +446,12 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                         height: 10,
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
-                          color: i == 0
-                              ? AppColors.primary
-                              : AppColors.border,
+                          color: i == 0 ? AppColors.primary : AppColors.border,
                         ),
                       ),
                       if (!isLast)
                         Expanded(
-                          child: Container(
-                              width: 1.5, color: AppColors.border),
+                          child: Container(width: 1.5, color: AppColors.border),
                         ),
                     ],
                   ),

--- a/lib/services/item_store.dart
+++ b/lib/services/item_store.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import '../models/item.dart';
+import 'supabase_service.dart';
+
+/// 제품 상태 저장소
+///
+/// [ValueNotifier]를 상속하여 [ValueListenableBuilder]로 UI가 자동 갱신됩니다.
+/// add / update / delete는 로컬 상태를 즉시 반영한 뒤 Supabase에 비동기 동기화합니다.
+class ItemStore extends ValueNotifier<List<ConsumableItem>> {
+  static final ItemStore instance = ItemStore._();
+  ItemStore._() : super([]);
+
+  bool _initialized = false;
+
+  /// Supabase에서 초기 제품 목록을 불러옵니다.
+  Future<void> initialize() async {
+    if (_initialized) return;
+    _initialized = true;
+    value = await SupabaseService.loadItems();
+    debugPrint('[ItemStore] 초기 로드 완료: ${value.length}개');
+  }
+
+  /// 새 제품 추가 — 로컬 즉시 반영 후 Supabase 동기화
+  Future<void> add(ConsumableItem item) async {
+    value = [...value, item];
+    await SupabaseService.saveItem(item);
+  }
+
+  /// 기존 제품 수정 — 로컬 즉시 반영 후 Supabase 동기화
+  Future<void> update(ConsumableItem updated) async {
+    value = value
+        .map((item) => item.id == updated.id ? updated : item)
+        .toList();
+    await SupabaseService.saveItem(updated);
+  }
+
+  /// 제품 삭제 — 로컬 즉시 반영 후 Supabase 동기화
+  Future<void> delete(String id) async {
+    value = value.where((item) => item.id != id).toList();
+    await SupabaseService.deleteItem(id);
+  }
+
+  /// id로 제품 조회 (없으면 null)
+  ConsumableItem? findById(String id) {
+    final matches = value.where((item) => item.id == id);
+    return matches.isEmpty ? null : matches.first;
+  }
+}

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -10,11 +10,9 @@ import '../models/item.dart';
 /// Storage: product-images 버킷 (공개)
 class SupabaseService {
   static const _supabaseUrl = 'https://fervijwxdgkwjtcpzskx.supabase.co';
-  static const _anonKey =
-      'sb_publishable_FO7WmA_Pu4RsGgsfRJzssQ_f0orCu7w';
+  static const _anonKey = 'sb_publishable_FO7WmA_Pu4RsGgsfRJzssQ_f0orCu7w';
   // flutter run 시 --dart-define=SUPABASE_SERVICE_KEY=sb_secret_... 로 주입
-  static const _serviceKey =
-      String.fromEnvironment('SUPABASE_SERVICE_KEY');
+  static const _serviceKey = String.fromEnvironment('SUPABASE_SERVICE_KEY');
   static const _storageBucket = 'product-images';
 
   static SupabaseClient get _db => Supabase.instance.client;
@@ -57,16 +55,17 @@ class SupabaseService {
   }) async {
     try {
       final path = 'items/$itemId.jpg';
-      await _adminClient.storage.from(_storageBucket).uploadBinary(
-        path,
-        imageBytes,
-        fileOptions: const FileOptions(
-          contentType: 'image/jpeg',
-          upsert: true,
-        ),
-      );
-      final url =
-          _adminClient.storage.from(_storageBucket).getPublicUrl(path);
+      await _adminClient.storage
+          .from(_storageBucket)
+          .uploadBinary(
+            path,
+            imageBytes,
+            fileOptions: const FileOptions(
+              contentType: 'image/jpeg',
+              upsert: true,
+            ),
+          );
+      final url = _adminClient.storage.from(_storageBucket).getPublicUrl(path);
       debugPrint('[Supabase] 이미지 업로드 완료: $url');
       return url;
     } catch (e) {
@@ -83,7 +82,9 @@ class SupabaseService {
   static Future<List<ConsumableItem>> loadItems() async {
     final uid = currentUserId;
     try {
-      final rows = await _db.from('product_items').select('''
+      final rows = await _db
+          .from('product_items')
+          .select('''
           id,
           name,
           brand,
@@ -93,23 +94,24 @@ class SupabaseService {
           categories ( id, name ),
           purchases ( id, purchase_date, price, store_name ),
           ai_predictions ( predicted_cycle_days, confidence )
-        ''').eq('user_id', uid).order('created_at', ascending: false);
+        ''')
+          .eq('user_id', uid)
+          .order('created_at', ascending: false);
 
       return rows.map<ConsumableItem>((row) {
         final categoryName =
-            (row['categories'] as Map<String, dynamic>?)?['name']
-                    as String? ??
-                '기타';
+            (row['categories'] as Map<String, dynamic>?)?['name'] as String? ??
+            '기타';
 
         final purchases =
             (row['purchases'] as List<dynamic>?)
-                    ?.cast<Map<String, dynamic>>() ??
-                [];
+                ?.cast<Map<String, dynamic>>() ??
+            [];
 
         final aiList =
             (row['ai_predictions'] as List<dynamic>?)
-                    ?.cast<Map<String, dynamic>>() ??
-                [];
+                ?.cast<Map<String, dynamic>>() ??
+            [];
         // 가장 최근 AI 예측 1건 사용
         final ai = aiList.isNotEmpty ? aiList.last : null;
 
@@ -239,8 +241,7 @@ class SupabaseService {
     final bytes = List<int>.generate(16, (_) => random.nextInt(256));
     bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
     bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant bits
-    final hex =
-        bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+    final hex = bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
     return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
         '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
         '${hex.substring(20)}';

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -1,0 +1,259 @@
+import 'dart:math';
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/item.dart';
+
+/// Supabase 연동 서비스
+///
+/// 프로젝트: fervijwxdgkwjtcpzskx
+/// 테이블: product_items / purchases / categories / ai_predictions
+/// Storage: product-images 버킷 (공개)
+class SupabaseService {
+  static const _supabaseUrl = 'https://fervijwxdgkwjtcpzskx.supabase.co';
+  static const _anonKey =
+      'sb_publishable_FO7WmA_Pu4RsGgsfRJzssQ_f0orCu7w';
+  // flutter run 시 --dart-define=SUPABASE_SERVICE_KEY=sb_secret_... 로 주입
+  static const _serviceKey =
+      String.fromEnvironment('SUPABASE_SERVICE_KEY');
+  static const _storageBucket = 'product-images';
+
+  static SupabaseClient get _db => Supabase.instance.client;
+
+  /// Storage 업로드 전용 어드민 클라이언트 (service role — RLS 우회)
+  ///
+  /// ⚠️ 프로덕션에서는 서버사이드(Edge Function 등)에서만 사용해야 합니다.
+  static final _adminClient = SupabaseClient(_supabaseUrl, _serviceKey);
+
+  /// 카테고리 이름 → UUID 로컬 캐시 (앱 세션 동안 유지)
+  static final Map<String, String> _categoryCache = {};
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 초기화 & 인증
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// 개발용 임시 사용자 ID (RLS 비활성 환경에서 사용)
+  static const _devUserId = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8';
+
+  /// Supabase 초기화
+  static Future<void> initialize() async {
+    await Supabase.initialize(url: _supabaseUrl, anonKey: _anonKey);
+    debugPrint('[Supabase] 초기화 완료');
+  }
+
+  /// 현재 사용자 ID
+  static String get currentUserId => _devUserId;
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 이미지 업로드
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// 제품 이미지를 Storage에 업로드하고 공개 URL을 반환합니다.
+  ///
+  /// [imageBytes] 업로드할 이미지 바이트 (image_picker로 획득)
+  /// [itemId]     제품 UUID (파일 경로에 사용)
+  static Future<String?> uploadItemImage({
+    required Uint8List imageBytes,
+    required String itemId,
+  }) async {
+    try {
+      final path = 'items/$itemId.jpg';
+      await _adminClient.storage.from(_storageBucket).uploadBinary(
+        path,
+        imageBytes,
+        fileOptions: const FileOptions(
+          contentType: 'image/jpeg',
+          upsert: true,
+        ),
+      );
+      final url =
+          _adminClient.storage.from(_storageBucket).getPublicUrl(path);
+      debugPrint('[Supabase] 이미지 업로드 완료: $url');
+      return url;
+    } catch (e) {
+      debugPrint('[Supabase] 이미지 업로드 오류: $e');
+      return null;
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 제품 목록 로드
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// 현재 사용자의 모든 제품을 Supabase에서 불러옵니다.
+  static Future<List<ConsumableItem>> loadItems() async {
+    final uid = currentUserId;
+    try {
+      final rows = await _db.from('product_items').select('''
+          id,
+          name,
+          brand,
+          image_url,
+          replacement_cycle_days,
+          created_at,
+          categories ( id, name ),
+          purchases ( id, purchase_date, price, store_name ),
+          ai_predictions ( predicted_cycle_days, confidence )
+        ''').eq('user_id', uid).order('created_at', ascending: false);
+
+      return rows.map<ConsumableItem>((row) {
+        final categoryName =
+            (row['categories'] as Map<String, dynamic>?)?['name']
+                    as String? ??
+                '기타';
+
+        final purchases =
+            (row['purchases'] as List<dynamic>?)
+                    ?.cast<Map<String, dynamic>>() ??
+                [];
+
+        final aiList =
+            (row['ai_predictions'] as List<dynamic>?)
+                    ?.cast<Map<String, dynamic>>() ??
+                [];
+        // 가장 최근 AI 예측 1건 사용
+        final ai = aiList.isNotEmpty ? aiList.last : null;
+
+        return ConsumableItem.fromSupabase(
+          data: row,
+          categoryName: categoryName,
+          purchases: purchases,
+          aiPrediction: ai,
+        );
+      }).toList();
+    } catch (e) {
+      debugPrint('[Supabase] loadItems 오류: $e');
+      return [];
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 제품 저장 (신규 등록 & 수정)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// ConsumableItem을 Supabase에 upsert합니다.
+  ///
+  /// - product_items 테이블에 upsert (id 기준)
+  /// - id가 없는 신규 PurchaseRecord만 purchases 테이블에 insert
+  static Future<void> saveItem(ConsumableItem item) async {
+    final uid = currentUserId;
+    try {
+      final categoryId = await _ensureCategory(item.category);
+
+      await _db.from('product_items').upsert({
+        'id': item.id,
+        'user_id': uid,
+        'registered_by': uid,
+        'category_id': categoryId,
+        'name': item.name,
+        'brand': item.brand,
+        'image_url': item.imageUrl,
+        'replacement_cycle_days': item.cycleDays,
+      });
+
+      // id가 null인 신규 구매 이력만 삽입
+      for (final record in item.purchaseHistory) {
+        if (record.id == null) {
+          await _db.from('purchases').insert({
+            'product_item_id': item.id,
+            'purchased_by': uid,
+            'purchase_date': record.date.toIso8601String().substring(0, 10),
+            'price': record.price,
+            'store_name': record.store,
+            'quantity': 1,
+          });
+        }
+      }
+
+      debugPrint('[Supabase] saveItem 완료: ${item.name} (${item.id})');
+    } catch (e) {
+      debugPrint('[Supabase] saveItem 오류: $e');
+      rethrow;
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 제품 삭제
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// product_items에서 삭제합니다.
+  /// purchases는 DB의 ON DELETE CASCADE 설정에 따라 자동 삭제됩니다.
+  static Future<void> deleteItem(String itemId) async {
+    try {
+      // purchases는 FK CASCADE로 자동 삭제. 없다면 아래 줄 먼저 실행:
+      // await _db.from('purchases').delete().eq('product_item_id', itemId);
+      await _db.from('product_items').delete().eq('id', itemId);
+      debugPrint('[Supabase] deleteItem 완료: $itemId');
+    } catch (e) {
+      debugPrint('[Supabase] deleteItem 오류: $e');
+      rethrow;
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // 카테고리 조회 또는 생성
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// 카테고리 이름으로 UUID를 반환합니다. 없으면 새로 생성합니다.
+  static Future<String> _ensureCategory(String name) async {
+    if (_categoryCache.containsKey(name)) return _categoryCache[name]!;
+
+    final uid = currentUserId;
+
+    // 기존 카테고리 조회
+    final existing = await _db
+        .from('categories')
+        .select('id')
+        .eq('user_id', uid)
+        .eq('name', name)
+        .maybeSingle();
+
+    if (existing != null) {
+      _categoryCache[name] = existing['id'] as String;
+      return existing['id'] as String;
+    }
+
+    // 없으면 생성
+    final created = await _db
+        .from('categories')
+        .insert({
+          'user_id': uid,
+          'name': name,
+          'icon': _iconNameForCategory(name),
+          'color': '#4F7FFF',
+          'sort_order': 0,
+        })
+        .select('id')
+        .single();
+
+    _categoryCache[name] = created['id'] as String;
+    return created['id'] as String;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // UUID 생성 (외부 패키지 없이 dart:math 사용)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// RFC 4122 UUID v4를 생성합니다.
+  static String generateUuid() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(16, (_) => random.nextInt(256));
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant bits
+    final hex =
+        bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+    return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
+        '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
+        '${hex.substring(20)}';
+  }
+
+  static String _iconNameForCategory(String name) {
+    return switch (name) {
+      '욕실/위생' => 'bathroom',
+      '주방/세제' => 'kitchen',
+      '세탁/청소' => 'laundry',
+      '헤어/바디' => 'shower',
+      '가전/필터' => 'air',
+      _ => 'category',
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -185,6 +193,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fl_chart:
     dependency: "direct main"
     description:
@@ -206,6 +246,19 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.34"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -296,6 +349,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: "784210112be18ea55f69d7076e2c656a4e24949fa9e76429fe53af0c0f4fa320"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "66810af8e99b2657ee98e5c6f02064f69bb63f7a70e343937f70946c5f8c6622"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+16"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -452,10 +577,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      sha256: "914a07484c4380e572998d30486e77e0d9cd2faec72fee268086d07bf7f302c9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.0"
   path_provider_foundation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -37,17 +39,12 @@ dependencies:
   fl_chart: ^1.2.0
   google_fonts: ^8.0.2
   percent_indicator: ^4.2.5
-  supabase_flutter: ^2.12.2
+  supabase_flutter: ^2.8.4
+  image_picker: ^1.1.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  # The "flutter_lints" package below contains a set of recommended lints to
-  # encourage good coding practices. The lint set provided by the package is
-  # activated in the `analysis_options.yaml` file located at the root of your
-  # package. See that file for information about deactivating specific lint
-  # rules and activating additional ones.
   flutter_lints: ^6.0.0
   test: ^1.30.0
 


### PR DESCRIPTION
## 작업 내용

Firebase Stub 코드를 제거하고 Supabase 실연동으로 교체했습니다. 또한 제품 이미지 업로드 및 세부 화면 표시 기능을 추가했습니다.

## 주요 변경 사항

- **Firebase → Supabase 교체**: `firebase_service.dart` 제거, `supabase_service.dart` 신규 작성
- **DB 연동**: `product_items`, `purchases`, `categories`, `ai_predictions` 테이블 JOIN 쿼리로 제품 목록 로드
- **이미지 업로드**: `image_picker`로 갤러리 이미지 선택 → Supabase Storage(`product-images` 버킷)에 업로드
- **이미지 표시**: 세부 화면 상단에 220px 전체 너비 배너 이미지 표시 (이미지 없으면 카테고리 아이콘 유지)
- **상태 관리**: `ItemStore`에서 비동기 CRUD 처리 및 Supabase 동기화

## 실행 방법

이미지 업로드 기능 사용 시 service role key 주입 필요:
```bash
flutter run -d chrome --web-port 3000 \
  --dart-define=SUPABASE_SERVICE_KEY=<서비스_롤_키>
```

## 테스트 체크리스트

- [ ] 앱 실행 시 Supabase에서 제품 목록 정상 로드
- [ ] 제품 등록 시 갤러리에서 이미지 선택 및 미리보기 표시
- [ ] 저장 시 Supabase Storage에 이미지 업로드 및 URL 저장
- [ ] 세부 화면에서 이미지 배너 정상 표시
- [ ] 이미지 없는 제품은 기존 아이콘 레이아웃 유지
- [ ] 제품 삭제 시 DB에서 정상 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)