### PR TITLE
fix: 구매이력 표시/삭제/OCR 등록 버그 수정 및 중복 제품 병합

### DIFF
--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -291,11 +291,15 @@ class _AddItemScreenState extends State<AddItemScreen> {
           );
 
           if (shouldMerge == true) {
-            final newPurchases = purchases.map((p) => PurchaseRecord(
-                  date: p.date,
-                  price: p.price,
-                  store: p.store,
-                )).toList();
+            final newPurchases = purchases
+                .map(
+                  (p) => PurchaseRecord(
+                    date: p.date,
+                    price: p.price,
+                    store: p.store,
+                  ),
+                )
+                .toList();
             final merged = ConsumableItem(
               id: duplicate.id,
               name: duplicate.name,

--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -82,6 +82,7 @@ class _AddItemScreenState extends State<AddItemScreen> {
       for (final r in edit.purchaseHistory) {
         _purchases.add(
           _PurchaseEntry(
+            id: r.id,
             date: r.date,
             priceCtrl: TextEditingController(text: r.price.toString()),
             storeCtrl: TextEditingController(text: r.store),
@@ -218,10 +219,12 @@ class _AddItemScreenState extends State<AddItemScreen> {
         );
       }
 
+      // _purchases가 UI의 단일 진실 공급원 — 기존 id 보존, 신규는 null
       final purchases = _purchases
           .where((e) => e.priceCtrl.text.trim().isNotEmpty)
           .map(
             (e) => PurchaseRecord(
+              id: e.id,
               date: e.date,
               price:
                   int.tryParse(
@@ -237,10 +240,91 @@ class _AddItemScreenState extends State<AddItemScreen> {
           int.tryParse(_cycleDaysCtrl.text) ??
           getDefaultDays(_selectedCategory);
 
-      // 편집 시 기존 purchases (id 있음) + 새 purchases (id 없음) 합치기
-      final existingPurchases = _isEditing
-          ? widget.editItem!.purchaseHistory.where((r) => r.id != null).toList()
-          : <PurchaseRecord>[];
+      // 편집 시 UI에서 삭제된 구매 이력을 DB에서도 제거
+      if (_isEditing) {
+        final originalIds = widget.editItem!.purchaseHistory
+            .where((r) => r.id != null)
+            .map((r) => r.id!)
+            .toSet();
+        final keepIds = purchases
+            .where((r) => r.id != null)
+            .map((r) => r.id!)
+            .toSet();
+        final deletedIds = originalIds.difference(keepIds);
+        if (deletedIds.isNotEmpty) {
+          await SupabaseService.deletePurchases(deletedIds);
+        }
+      }
+
+      // 신규 등록 시 동일 이름 제품이 있으면 병합 여부 확인
+      if (!_isEditing) {
+        final nameToCheck = _nameCtrl.text.trim().toLowerCase();
+        final duplicate = ItemStore.instance.value
+            .cast<ConsumableItem?>()
+            .firstWhere(
+              (i) => i!.name.trim().toLowerCase() == nameToCheck,
+              orElse: () => null,
+            );
+
+        if (duplicate != null && mounted) {
+          final shouldMerge = await showDialog<bool>(
+            context: context,
+            builder: (ctx) => AlertDialog(
+              title: const Text('동일 제품 발견'),
+              content: Text(
+                "'${duplicate.name}'이(가) 이미 등록되어 있습니다.\n구매 이력을 기존 제품에 추가하시겠습니까?",
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, false),
+                  child: const Text('새로 등록'),
+                ),
+                FilledButton(
+                  onPressed: () => Navigator.pop(ctx, true),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                  ),
+                  child: const Text('이력 추가'),
+                ),
+              ],
+            ),
+          );
+
+          if (shouldMerge == true) {
+            final newPurchases = purchases.map((p) => PurchaseRecord(
+                  date: p.date,
+                  price: p.price,
+                  store: p.store,
+                )).toList();
+            final merged = ConsumableItem(
+              id: duplicate.id,
+              name: duplicate.name,
+              brand: duplicate.brand,
+              category: duplicate.category,
+              icon: duplicate.icon,
+              daysRemaining: duplicate.daysRemaining,
+              cycleDays: duplicate.cycleDays,
+              progress: duplicate.progress,
+              aiPredictedDays: duplicate.aiPredictedDays,
+              aiConfidence: duplicate.aiConfidence,
+              imageUrl: imageUrl ?? duplicate.imageUrl,
+              purchaseHistory: [...duplicate.purchaseHistory, ...newPurchases],
+            );
+            await ItemStore.instance.update(merged);
+            if (mounted) {
+              Navigator.pop(context);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('${duplicate.name}에 구매 이력이 추가되었습니다!'),
+                  behavior: SnackBarBehavior.floating,
+                  backgroundColor: AppColors.success,
+                ),
+              );
+            }
+            return;
+          }
+        }
+      }
 
       final item = ConsumableItem(
         id: itemId,
@@ -254,7 +338,7 @@ class _AddItemScreenState extends State<AddItemScreen> {
         aiPredictedDays: _isEditing ? widget.editItem!.aiPredictedDays : null,
         aiConfidence: _isEditing ? widget.editItem!.aiConfidence : null,
         imageUrl: imageUrl,
-        purchaseHistory: [...existingPurchases, ...purchases],
+        purchaseHistory: purchases,
       );
 
       // Supabase 저장 + 인메모리 스토어 반영
@@ -961,11 +1045,13 @@ class _AddItemScreenState extends State<AddItemScreen> {
 // ---------------------------------------------------------------------------
 
 class _PurchaseEntry {
+  final String? id; // DB에 저장된 기존 이력은 id 보유, 신규는 null
   final DateTime date;
   final TextEditingController priceCtrl;
   final TextEditingController storeCtrl;
 
   _PurchaseEntry({
+    this.id,
     required this.date,
     required this.priceCtrl,
     required this.storeCtrl,
@@ -973,6 +1059,7 @@ class _PurchaseEntry {
 
   _PurchaseEntry copyWith({DateTime? date}) {
     return _PurchaseEntry(
+      id: id,
       date: date ?? this.date,
       priceCtrl: priceCtrl,
       storeCtrl: storeCtrl,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 import '../theme/app_theme.dart';
 import '../widgets/item_card.dart';
 import '../models/item.dart';
+import '../services/item_store.dart';
 import 'item_detail_screen.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -28,6 +29,7 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     _fetchDbData(isInitial: true);
+    ItemStore.instance.addListener(_syncFromStore);
 
     // 스크롤 리스너 등록: 사용자가 끝까지 내렸는지 확인
     _scrollController.addListener(() {
@@ -42,8 +44,20 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   void dispose() {
-    _scrollController.dispose(); // 메모리 누수 방지
+    ItemStore.instance.removeListener(_syncFromStore);
+    _scrollController.dispose();
     super.dispose();
+  }
+
+  // ItemStore 변경(수정/삭제) 시 로컬 _items 동기화
+  void _syncFromStore() {
+    if (!mounted) return;
+    setState(() {
+      _items = _items
+          .where((i) => ItemStore.instance.findById(i.id) != null)
+          .map((i) => ItemStore.instance.findById(i.id)!)
+          .toList();
+    });
   }
 
   // Supabase 페이지네이션 쿼리 함수

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -421,82 +421,110 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            '구매 이력',
-            style: TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-              color: AppColors.text,
-            ),
+          Row(
+            children: [
+              const Text(
+                '구매 이력',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.text,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${_item.purchaseHistory.length}건',
+                style: const TextStyle(
+                  fontSize: 13,
+                  color: AppColors.textMuted,
+                ),
+              ),
+            ],
           ),
           const SizedBox(height: 16),
           ..._item.purchaseHistory.asMap().entries.map((entry) {
             final i = entry.key;
             final record = entry.value;
+            final isFirst = i == 0;
             final isLast = i == _item.purchaseHistory.length - 1;
 
-            return IntrinsicHeight(
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Column(
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: 24,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
                     children: [
+                      const SizedBox(height: 5),
                       Container(
                         width: 10,
                         height: 10,
                         decoration: BoxDecoration(
                           shape: BoxShape.circle,
-                          color: i == 0 ? AppColors.primary : AppColors.border,
+                          color: isFirst ? AppColors.primary : AppColors.border,
                         ),
                       ),
                       if (!isLast)
-                        Expanded(
-                          child: Container(width: 1.5, color: AppColors.border),
+                        Container(
+                          width: 1.5,
+                          height: 52,
+                          color: AppColors.border,
                         ),
                     ],
                   ),
-                  const SizedBox(width: 14),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.only(bottom: 20),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Column(
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: isLast ? 0 : 12),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               Text(
                                 '${record.date.year}.${record.date.month.toString().padLeft(2, '0')}.${record.date.day.toString().padLeft(2, '0')}',
-                                style: const TextStyle(
+                                style: TextStyle(
                                   fontSize: 14,
-                                  fontWeight: FontWeight.w500,
+                                  fontWeight: isFirst
+                                      ? FontWeight.w600
+                                      : FontWeight.w500,
                                   color: AppColors.text,
                                 ),
                               ),
-                              const SizedBox(height: 2),
-                              Text(
-                                record.store,
-                                style: const TextStyle(
-                                  fontSize: 12,
-                                  color: AppColors.textMuted,
+                              if (record.store.isNotEmpty) ...[
+                                const SizedBox(height: 2),
+                                Text(
+                                  record.store,
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    color: AppColors.textMuted,
+                                  ),
                                 ),
-                              ),
+                              ],
                             ],
                           ),
+                        ),
+                        if (record.price > 0)
                           Text(
                             _formatPrice(record.price),
-                            style: const TextStyle(
+                            style: TextStyle(
                               fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: AppColors.text,
+                              fontWeight: isFirst
+                                  ? FontWeight.w700
+                                  : FontWeight.w500,
+                              color: isFirst
+                                  ? AppColors.text
+                                  : AppColors.textSecondary,
                             ),
                           ),
-                        ],
-                      ),
+                      ],
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
             );
           }),
         ],

--- a/lib/screens/scan_screen.dart
+++ b/lib/screens/scan_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
+import 'add_item_screen.dart';
 
 class ScanScreen extends StatefulWidget {
   const ScanScreen({super.key});
@@ -15,6 +16,13 @@ class _ScanScreenState extends State<ScanScreen>
   ScanState _state = ScanState.camera;
   late AnimationController _pulseController;
 
+  // OCR 결과 상태 (스캔 완료 후 편집 가능)
+  final TextEditingController _storeCtrl =
+      TextEditingController(text: '이마트 성수점');
+  DateTime _scanDate = DateTime(2026, 4, 8);
+  final List<_OcrItemEntry> _ocrItems = [];
+  bool _isSaving = false;
+
   @override
   void initState() {
     super.initState();
@@ -22,11 +30,21 @@ class _ScanScreenState extends State<ScanScreen>
       vsync: this,
       duration: const Duration(seconds: 1),
     )..repeat(reverse: true);
+
+    _ocrItems.addAll([
+      _OcrItemEntry('정수기 필터 (코웨이)', 35000),
+      _OcrItemEntry('주방세제 (퐁퐁)', 4500),
+      _OcrItemEntry('세탁세제 (피죤)', 15900),
+    ]);
   }
 
   @override
   void dispose() {
     _pulseController.dispose();
+    _storeCtrl.dispose();
+    for (final item in _ocrItems) {
+      item.dispose();
+    }
     super.dispose();
   }
 
@@ -39,6 +57,56 @@ class _ScanScreenState extends State<ScanScreen>
 
   void _rescan() {
     setState(() => _state = ScanState.camera);
+  }
+
+  Future<void> _pickScanDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _scanDate,
+      firstDate: DateTime(2000),
+      lastDate: DateTime.now(),
+      builder: (context, child) => Theme(
+        data: Theme.of(context).copyWith(
+          colorScheme: const ColorScheme.light(
+            primary: AppColors.primary,
+            onPrimary: Colors.white,
+            surface: AppColors.surface,
+          ),
+        ),
+        child: child!,
+      ),
+    );
+    if (picked != null) setState(() => _scanDate = picked);
+  }
+
+  // 각 OCR 아이템을 AddItemScreen으로 순차 이동하여 저장
+  Future<void> _confirmAndSave() async {
+    setState(() => _isSaving = true);
+    try {
+      for (final ocrItem in _ocrItems) {
+        final priceText =
+            ocrItem.priceCtrl.text.replaceAll(RegExp(r'[^0-9]'), '');
+        final price = int.tryParse(priceText);
+        if (!mounted) break;
+        await Navigator.push<void>(
+          context,
+          MaterialPageRoute(
+            builder: (_) => AddItemScreen(
+              prefillData: OcrPrefillData(
+                productName: ocrItem.nameCtrl.text.trim(),
+                price: price,
+                storeName: _storeCtrl.text.trim(),
+                purchaseDate: _scanDate,
+              ),
+              isOcrReview: true,
+            ),
+          ),
+        );
+      }
+      if (mounted) setState(() => _state = ScanState.camera);
+    } finally {
+      if (mounted) setState(() => _isSaving = false);
+    }
   }
 
   @override
@@ -68,7 +136,6 @@ class _ScanScreenState extends State<ScanScreen>
           style: Theme.of(context).textTheme.bodyMedium,
         ),
         const SizedBox(height: 24),
-        // Camera viewfinder
         Expanded(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -79,7 +146,6 @@ class _ScanScreenState extends State<ScanScreen>
               ),
               child: Stack(
                 children: [
-                  // Simulated camera background
                   Center(
                     child: Icon(
                       Icons.receipt_long_outlined,
@@ -87,7 +153,6 @@ class _ScanScreenState extends State<ScanScreen>
                       color: Colors.white.withOpacity(0.15),
                     ),
                   ),
-                  // Corner guides
                   Positioned(
                     top: 40,
                     left: 30,
@@ -108,7 +173,6 @@ class _ScanScreenState extends State<ScanScreen>
                     right: 30,
                     child: _cornerGuide(false, false),
                   ),
-                  // Center text
                   const Center(
                     child: Text(
                       '카메라 미리보기',
@@ -121,7 +185,6 @@ class _ScanScreenState extends State<ScanScreen>
           ),
         ),
         const SizedBox(height: 24),
-        // Scan button
         Padding(
           padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
           child: SizedBox(
@@ -208,6 +271,11 @@ class _ScanScreenState extends State<ScanScreen>
   }
 
   Widget _buildResult() {
+    final total = _ocrItems.fold<int>(0, (sum, e) {
+      final t = e.priceCtrl.text.replaceAll(RegExp(r'[^0-9]'), '');
+      return sum + (int.tryParse(t) ?? 0);
+    });
+
     return SingleChildScrollView(
       padding: const EdgeInsets.all(20),
       child: Column(
@@ -215,13 +283,12 @@ class _ScanScreenState extends State<ScanScreen>
         children: [
           Row(
             children: [
-              const Icon(
-                Icons.check_circle,
-                color: AppColors.success,
-                size: 24,
-              ),
+              const Icon(Icons.check_circle, color: AppColors.success, size: 24),
               const SizedBox(width: 8),
-              Text('스캔 완료', style: Theme.of(context).textTheme.headlineMedium),
+              Text(
+                '스캔 완료',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
             ],
           ),
           const SizedBox(height: 6),
@@ -231,7 +298,6 @@ class _ScanScreenState extends State<ScanScreen>
           ),
           const SizedBox(height: 24),
 
-          // Extracted data
           Container(
             padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
@@ -241,13 +307,102 @@ class _ScanScreenState extends State<ScanScreen>
             ),
             child: Column(
               children: [
-                _editableField('매장명', '이마트 성수점'),
-                _editableField('날짜', '2026.04.08'),
-                const Divider(height: 24, color: AppColors.border),
-                _editableItemRow('정수기 필터 (코웨이)', '35,000원'),
-                _editableItemRow('주방세제 (퐁퐁)', '4,500원'),
-                _editableItemRow('세탁세제 (피죤)', '15,900원'),
-                const Divider(height: 24, color: AppColors.border),
+                // 매장명
+                _labeledTextField('매장명', _storeCtrl),
+                const SizedBox(height: 14),
+                // 구매일 (탭으로 날짜 선택)
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      '날짜',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: AppColors.textMuted,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    InkWell(
+                      onTap: _pickScanDate,
+                      borderRadius: BorderRadius.circular(10),
+                      child: Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 10,
+                        ),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(10),
+                          border: Border.all(color: AppColors.border),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(
+                              Icons.calendar_today_outlined,
+                              size: 15,
+                              color: AppColors.primary,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              '${_scanDate.year}.${_scanDate.month.toString().padLeft(2, '0')}.${_scanDate.day.toString().padLeft(2, '0')}',
+                              style: const TextStyle(
+                                fontSize: 15,
+                                color: AppColors.text,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                const Divider(height: 1, color: AppColors.border),
+                const SizedBox(height: 14),
+                // 아이템 목록
+                ...List.generate(_ocrItems.length, (i) {
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.drag_indicator,
+                          size: 18,
+                          color: AppColors.textMuted,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          flex: 3,
+                          child: TextField(
+                            controller: _ocrItems[i].nameCtrl,
+                            style: const TextStyle(
+                              fontSize: 14,
+                              color: AppColors.text,
+                            ),
+                            decoration: _compactDecoration(),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          flex: 2,
+                          child: TextField(
+                            controller: _ocrItems[i].priceCtrl,
+                            textAlign: TextAlign.right,
+                            keyboardType: TextInputType.number,
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.text,
+                            ),
+                            decoration: _compactDecoration(suffix: '원'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }),
+                const Divider(height: 16, color: AppColors.border),
+                // 합계
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
@@ -260,8 +415,8 @@ class _ScanScreenState extends State<ScanScreen>
                       ),
                     ),
                     Text(
-                      '55,400원',
-                      style: TextStyle(
+                      _formatPrice(total),
+                      style: const TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w700,
                         color: AppColors.primary,
@@ -272,25 +427,35 @@ class _ScanScreenState extends State<ScanScreen>
               ],
             ),
           ),
+          const SizedBox(height: 12),
+          Text(
+            '아이템 ${_ocrItems.length}개를 순서대로 검수 후 각각 저장합니다.',
+            style: const TextStyle(fontSize: 12, color: AppColors.textMuted),
+          ),
           const SizedBox(height: 20),
 
-          // Action buttons
           SizedBox(
             width: double.infinity,
             child: FilledButton.icon(
-              onPressed: () {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text('저장되었습니다!'),
-                    behavior: SnackBarBehavior.floating,
-                  ),
-                );
-              },
-              icon: const Icon(Icons.check, size: 20),
-              label: const Text('확인 및 저장', style: TextStyle(fontSize: 16)),
+              onPressed: _isSaving ? null : _confirmAndSave,
+              icon: _isSaving
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Icon(Icons.check, size: 20),
+              label: Text(
+                _isSaving ? '저장 중...' : '확인 및 저장',
+                style: const TextStyle(fontSize: 16),
+              ),
               style: FilledButton.styleFrom(
                 backgroundColor: AppColors.primary,
                 foregroundColor: Colors.white,
+                disabledBackgroundColor: AppColors.textMuted,
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(14),
@@ -320,112 +485,85 @@ class _ScanScreenState extends State<ScanScreen>
     );
   }
 
-  Widget _editableField(String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 14),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            style: const TextStyle(fontSize: 12, color: AppColors.textMuted),
-          ),
-          const SizedBox(height: 6),
-          TextFormField(
-            initialValue: value,
-            style: const TextStyle(fontSize: 15, color: AppColors.text),
-            decoration: InputDecoration(
-              isDense: true,
-              contentPadding: const EdgeInsets.symmetric(
-                horizontal: 12,
-                vertical: 10,
-              ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(10),
-                borderSide: const BorderSide(color: AppColors.border),
-              ),
-              enabledBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(10),
-                borderSide: const BorderSide(color: AppColors.border),
-              ),
-              focusedBorder: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(10),
-                borderSide: const BorderSide(
-                  color: AppColors.primary,
-                  width: 1.5,
-                ),
-              ),
+  Widget _labeledTextField(String label, TextEditingController ctrl) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(fontSize: 12, color: AppColors.textMuted),
+        ),
+        const SizedBox(height: 6),
+        TextField(
+          controller: ctrl,
+          style: const TextStyle(fontSize: 15, color: AppColors.text),
+          decoration: InputDecoration(
+            isDense: true,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 12,
+              vertical: 10,
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(10),
+              borderSide: const BorderSide(color: AppColors.border),
+            ),
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(10),
+              borderSide: const BorderSide(color: AppColors.border),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(10),
+              borderSide:
+                  const BorderSide(color: AppColors.primary, width: 1.5),
             ),
           ),
-        ],
+        ),
+      ],
+    );
+  }
+
+  InputDecoration _compactDecoration({String? suffix}) {
+    return InputDecoration(
+      isDense: true,
+      suffixText: suffix,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: AppColors.border),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: AppColors.border),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(8),
+        borderSide: const BorderSide(color: AppColors.primary, width: 1.5),
       ),
     );
   }
 
-  Widget _editableItemRow(String name, String price) {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Row(
-        children: [
-          const Icon(
-            Icons.drag_indicator,
-            size: 18,
-            color: AppColors.textMuted,
-          ),
-          const SizedBox(width: 8),
-          Expanded(
-            flex: 3,
-            child: TextFormField(
-              initialValue: name,
-              style: const TextStyle(fontSize: 14, color: AppColors.text),
-              decoration: InputDecoration(
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 10,
-                  vertical: 8,
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: AppColors.border),
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: AppColors.border),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            flex: 2,
-            child: TextFormField(
-              initialValue: price,
-              textAlign: TextAlign.right,
-              style: const TextStyle(
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-                color: AppColors.text,
-              ),
-              decoration: InputDecoration(
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(
-                  horizontal: 10,
-                  vertical: 8,
-                ),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: AppColors.border),
-                ),
-                enabledBorder: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
-                  borderSide: const BorderSide(color: AppColors.border),
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
+  String _formatPrice(int price) {
+    final str = price.toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < str.length; i++) {
+      if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
+      buffer.write(str[i]);
+    }
+    return '$buffer원';
+  }
+}
+
+class _OcrItemEntry {
+  final TextEditingController nameCtrl;
+  final TextEditingController priceCtrl;
+
+  _OcrItemEntry(String name, int price)
+      : nameCtrl = TextEditingController(text: name),
+        priceCtrl = TextEditingController(text: price.toString());
+
+  void dispose() {
+    nameCtrl.dispose();
+    priceCtrl.dispose();
   }
 }
 

--- a/lib/screens/scan_screen.dart
+++ b/lib/screens/scan_screen.dart
@@ -17,8 +17,9 @@ class _ScanScreenState extends State<ScanScreen>
   late AnimationController _pulseController;
 
   // OCR 결과 상태 (스캔 완료 후 편집 가능)
-  final TextEditingController _storeCtrl =
-      TextEditingController(text: '이마트 성수점');
+  final TextEditingController _storeCtrl = TextEditingController(
+    text: '이마트 성수점',
+  );
   DateTime _scanDate = DateTime(2026, 4, 8);
   final List<_OcrItemEntry> _ocrItems = [];
   bool _isSaving = false;
@@ -84,8 +85,10 @@ class _ScanScreenState extends State<ScanScreen>
     setState(() => _isSaving = true);
     try {
       for (final ocrItem in _ocrItems) {
-        final priceText =
-            ocrItem.priceCtrl.text.replaceAll(RegExp(r'[^0-9]'), '');
+        final priceText = ocrItem.priceCtrl.text.replaceAll(
+          RegExp(r'[^0-9]'),
+          '',
+        );
         final price = int.tryParse(priceText);
         if (!mounted) break;
         await Navigator.push<void>(
@@ -283,12 +286,13 @@ class _ScanScreenState extends State<ScanScreen>
         children: [
           Row(
             children: [
-              const Icon(Icons.check_circle, color: AppColors.success, size: 24),
-              const SizedBox(width: 8),
-              Text(
-                '스캔 완료',
-                style: Theme.of(context).textTheme.headlineMedium,
+              const Icon(
+                Icons.check_circle,
+                color: AppColors.success,
+                size: 24,
               ),
+              const SizedBox(width: 8),
+              Text('스캔 완료', style: Theme.of(context).textTheme.headlineMedium),
             ],
           ),
           const SizedBox(height: 6),
@@ -513,8 +517,10 @@ class _ScanScreenState extends State<ScanScreen>
             ),
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(10),
-              borderSide:
-                  const BorderSide(color: AppColors.primary, width: 1.5),
+              borderSide: const BorderSide(
+                color: AppColors.primary,
+                width: 1.5,
+              ),
             ),
           ),
         ),
@@ -558,8 +564,8 @@ class _OcrItemEntry {
   final TextEditingController priceCtrl;
 
   _OcrItemEntry(String name, int price)
-      : nameCtrl = TextEditingController(text: name),
-        priceCtrl = TextEditingController(text: price.toString());
+    : nameCtrl = TextEditingController(text: name),
+      priceCtrl = TextEditingController(text: price.toString());
 
   void dispose() {
     nameCtrl.dispose();

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -192,6 +192,22 @@ class SupabaseService {
   }
 
   // ────────────────────────────────────────────────────────────────────────────
+  // 구매 이력 삭제
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /// 지정한 purchases.id 목록을 DB에서 삭제합니다.
+  static Future<void> deletePurchases(Set<String> ids) async {
+    if (ids.isEmpty) return;
+    try {
+      await _db.from('purchases').delete().inFilter('id', ids.toList());
+      debugPrint('[Supabase] deletePurchases 완료: ${ids.length}건');
+    } catch (e) {
+      debugPrint('[Supabase] deletePurchases 오류: $e');
+      rethrow;
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
   // 카테고리 조회 또는 생성
   // ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **구매이력 레이아웃 수정**: `IntrinsicHeight` + `Expanded` 조합이 Flutter Web에서 렌더링 오류를 일으키는 문제 수정, 이력 건수 표시 및 빈 store/price 조건부 처리 추가
- **구매이력 삭제 버그 수정**: `_PurchaseEntry`가 DB `id`를 보존하지 않아 편집 시 삭제한 이력이 다시 추가되던 문제 수정, `deletePurchases()` 메서드로 DB에서도 삭제
- **홈 화면 데이터 동기화**: `ItemStore` 리스너 추가 — 수정/삭제 후 다른 페이지 이동 시 이전 데이터가 표시되던 문제 수정
- **OCR 저장 버그 수정**: "확인 및 저장" 버튼이 스낵바만 표시하고 실제로 저장하지 않던 문제 수정, 컨트롤러 도입 및 `AddItemScreen` 순차 이동으로 실제 등록 가능
- **중복 제품 병합**: 동일 이름 제품 신규 등록 시 기존 제품에 구매 이력을 추가할지 선택하는 다이얼로그 추가

## Test plan

- [x] 제품 세부화면 → 구매이력이 올바르게 표시되는지 확인
- [x] 제품 수정 → 구매이력 삭제 후 저장 → 다른 페이지 이동 후 재진입 시 삭제 유지 확인
- [x] OCR 스캔 → "확인 및 저장" → AddItemScreen으로 이동하여 실제 저장 확인
- [x] 동일 이름 제품 등록 시 병합 다이얼로그 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)