### PR TITLE
Supabase 사용 시작일 및 장기 샘플 데이터 migration 추가

### DIFF
--- a/supabase/migrations/20260424000100_initial_schema.sql
+++ b/supabase/migrations/20260424000100_initial_schema.sql
@@ -1,0 +1,197 @@
+-- ============================================
+-- Buylog DB Migration
+-- 테이블 생성 + 시스템 기본 카테고리 seed
+-- Supabase SQL Editor에서 실행
+-- ============================================
+
+
+-- =========================
+-- 1. users
+-- =========================
+create table public.users (
+  id uuid primary key references auth.users(id) on delete cascade,
+  email text not null,
+  display_name text,
+  avatar_url text,
+  fcm_token text,
+  notification_enabled boolean default true,
+  default_group_id uuid,  -- FK는 groups 생성 후 추가
+  created_at timestamptz default now()
+);
+
+comment on table public.users is '사용자 프로필 정보 (auth.users와 1:1)';
+
+
+-- =========================
+-- 2. groups
+-- =========================
+create table public.groups (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  invite_code text unique,
+  created_by uuid references public.users(id) on delete set null,
+  created_at timestamptz default now()
+);
+
+comment on table public.groups is '가구/동아리 등 그룹';
+
+-- users.default_group_id FK 추가
+alter table public.users
+  add constraint fk_users_default_group
+  foreign key (default_group_id) references public.groups(id) on delete set null;
+
+
+-- =========================
+-- 3. group_members
+-- =========================
+create table public.group_members (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid not null references public.groups(id) on delete cascade,
+  user_id uuid not null references public.users(id) on delete cascade,
+  role text not null default 'member',
+  joined_at timestamptz default now(),
+  unique(group_id, user_id)  -- 같은 그룹에 중복 가입 방지
+);
+
+comment on table public.group_members is '그룹 ↔ 사용자 연결 (N:M)';
+
+
+-- =========================
+-- 4. categories
+-- =========================
+create table public.categories (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.users(id) on delete cascade,
+  group_id uuid references public.groups(id) on delete cascade,
+  name text not null,
+  icon text,
+  color text,
+  sort_order int default 0,
+  created_at timestamptz default now()
+);
+
+comment on table public.categories is '소모품 카테고리 (user_id, group_id 모두 null이면 시스템 기본)';
+
+
+-- =========================
+-- 5. product_items
+-- =========================
+create table public.product_items (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references public.users(id) on delete cascade,
+  group_id uuid references public.groups(id) on delete cascade,
+  category_id uuid not null references public.categories(id) on delete restrict,
+  name text not null,
+  brand text,
+  barcode text,
+  memo text,
+  image_url text,
+  replacement_cycle_days int,
+  registered_by uuid references public.users(id) on delete set null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  -- user_id 또는 group_id 중 하나만 값이 있어야 함
+  constraint chk_product_owner check (
+    (user_id is not null and group_id is null) or
+    (user_id is null and group_id is not null)
+  )
+);
+
+comment on table public.product_items is '등록된 소모품 (핵심 테이블)';
+
+-- updated_at 자동 갱신 트리거
+create or replace function update_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+create trigger trg_product_items_updated_at
+  before update on public.product_items
+  for each row execute function update_updated_at();
+
+
+-- =========================
+-- 6. purchases
+-- =========================
+create table public.purchases (
+  id uuid primary key default gen_random_uuid(),
+  product_item_id uuid not null references public.product_items(id) on delete cascade,
+  purchased_by uuid references public.users(id) on delete set null,
+  purchase_date date not null,
+  price int not null,
+  store_name text,
+  quantity int default 1,
+  memo text,
+  receipt_image_url text,
+  created_at timestamptz default now()
+);
+
+comment on table public.purchases is '구매 이력';
+
+
+-- =========================
+-- 7. ocr_scans
+-- =========================
+create table public.ocr_scans (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  image_url text not null,
+  raw_result jsonb,
+  parsed_data jsonb,
+  status text default 'pending' check (status in ('pending', 'confirmed', 'rejected')),
+  product_item_id uuid references public.product_items(id) on delete set null,
+  purchase_id uuid references public.purchases(id) on delete set null,
+  created_at timestamptz default now()
+);
+
+comment on table public.ocr_scans is 'OCR 영수증 스캔 임시 결과';
+
+
+-- =========================
+-- 8. ai_predictions
+-- =========================
+create table public.ai_predictions (
+  id uuid primary key default gen_random_uuid(),
+  product_item_id uuid not null references public.product_items(id) on delete cascade,
+  predicted_replacement_date date,
+  predicted_cycle_days int,
+  predicted_cost int,
+  recommendation jsonb,
+  confidence float,
+  created_at timestamptz default now()
+);
+
+comment on table public.ai_predictions is 'AI 교체주기 예측 결과';
+
+
+-- =========================
+-- 9. notifications
+-- =========================
+create table public.notifications (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  product_item_id uuid references public.product_items(id) on delete set null,
+  type text not null check (type in ('replacement', 'price_drop', 'report')),
+  title text not null,
+  body text not null,
+  is_read boolean default false,
+  created_at timestamptz default now()
+);
+
+comment on table public.notifications is '푸시 알림 기록';
+
+
+-- ============================================
+-- 시스템 기본 카테고리 seed 데이터
+-- user_id = null, group_id = null → 모든 사용자에게 보임
+-- ============================================
+insert into public.categories (name, icon, color, sort_order) values
+  ('미분류',    '📦', '#888888', 0),
+  ('위생용품',  '🧴', '#4A90D9', 1),
+  ('주방용품',  '🍳', '#E8913A', 2),
+  ('필터류',    '💧', '#45B7D1', 3),
+  ('세탁용품',  '👕', '#9B59B6', 4),
+  ('생활잡화',  '🏠', '#2ECC71', 5);

--- a/supabase/migrations/20260424000200_add_purchase_use_started_on.sql
+++ b/supabase/migrations/20260424000200_add_purchase_use_started_on.sql
@@ -1,0 +1,34 @@
+-- Track when a purchased item actually starts being used.
+-- Existing rows default to purchase_date so current D-day behavior is preserved.
+
+begin;
+
+alter table public.purchases
+  add column if not exists use_started_on date;
+
+comment on column public.purchases.use_started_on is
+  'Date this purchased product actually started being used/opened.';
+
+update public.purchases
+set use_started_on = purchase_date
+where use_started_on is null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'purchases_use_started_on_after_purchase_date'
+      and conrelid = 'public.purchases'::regclass
+  ) then
+    alter table public.purchases
+      add constraint purchases_use_started_on_after_purchase_date
+      check (use_started_on is null or use_started_on >= purchase_date);
+  end if;
+end $$;
+
+create index if not exists purchases_product_item_use_started_on_idx
+on public.purchases (product_item_id, use_started_on desc)
+where use_started_on is not null;
+
+commit;

--- a/supabase/migrations/20260424140307_seed_sample_consumables.sql
+++ b/supabase/migrations/20260424140307_seed_sample_consumables.sql
@@ -1,0 +1,203 @@
+-- Long-running sample consumable data for manual QA and demos.
+--
+-- This seed creates one deterministic demo user and gives that user enough
+-- purchase history to make D-day, cycle prediction, and spending screens look
+-- like the app has been used for a long time.
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.product_items') is null then
+    raise exception 'public.product_items must exist before applying seed_sample_consumables';
+  end if;
+
+  if to_regclass('public.purchases') is null then
+    raise exception 'public.purchases must exist before applying seed_sample_consumables';
+  end if;
+
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'purchases'
+      and column_name = 'use_started_on'
+  ) then
+    raise exception 'public.purchases.use_started_on must exist before applying seed_sample_consumables';
+  end if;
+end $$;
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values (
+  '00000000-0000-4000-8000-000000000101',
+  'authenticated',
+  'authenticated',
+  'demo.user+buylog@example.com',
+  now() - interval '760 days',
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"display_name":"Buylog Demo User"}'::jsonb,
+  now() - interval '760 days',
+  now() - interval '1 day'
+)
+on conflict (id) do update
+set
+  email = excluded.email,
+  raw_app_meta_data = excluded.raw_app_meta_data,
+  raw_user_meta_data = excluded.raw_user_meta_data,
+  updated_at = now();
+
+insert into public.users (
+  id,
+  email,
+  display_name,
+  notification_enabled,
+  created_at
+)
+values (
+  '00000000-0000-4000-8000-000000000101',
+  'demo.user+buylog@example.com',
+  'Buylog Demo User',
+  true,
+  now() - interval '760 days'
+)
+on conflict (id) do update
+set
+  email = excluded.email,
+  display_name = excluded.display_name,
+  notification_enabled = excluded.notification_enabled;
+
+with seed_products(name, brand, category_name, replacement_cycle_days, created_at) as (
+  values
+    ('정수기 필터', '코웨이', '필터류', 90, now() - interval '720 days'),
+    ('주방 세제', '자연퐁', '주방용품', 30, now() - interval '710 days'),
+    ('고양이 모래', '카사바랑', '생활잡화', 21, now() - interval '700 days'),
+    ('액상 세제', '퍼실', '세탁용품', 45, now() - interval '690 days'),
+    ('휴지', '코디', '위생용품', 42, now() - interval '680 days'),
+    ('치약', '덴티스테', '위생용품', 60, now() - interval '670 days'),
+    ('칫솔', '오랄비', '위생용품', 90, now() - interval '660 days'),
+    ('에어컨 필터', '삼성', '필터류', 180, now() - interval '650 days'),
+    ('샤워기 필터', '바디럽', '필터류', 75, now() - interval '640 days'),
+    ('식기세척기 세제', '프로쉬', '주방용품', 50, now() - interval '630 days')
+),
+resolved_products as (
+  select
+    '00000000-0000-4000-8000-000000000101'::uuid as user_id,
+    categories.id as category_id,
+    seed_products.name,
+    seed_products.brand,
+    seed_products.replacement_cycle_days,
+    seed_products.created_at
+  from seed_products
+  join public.categories
+    on categories.name = seed_products.category_name
+   and categories.user_id is null
+   and categories.group_id is null
+)
+insert into public.product_items (
+  user_id,
+  category_id,
+  name,
+  brand,
+  replacement_cycle_days,
+  registered_by,
+  created_at
+)
+select
+  resolved_products.user_id,
+  resolved_products.category_id,
+  resolved_products.name,
+  resolved_products.brand,
+  resolved_products.replacement_cycle_days,
+  resolved_products.user_id,
+  resolved_products.created_at
+from resolved_products
+where not exists (
+  select 1
+  from public.product_items existing
+  where existing.user_id = resolved_products.user_id
+    and existing.name = resolved_products.name
+    and existing.brand = resolved_products.brand
+);
+
+with demo_products(name, brand, start_offset, cycle_days, count_rows, base_price, store_names) as (
+  values
+    ('정수기 필터', '코웨이', 641, 92, 7, 34900, array['쿠팡','네이버쇼핑','오늘의집']),
+    ('주방 세제', '자연퐁', 705, 32, 22, 4300, array['이마트','쿠팡','홈플러스']),
+    ('고양이 모래', '카사바랑', 620, 23, 27, 13200, array['마켓컬리','쿠팡','펫프렌즈']),
+    ('액상 세제', '퍼실', 610, 45, 14, 14900, array['이마트','쿠팡','네이버쇼핑']),
+    ('휴지', '코디', 590, 42, 14, 18900, array['쿠팡','이마트','홈플러스']),
+    ('치약', '덴티스테', 540, 61, 9, 10800, array['올리브영','쿠팡','네이버쇼핑']),
+    ('칫솔', '오랄비', 620, 91, 7, 7900, array['다이소','쿠팡','올리브영']),
+    ('에어컨 필터', '삼성', 560, 182, 4, 19800, array['삼성몰','쿠팡','네이버쇼핑']),
+    ('샤워기 필터', '바디럽', 520, 76, 7, 11900, array['쿠팡','오늘의집']),
+    ('식기세척기 세제', '프로쉬', 490, 51, 10, 14900, array['마켓컬리','쿠팡','이마트'])
+),
+seed_purchases as (
+  select
+    demo_products.name as product_name,
+    demo_products.brand as product_brand,
+    (current_date - (demo_products.start_offset - (n * demo_products.cycle_days)))::date as purchase_date,
+    (current_date - (demo_products.start_offset - (n * demo_products.cycle_days)) + ((n % 4) + 1))::date as use_started_on,
+    (demo_products.base_price + (n * 350) + ((n % 3) * 200))::integer as price,
+    demo_products.store_names[(n % array_length(demo_products.store_names, 1)) + 1] as store_name
+  from demo_products
+  cross join lateral generate_series(0, demo_products.count_rows - 1) as n
+),
+valid_seed_purchases as (
+  select *
+  from seed_purchases
+  where purchase_date <= current_date
+    and use_started_on <= current_date
+),
+resolved_purchases as (
+  select
+    product_items.id as product_item_id,
+    '00000000-0000-4000-8000-000000000101'::uuid as purchased_by,
+    valid_seed_purchases.purchase_date,
+    valid_seed_purchases.use_started_on,
+    valid_seed_purchases.price,
+    valid_seed_purchases.store_name,
+    valid_seed_purchases.purchase_date::timestamp with time zone + interval '12 hours' as created_at
+  from valid_seed_purchases
+  join public.product_items
+    on product_items.user_id = '00000000-0000-4000-8000-000000000101'::uuid
+   and product_items.name = valid_seed_purchases.product_name
+   and product_items.brand = valid_seed_purchases.product_brand
+)
+insert into public.purchases (
+  product_item_id,
+  purchased_by,
+  purchase_date,
+  use_started_on,
+  price,
+  store_name,
+  created_at
+)
+select
+  resolved_purchases.product_item_id,
+  resolved_purchases.purchased_by,
+  resolved_purchases.purchase_date,
+  resolved_purchases.use_started_on,
+  resolved_purchases.price,
+  resolved_purchases.store_name,
+  resolved_purchases.created_at
+from resolved_purchases
+where not exists (
+  select 1
+  from public.purchases existing
+  where existing.product_item_id = resolved_purchases.product_item_id
+    and existing.purchase_date = resolved_purchases.purchase_date
+    and existing.store_name = resolved_purchases.store_name
+);
+
+commit;


### PR DESCRIPTION
﻿## 변경 사항
- Notion `DB 설계` 기준 초기 Supabase 스키마 migration 추가
- `purchases.use_started_on` 컬럼 추가 migration 추가
- 장기간 사용 이력처럼 보이는 테스트용 demo seed migration 추가
- 원격 Supabase에 `use_started_on` 컬럼 및 demo seed 데이터 적용

## 변경 이유
- 구매일과 실제 사용 시작일이 다를 수 있어 D-day 계산 기준을 분리해야 합니다.
- develop에서 재현 가능한 Supabase migration 이력이 필요합니다.
- D-day, 교체 주기 예측, 지출 화면을 테스트할 수 있도록 오래 사용한 형태의 샘플 데이터가 필요합니다.

## 테스트
- 원격 Supabase `purchases.use_started_on` 컬럼 추가 및 기존 구매 이력 백필 확인
- 원격 Supabase demo seed 적용 확인: demo user 1명, 제품 10개, 구매 이력 121개
- `use_started_on < purchase_date` 위반 데이터 0건 확인
- `git diff --cached --check` 통과

## 참고 사항
- `supabase db lint --local`은 로컬 Postgres가 `127.0.0.1:54322`에서 실행 중이 아니라 실패했습니다.
- Supabase advisor에서 기존 RLS 미적용 및 일부 FK 인덱스 미비 경고가 남아 있습니다. 이번 PR 범위에는 포함하지 않았습니다.
- 관련 이슈: #26
