### PR TITLE
홈 다이제스트 UI와 전체 제품 탭 재구성

### DIFF
--- a/docs/REDESIGN_NOTES.md
+++ b/docs/REDESIGN_NOTES.md
@@ -86,4 +86,15 @@
 | `29bf470` | (선행) `lib/screens/items_screen.dart` 신규 |
 | `1e671ac` | (선행) `ItemStore` 롤백 추가 |
 | `54dcd3f` | (선행) `ItemDetailScreen` 에러 처리 |
-| (이 PR 본편) | 위 노트의 본 변경사항 — Task 7에서 SHA 채움 |
+| `ac3b3ac` | docs: REDESIGN_NOTES 신규 |
+| `7492fd1` | docs: REDESIGN_NOTES 시제 프레이밍 정리 |
+| `a93467d` | theme: warm-neutral 팔레트로 토큰 값 교체 |
+| `9f92613` | theme: D-day 4-tier 보존 위해 `danger ≠ primary` 분리 |
+| `ee7524f` | theme: `dangerLight` 갭 확대 + 시각적 한계 문서화 |
+| `d1ea091` | widgets/home: `HomeHeroCard`, `UpcomingItemRow` 신규 |
+| `9dd1dbf` | widgets/home: 리뷰 반영 (조건부 CTA, warm surface) |
+| `4efd77e` | home: `ItemStore` 구독으로 빌드 트리 교체 |
+| `e8a32af` | main: 하단 탭 재구성 + FAB 액션 시트 |
+| `46db1ac` | home/main: 리뷰 반영 (exhaustive switch, userName dedup) |
+| `6aad00f` | home: `upcoming` 비었을 때 '다가오는 교체' 섹션 숨김 |
+| `ea97dbe` | test/widget: 탭 라벨 검증 갱신 |

--- a/docs/REDESIGN_NOTES.md
+++ b/docs/REDESIGN_NOTES.md
@@ -1,0 +1,71 @@
+# buylog UI 리디자인 (2026-05) 변경 노트
+
+> 작성: 전승환 / 검토 대상: 팀원 4명 / 적용 브랜치: `ui-test`
+> 디자인 원본: `.design-handoff/project/prototype.html` (Claude Design 핸드오프)
+
+이 문서는 리디자인 PR이 **어느 파일을 / 왜 / 어디까지** 건드렸는지를 1페이지로 요약한다. 자기 코드가 바뀌었다고 느낀다면 이 문서의 해당 섹션을 먼저 읽어주세요. 되돌리고 싶은 결정이 있다면 PR 코멘트로 토론합시다.
+
+## 한 줄 요약
+
+따뜻한 뉴트럴 톤(아이보리 + 테라코타 + 세이지 모스)으로 비주얼 통일 + 홈 화면 정보 위계 재정리 + 하단 탭에서 `스캔` 자리를 `모든 제품`으로 교체.
+
+## 변경 / 미변경 파일 한눈에
+
+| 파일 | 변경? | 이유 |
+| --- | --- | --- |
+| `lib/theme/app_theme.dart` | ✅ 값만 | 모든 화면이 토큰 경유 → 한 곳만 바꾸면 끝 |
+| `lib/main.dart` | ✅ 구조 | 하단 탭 IA 변경 (`스캔` → `모든 제품`), FAB 액션 시트 |
+| `lib/screens/home_screen.dart` | ✅ 구조 | 디자인의 1/3이 홈 히어로·다가오는 교체·최근 기록 |
+| `lib/screens/items_screen.dart` | 🆕 신규 | 새 `모든 제품` 탭 |
+| `lib/widgets/home/home_hero_card.dart` | 🆕 신규 | 홈 히어로 카드 컴포지트 |
+| `lib/widgets/home/upcoming_item_row.dart` | 🆕 신규 | 홈 컴팩트 행 |
+| `test/widget_test.dart` | ✅ 1줄 | 탭 라벨 변경 반영 |
+| `lib/services/item_store.dart` | ✅ 롤백 추가 (이전 PR) | Supabase 실패 시 ghost item 방지 |
+| `lib/screens/item_detail_screen.dart` | ✅ try/catch (이전 PR) | 위 롤백의 rethrow 처리 |
+| **그 외 모든 화면/위젯 파일** | ❌ | `AppColors` 토큰 경유 → 자동으로 새 팔레트 |
+
+> 팀원 작성 코드(`group_screen`, `reports_screen`, `settings_screen`, `add_item_screen`, `widgets/item_card`, `widgets/dday_badge`, `widgets/countdown_ring`, `widgets/reports/*`)는 **한 줄도 수정하지 않았다.** 색/카드/링 비주얼이 달라 보이는 것은 토큰 값만 바뀐 결과.
+
+## 왜 이렇게 바꿨나 (3가지 의사결정)
+
+### 1. 팔레트 토큰 값만 교체 — 식별자 유지
+
+`AppColors.primary` 등 19개 토큰의 *값*만 바꾸고 *이름*은 유지했다. 이유:
+- 모든 팀원 코드가 토큰 경유로 색을 사용 중 → 한 군데만 바꾸면 자동 적용
+- 식별자가 그대로라 grep 호환성·blame 안정성 보존
+- 각자가 작업한 화면 파일은 diff에 등장하지 않음
+
+`primary`라는 이름이 더 이상 cyan이 아니라 terracotta가 된 점이 약간의 인지 부조화를 유발하지만, 이름을 바꾸면 모든 호출부를 건드려야 해서 비용 대비 손실이 더 컸다.
+
+### 2. 홈 = 큐레이팅 다이제스트, 전체 리스트 = `모든 제품` 탭
+
+기존 홈은 무한 스크롤로 전체 품목을 노출했다. 새 디자인은 홈을 "오늘 챙겨야 할 것"에 집중하는 다이제스트로 바꾸고, 전체 리스트는 새 `모든 제품` 탭으로 옮겼다.
+
+기술적 결과:
+- 홈의 자체 Supabase 페이지네이션 (`_supabase.from('product_items')`, `ScrollController`, `_isMoreLoading` 등)을 모두 제거
+- 홈은 `ValueListenableBuilder<List<ConsumableItem>>`로 `ItemStore` 구독 → AddItem/ItemDetail과 동일한 단일 소스
+- 결과: 직접 등록 직후 홈에 즉시 반영. 이전에는 홈만 stale.
+
+### 3. `스캔` 탭 → `모든 제품` 탭, 스캔은 FAB 액션 시트로
+
+5탭 중 `스캔`은 진입 빈도가 낮은 모달성 작업이라 탭 슬롯을 차지하기엔 비효율. 디자인은 이 자리를 `모든 제품`으로 바꾸고, FAB을 누르면 *카메라 스캔* / *직접 등록* 두 가지가 떠오르는 액션 시트로 통합.
+
+기술적 결과:
+- `ScanScreen` 코드 자체는 한 줄도 안 바뀜 — `main.dart`에서만 라우팅이 바뀜
+- FAB이 홈/모든 제품 탭에서 노출
+
+## 되돌리고 싶다면
+
+- 팔레트만 되돌리기: `lib/theme/app_theme.dart` 한 파일을 develop 시점으로 되돌리면 끝
+- 홈 구조 되돌리기: `lib/screens/home_screen.dart`만 되돌리면 끝 (다른 화면 영향 없음)
+- 탭 IA 되돌리기: `lib/main.dart`만 되돌리면 끝
+- 전체 되돌리기: `git revert`로 이 PR의 머지 커밋 하나만
+
+## 관련 커밋
+
+| SHA | 설명 |
+| --- | --- |
+| `29bf470` | `lib/screens/items_screen.dart` 신규 (이 PR 이전 작업) |
+| `1e671ac` | `ItemStore` 롤백 추가 |
+| `54dcd3f` | `ItemDetailScreen` 에러 처리 |
+| (이 PR) | 위 노트의 본 변경사항 |

--- a/docs/REDESIGN_NOTES.md
+++ b/docs/REDESIGN_NOTES.md
@@ -66,6 +66,17 @@
 - **탭 IA 되돌리기**: `lib/main.dart`만 되돌리면 `스캔` 탭이 복귀합니다. `lib/screens/items_screen.dart`는 import 사라지면 오펀이 되니 함께 정리하세요.
 - **전체 되돌리기**: `git revert`로 본 PR의 머지 커밋 한 개.
 
+## 알려진 시각적 한계 (후속 폴리시 후보)
+
+리디자인 적용 후에도 남는 자잘한 시각 이슈를 팀 공통 인지로 남깁니다. 본 PR 범위에서는 의도적으로 손대지 않았습니다.
+
+- **D-day 배지 텍스트 대비**: warm 팔레트의 status fg/bg 페어(`success/successLight`, `warning/warningLight`, `primary/primaryLight2`)는 12 px 굵은 글자에서 WCAG AA(4.5:1)에 미달합니다. 디자인 핸드오프의 의도적 선택을 따랐고, 접근성 보강이 필요해지면 fg 토큰을 한 단계 어둡게 하거나 별도 `onPrimary/onSuccess` 토큰을 도입하는 follow-up이 자연스럽습니다.
+- **`lib/widgets/reports/category_pie_chart.dart` 카테고리 색**: 파일 내부에 cool 톤 hex가 하드코딩되어 있어 새 팔레트와 톤이 어긋나 보일 수 있습니다. 팀원 작성 코드라 이번 PR에서는 보존했습니다.
+- **`lib/data/sample_data.dart`의 멤버 아바타 색**: 4명 그룹 멤버 아바타 색이 hex 문자열로 박혀 있어 warm 팔레트와 무관하게 표시됩니다. 동일한 이유로 보존했습니다.
+- **`lib/screens/scan_screen.dart`의 뷰파인더 슬레이트(`0xFF1E293B`)**: 카메라 오버레이용 어두운 배경. 카메라 chrome 톤은 디자인 변경 범위 밖이라 그대로 둡니다.
+
+위 항목 중 하나라도 폴리시가 필요하다고 판단되면 별도 PR로 진행해주세요.
+
 ## 관련 커밋
 
 본 PR이 develop 위에 누적하는 커밋:

--- a/docs/REDESIGN_NOTES.md
+++ b/docs/REDESIGN_NOTES.md
@@ -3,7 +3,9 @@
 > 작성: 전승환 / 검토 대상: 팀원 4명 / 적용 브랜치: `ui-test`
 > 디자인 원본: `.design-handoff/project/prototype.html` (Claude Design 핸드오프)
 
-이 문서는 리디자인 PR이 **어느 파일을 / 왜 / 어디까지** 건드렸는지를 1페이지로 요약한다. 자기 코드가 바뀌었다고 느낀다면 이 문서의 해당 섹션을 먼저 읽어주세요. 되돌리고 싶은 결정이 있다면 PR 코멘트로 토론합시다.
+이 문서는 본 PR이 **어느 파일을 / 왜 / 어디까지** 건드리는지를 1페이지로 요약한다. 본인 담당 화면의 영향 범위가 궁금하다면 이 문서의 해당 섹션을 먼저 확인해주세요. 되돌리고 싶은 결정이 있다면 PR 코멘트로 토론합시다.
+
+> **주의:** 본 PR은 여러 커밋에 나눠 적용됩니다. 이 문서는 PR이 모두 머지된 시점의 최종 상태를 기준으로 작성되었습니다. 중간 커밋을 fetch한 시점에는 표의 일부 변경이 아직 반영되지 않았을 수 있습니다.
 
 ## 한 줄 요약
 
@@ -11,18 +13,19 @@
 
 ## 변경 / 미변경 파일 한눈에
 
-| 파일 | 변경? | 이유 |
-| --- | --- | --- |
-| `lib/theme/app_theme.dart` | ✅ 값만 | 모든 화면이 토큰 경유 → 한 곳만 바꾸면 끝 |
-| `lib/main.dart` | ✅ 구조 | 하단 탭 IA 변경 (`스캔` → `모든 제품`), FAB 액션 시트 |
-| `lib/screens/home_screen.dart` | ✅ 구조 | 디자인의 1/3이 홈 히어로·다가오는 교체·최근 기록 |
-| `lib/screens/items_screen.dart` | 🆕 신규 | 새 `모든 제품` 탭 |
-| `lib/widgets/home/home_hero_card.dart` | 🆕 신규 | 홈 히어로 카드 컴포지트 |
-| `lib/widgets/home/upcoming_item_row.dart` | 🆕 신규 | 홈 컴팩트 행 |
-| `test/widget_test.dart` | ✅ 1줄 | 탭 라벨 변경 반영 |
-| `lib/services/item_store.dart` | ✅ 롤백 추가 (이전 PR) | Supabase 실패 시 ghost item 방지 |
-| `lib/screens/item_detail_screen.dart` | ✅ try/catch (이전 PR) | 위 롤백의 rethrow 처리 |
-| **그 외 모든 화면/위젯 파일** | ❌ | `AppColors` 토큰 경유 → 자동으로 새 팔레트 |
+| 파일 | 변경? | 적용 커밋 그룹 | 이유 |
+| --- | --- | --- | --- |
+| `lib/services/item_store.dart` | 롤백 추가 | 데이터 안정화 (1e671ac 외) | Supabase 실패 시 ghost item 방지 |
+| `lib/screens/item_detail_screen.dart` | try/catch | 데이터 안정화 (54dcd3f) | 위 롤백의 rethrow 처리 |
+| `lib/screens/items_screen.dart` | 🆕 신규 | 데이터 안정화 (29bf470) | 새 `모든 제품` 탭의 본체 |
+| `docs/REDESIGN_NOTES.md` | 🆕 신규 | 리디자인 본편 | 이 문서 |
+| `lib/theme/app_theme.dart` | 값만 | 리디자인 본편 | 모든 화면이 토큰 경유 → 한 곳만 바꾸면 끝 |
+| `lib/widgets/home/home_hero_card.dart` | 🆕 신규 | 리디자인 본편 | 홈 히어로 카드 컴포지트 |
+| `lib/widgets/home/upcoming_item_row.dart` | 🆕 신규 | 리디자인 본편 | 홈 컴팩트 행 |
+| `lib/screens/home_screen.dart` | 구조 | 리디자인 본편 | 디자인의 1/3이 홈 (히어로·다가오는 교체·최근 기록) |
+| `lib/main.dart` | 구조 | 리디자인 본편 | 하단 탭 IA 변경 (`스캔` → `모든 제품`), FAB 액션 시트 |
+| `test/widget_test.dart` | 1줄 | 리디자인 본편 | 탭 라벨 변경 반영 |
+| **그 외 모든 화면/위젯 파일** | ❌ | — | `AppColors` 토큰 경유 → 자동으로 새 팔레트 |
 
 > 팀원 작성 코드(`group_screen`, `reports_screen`, `settings_screen`, `add_item_screen`, `widgets/item_card`, `widgets/dday_badge`, `widgets/countdown_ring`, `widgets/reports/*`)는 **한 줄도 수정하지 않았다.** 색/카드/링 비주얼이 달라 보이는 것은 토큰 값만 바뀐 결과.
 
@@ -56,16 +59,20 @@
 
 ## 되돌리고 싶다면
 
-- 팔레트만 되돌리기: `lib/theme/app_theme.dart` 한 파일을 develop 시점으로 되돌리면 끝
-- 홈 구조 되돌리기: `lib/screens/home_screen.dart`만 되돌리면 끝 (다른 화면 영향 없음)
-- 탭 IA 되돌리기: `lib/main.dart`만 되돌리면 끝
-- 전체 되돌리기: `git revert`로 이 PR의 머지 커밋 하나만
+본 PR이 머지된 후 부분 롤백이 필요한 경우의 가이드입니다.
+
+- **팔레트만 되돌리기**: `lib/theme/app_theme.dart`만 develop 시점으로 되돌립니다. `home_hero_card.dart`/`upcoming_item_row.dart`는 토큰 경유라 자동 적응합니다.
+- **홈 구조 되돌리기**: `lib/screens/home_screen.dart`을 되돌리고 `lib/widgets/home/` 디렉토리를 삭제합니다. `lib/main.dart`의 `MainNavigationState.switchTab` 호출이 사라지더라도 main.dart 자체는 그대로 둘 수 있습니다.
+- **탭 IA 되돌리기**: `lib/main.dart`만 되돌리면 `스캔` 탭이 복귀합니다. `lib/screens/items_screen.dart`는 import 사라지면 오펀이 되니 함께 정리하세요.
+- **전체 되돌리기**: `git revert`로 본 PR의 머지 커밋 한 개.
 
 ## 관련 커밋
 
+본 PR이 develop 위에 누적하는 커밋:
+
 | SHA | 설명 |
 | --- | --- |
-| `29bf470` | `lib/screens/items_screen.dart` 신규 (이 PR 이전 작업) |
-| `1e671ac` | `ItemStore` 롤백 추가 |
-| `54dcd3f` | `ItemDetailScreen` 에러 처리 |
-| (이 PR) | 위 노트의 본 변경사항 |
+| `29bf470` | (선행) `lib/screens/items_screen.dart` 신규 |
+| `1e671ac` | (선행) `ItemStore` 롤백 추가 |
+| `54dcd3f` | (선행) `ItemDetailScreen` 에러 처리 |
+| (이 PR 본편) | 위 노트의 본 변경사항 — Task 7에서 SHA 채움 |

--- a/docs/REDESIGN_NOTES.md
+++ b/docs/REDESIGN_NOTES.md
@@ -3,79 +3,123 @@
 > 작성: 전승환 / 검토 대상: 팀원 4명 / 적용 브랜치: `ui-test`
 > 디자인 원본: `.design-handoff/project/prototype.html` (Claude Design 핸드오프)
 
-이 문서는 본 PR이 **어느 파일을 / 왜 / 어디까지** 건드리는지를 1페이지로 요약한다. 본인 담당 화면의 영향 범위가 궁금하다면 이 문서의 해당 섹션을 먼저 확인해주세요. 되돌리고 싶은 결정이 있다면 PR 코멘트로 토론합시다.
+본인 담당 화면의 영향 범위가 궁금하다면 아래 해당 항목을 먼저 확인해주세요. 되돌리고 싶은 결정이 있다면 PR 코멘트로 토론합시다.
 
-> **주의:** 본 PR은 여러 커밋에 나눠 적용됩니다. 이 문서는 PR이 모두 머지된 시점의 최종 상태를 기준으로 작성되었습니다. 중간 커밋을 fetch한 시점에는 표의 일부 변경이 아직 반영되지 않았을 수 있습니다.
+---
 
-## 한 줄 요약
+## 한눈에 보기
 
-따뜻한 뉴트럴 톤(아이보리 + 테라코타 + 세이지 모스)으로 비주얼 통일 + 홈 화면 정보 위계 재정리 + 하단 탭에서 `스캔` 자리를 `모든 제품`으로 교체.
+따뜻한 뉴트럴 톤(아이보리 + 테라코타 + 세이지 모스)으로 비주얼 통일 + 홈 화면 정보 위계 재정리 + 하단 탭 `스캔` 자리를 `모든 제품`으로 교체.
 
-## 변경 / 미변경 파일 한눈에
-
-| 파일 | 변경? | 적용 커밋 그룹 | 이유 |
-| --- | --- | --- | --- |
-| `lib/services/item_store.dart` | 롤백 추가 | 데이터 안정화 (1e671ac 외) | Supabase 실패 시 ghost item 방지 |
-| `lib/screens/item_detail_screen.dart` | try/catch | 데이터 안정화 (54dcd3f) | 위 롤백의 rethrow 처리 |
-| `lib/screens/items_screen.dart` | 🆕 신규 | 데이터 안정화 (29bf470) | 새 `모든 제품` 탭의 본체 |
-| `docs/REDESIGN_NOTES.md` | 🆕 신규 | 리디자인 본편 | 이 문서 |
-| `lib/theme/app_theme.dart` | 값만 | 리디자인 본편 | 모든 화면이 토큰 경유 → 한 곳만 바꾸면 끝 |
-| `lib/widgets/home/home_hero_card.dart` | 🆕 신규 | 리디자인 본편 | 홈 히어로 카드 컴포지트 |
-| `lib/widgets/home/upcoming_item_row.dart` | 🆕 신규 | 리디자인 본편 | 홈 컴팩트 행 |
-| `lib/screens/home_screen.dart` | 구조 | 리디자인 본편 | 디자인의 1/3이 홈 (히어로·다가오는 교체·최근 기록) |
-| `lib/main.dart` | 구조 | 리디자인 본편 | 하단 탭 IA 변경 (`스캔` → `모든 제품`), FAB 액션 시트 |
-| `test/widget_test.dart` | 1줄 | 리디자인 본편 | 탭 라벨 변경 반영 |
-| **그 외 모든 화면/위젯 파일** | ❌ | — | `AppColors` 토큰 경유 → 자동으로 새 팔레트 |
+| # | 변경 | 영향 |
+| --- | --- | --- |
+| 1 | 하단 탭 `스캔` → `모든 제품` | 탭 IA 변경, 스캔은 FAB 액션 시트로 |
+| 2 | 홈 화면 구조 재편 | 무한 스크롤 → 큐레이팅 다이제스트 |
+| 3 | 테마 팔레트: 쿨 teal → 따뜻한 뉴트럴 | 모든 화면 자동 적용 (토큰 경유) |
+| 4 | 새 위젯 분리 (`lib/widgets/home/`) | 팀원 위젯 보존 |
+| 5 | 새 화면 `모든 제품` | 전체 품목 리스트 + 필터 |
+| 6 | `ItemStore` 롤백 | Supabase 실패 시 ghost item 방지 |
+| 7 | 탭 라벨 `내 아이템` → `홈` | 의미상 정합성 |
+| 8 | `docs/REDESIGN_NOTES.md` | 이 문서 |
 
 > 팀원 작성 코드(`group_screen`, `reports_screen`, `settings_screen`, `add_item_screen`, `widgets/item_card`, `widgets/dday_badge`, `widgets/countdown_ring`, `widgets/reports/*`)는 **한 줄도 수정하지 않았다.** 색/카드/링 비주얼이 달라 보이는 것은 토큰 값만 바뀐 결과.
 
-## 왜 이렇게 바꿨나 (3가지 의사결정)
+> **주의:** 본 PR은 여러 커밋에 나눠 적용됩니다. 이 문서는 PR이 모두 머지된 시점의 최종 상태를 기준입니다. 중간 커밋을 fetch한 시점에는 일부 변경이 아직 반영되지 않았을 수 있습니다.
 
-### 1. 팔레트 토큰 값만 교체 — 식별자 유지
+---
 
-`AppColors.primary` 등 19개 토큰의 *값*만 바꾸고 *이름*은 유지했다. 이유:
-- 모든 팀원 코드가 토큰 경유로 색을 사용 중 → 한 군데만 바꾸면 자동 적용
-- 식별자가 그대로라 grep 호환성·blame 안정성 보존
-- 각자가 작업한 화면 파일은 diff에 등장하지 않음
+## 세부 사항
 
-`primary`라는 이름이 더 이상 cyan이 아니라 terracotta가 된 점이 약간의 인지 부조화를 유발하지만, 이름을 바꾸면 모든 호출부를 건드려야 해서 비용 대비 손실이 더 컸다.
+### 1. 하단 탭: `스캔` → `모든 제품`
 
-### 2. 홈 = 큐레이팅 다이제스트, 전체 리스트 = `모든 제품` 탭
+- **이유**: 스캔 기능 진입 빈도가 낮아 탭 슬롯을 차지하기엔 비효율. 전체 제품 리스트 조회가 더 잦은 동작.
+- **변경 위치**: `lib/main.dart` 의 `_tabs`, `_screenAt`
+- **변경 내용**:
+  - `BottomNavigationBar`에서 `ScanScreen` 자리에 `ItemsScreen` 노출
+  - 스캔 진입은 FAB 누르면 뜨는 액션 시트(카메라 스캔 / 직접 등록)로 이동
+  - `ScanScreen` 코드 자체는 한 줄도 안 건드림
 
-기존 홈은 무한 스크롤로 전체 품목을 노출했다. 새 디자인은 홈을 "오늘 챙겨야 할 것"에 집중하는 다이제스트로 바꾸고, 전체 리스트는 새 `모든 제품` 탭으로 옮겼다.
+### 2. 홈 화면 구조 재편
 
-기술적 결과:
-- 홈의 자체 Supabase 페이지네이션 (`_supabase.from('product_items')`, `ScrollController`, `_isMoreLoading` 등)을 모두 제거
-- 홈은 `ValueListenableBuilder<List<ConsumableItem>>`로 `ItemStore` 구독 → AddItem/ItemDetail과 동일한 단일 소스
-- 결과: 직접 등록 직후 홈에 즉시 반영. 이전에는 홈만 stale.
+- **이유**: 기존 홈은 무한 스크롤로 전체 품목을 보여줘 정보 위계가 평평했음. "오늘 챙겨야 할 것"에 집중하는 다이제스트로 재정리.
+- **변경 위치**: `lib/screens/home_screen.dart`
+- **변경 내용**:
+  - 자체 `_supabase.from('product_items')` 페이지네이션 + `ScrollController` + `_isMoreLoading` 로직 제거
+  - `ValueListenableBuilder<ItemStore>` 구독으로 교체 → AddItem/Detail 결과가 즉시 홈에 반영
+  - 빌드 트리: 인사말 → 히어로 카드(가장 시급, 카운트다운 링) → AI 인사이트 → 다가오는 교체 4건 → 최근 기록
+  - 전체 품목 리스트는 `모든 제품` 탭이 담당
 
-### 3. `스캔` 탭 → `모든 제품` 탭, 스캔은 FAB 액션 시트로
+### 3. 테마 팔레트: 쿨 teal → 따뜻한 뉴트럴
 
-5탭 중 `스캔`은 진입 빈도가 낮은 모달성 작업이라 탭 슬롯을 차지하기엔 비효율. 디자인은 이 자리를 `모든 제품`으로 바꾸고, FAB을 누르면 *카메라 스캔* / *직접 등록* 두 가지가 떠오르는 액션 시트로 통합.
+- **이유**: 디자인 핸드오프가 따뜻한 톤(아이보리·테라코타·세이지). 식별자를 그대로 두면 팀원 코드 한 줄도 안 건드리고 자동 적용 가능.
+- **변경 위치**: `lib/theme/app_theme.dart`
+- **변경 내용**:
+  - `AppColors` 19개 토큰의 *값*만 교체. *이름*은 유지 (`primary`, `background`, `success` 등)
+  - `primary`: cyan `#0891B2` → terracotta `#C25A4A`
+  - `background`: 쿨 그레이 `#F7F6F3` → 아이보리 `#F7F2E9`
+  - D-day 4-tier 시각 구분 보존 위해 `danger`(`#B0392E`)와 `dangerLight`(`#EFC5B6`)는 `primary`/`primaryLight2`와 의도적으로 분리
+- **메모**: `primary`라는 이름이 더 이상 cyan이 아니라 terracotta가 된 점이 약간의 인지 부조화는 있지만, 이름을 바꾸면 모든 호출부를 건드려야 해서 비용 대비 손실이 더 컸음.
 
-기술적 결과:
-- `ScanScreen` 코드 자체는 한 줄도 안 바뀜 — `main.dart`에서만 라우팅이 바뀜
-- FAB이 홈/모든 제품 탭에서 노출
+### 4. 새 위젯 분리
 
-## 되돌리고 싶다면
+- **이유**: 디자인 신규 컴포넌트를 팀원 위젯에 끼워넣지 않고 별도 파일로 두면 PR diff에서 "새 파일이구나"로 즉시 인식됨.
+- **변경 위치**: `lib/widgets/home/` (신규 디렉토리)
+- **추가된 파일**:
+  - `home_hero_card.dart`: 카운트다운 링 + "가장 시급" 핀 + AI 예측% + 자세히/주문 버튼
+  - `upcoming_item_row.dart`: 36 px 아이콘 + 이름·주기 + D-day 배지의 컴팩트 행
 
-본 PR이 머지된 후 부분 롤백이 필요한 경우의 가이드입니다.
+### 5. 새 화면 `모든 제품`
 
-- **팔레트만 되돌리기**: `lib/theme/app_theme.dart`만 develop 시점으로 되돌립니다. `home_hero_card.dart`/`upcoming_item_row.dart`는 토큰 경유라 자동 적응합니다.
-- **홈 구조 되돌리기**: `lib/screens/home_screen.dart`을 되돌리고 `lib/widgets/home/` 디렉토리를 삭제합니다. `lib/main.dart`의 `MainNavigationState.switchTab` 호출이 사라지더라도 main.dart 자체는 그대로 둘 수 있습니다.
-- **탭 IA 되돌리기**: `lib/main.dart`만 되돌리면 `스캔` 탭이 복귀합니다. `lib/screens/items_screen.dart`는 import 사라지면 오펀이 되니 함께 정리하세요.
-- **전체 되돌리기**: `git revert`로 본 PR의 머지 커밋 한 개.
+- **이유**: 홈에서 빠진 전체 품목 리스트를 담을 곳이 필요. 필터 칩(전체/긴급/곧/여유)으로 정보 정리.
+- **변경 위치**: `lib/screens/items_screen.dart` (신규)
+- **변경 내용**:
+  - `ItemStore` 구독으로 전체 제품 표시
+  - 필터 칩 + 정렬(D-day 오름차순)
+  - 홈의 "모두 보기"에서 진입 가능
+
+### 6. `ItemStore` 롤백 + 에러 처리
+
+- **이유**: 기존 optimistic update가 Supabase 실패 시 롤백 없이 ghost item을 화면에 남겼음.
+- **변경 위치**: `lib/services/item_store.dart`, `lib/screens/item_detail_screen.dart`
+- **변경 내용**:
+  - `ItemStore.add/update/delete` 진입 시 이전 `value` 스냅샷 보관, Supabase 실패 catch에서 복원 후 rethrow
+  - `ItemDetailScreen._confirmDelete`에 try/catch + `SnackBar('삭제 실패...')` 추가 (rethrow 후속 처리)
+  - 회귀 보호용 단위 테스트 3건 신규 (`test/services/item_store_test.dart`)
+
+### 7. 탭 라벨: `내 아이템` → `홈`
+
+- **이유**: 첫 탭이 더 이상 "내 아이템 리스트"가 아닌 다이제스트라서 의미상 맞지 않음.
+- **변경 위치**: `lib/main.dart` 의 `_tabs[0]`, `test/widget_test.dart`
+- **변경 내용**: 라벨 문자열 + 위젯 테스트 검증 라벨 갱신
+
+### 8. 변경 사유 문서화
+
+- **이유**: 팀원 4명이 합쳐 작성한 코드 위에 진행되는 PR이라, 어디를 왜 건드렸는지 한눈에 보이게.
+- **변경 위치**: `docs/REDESIGN_NOTES.md` (신규, 이 문서)
+
+---
 
 ## 알려진 시각적 한계 (후속 폴리시 후보)
 
-리디자인 적용 후에도 남는 자잘한 시각 이슈를 팀 공통 인지로 남깁니다. 본 PR 범위에서는 의도적으로 손대지 않았습니다.
+리디자인 적용 후에도 남는 자잘한 시각 이슈. 본 PR 범위에서는 의도적으로 손대지 않음.
 
-- **D-day 배지 텍스트 대비**: warm 팔레트의 status fg/bg 페어(`success/successLight`, `warning/warningLight`, `primary/primaryLight2`)는 12 px 굵은 글자에서 WCAG AA(4.5:1)에 미달합니다. 디자인 핸드오프의 의도적 선택을 따랐고, 접근성 보강이 필요해지면 fg 토큰을 한 단계 어둡게 하거나 별도 `onPrimary/onSuccess` 토큰을 도입하는 follow-up이 자연스럽습니다.
-- **`lib/widgets/reports/category_pie_chart.dart` 카테고리 색**: 파일 내부에 cool 톤 hex가 하드코딩되어 있어 새 팔레트와 톤이 어긋나 보일 수 있습니다. 팀원 작성 코드라 이번 PR에서는 보존했습니다.
-- **`lib/data/sample_data.dart`의 멤버 아바타 색**: 4명 그룹 멤버 아바타 색이 hex 문자열로 박혀 있어 warm 팔레트와 무관하게 표시됩니다. 동일한 이유로 보존했습니다.
-- **`lib/screens/scan_screen.dart`의 뷰파인더 슬레이트(`0xFF1E293B`)**: 카메라 오버레이용 어두운 배경. 카메라 chrome 톤은 디자인 변경 범위 밖이라 그대로 둡니다.
+- **D-day 배지 텍스트 대비**: warm 팔레트의 status fg/bg 페어(`success/successLight`, `warning/warningLight`, `primary/primaryLight2`)는 12 px 굵은 글자에서 WCAG AA(4.5:1)에 미달. 디자인 핸드오프의 의도적 선택을 따름. 접근성 보강이 필요해지면 fg 토큰을 한 단계 어둡게 하거나 별도 `onPrimary/onSuccess` 토큰을 도입하는 follow-up.
+- **`lib/widgets/reports/category_pie_chart.dart` 카테고리 색**: 파일 내부에 cool 톤 hex가 하드코딩되어 있어 새 팔레트와 톤이 어긋나 보일 수 있음. 팀원 작성 코드라 이번 PR에서는 보존.
+- **`lib/data/sample_data.dart`의 멤버 아바타 색**: 4명 그룹 멤버 아바타 색이 hex 문자열로 박혀 있어 warm 팔레트와 무관하게 표시. 동일한 이유로 보존.
+- **`lib/screens/scan_screen.dart`의 뷰파인더 슬레이트(`0xFF1E293B`)**: 카메라 오버레이용 어두운 배경. 카메라 chrome 톤은 디자인 변경 범위 밖.
 
-위 항목 중 하나라도 폴리시가 필요하다고 판단되면 별도 PR로 진행해주세요.
+---
+
+## 되돌리고 싶다면
+
+본 PR이 머지된 후 부분 롤백이 필요한 경우의 가이드.
+
+- **팔레트만 되돌리기**: `lib/theme/app_theme.dart`만 develop 시점으로 되돌리면 끝. `home_hero_card.dart`/`upcoming_item_row.dart`는 토큰 경유라 자동 적응.
+- **홈 구조 되돌리기**: `lib/screens/home_screen.dart`을 되돌리고 `lib/widgets/home/` 디렉토리를 삭제. `lib/main.dart`의 `MainNavigationState.switchTab` 호출이 사라지더라도 main.dart 자체는 그대로 둘 수 있음.
+- **탭 IA 되돌리기**: `lib/main.dart`만 되돌리면 `스캔` 탭이 복귀. `lib/screens/items_screen.dart`는 import 사라지면 오펀이 되니 함께 정리.
+- **전체 되돌리기**: `git revert`로 본 PR의 머지 커밋 한 개.
+
+---
 
 ## 관련 커밋
 
@@ -98,3 +142,5 @@
 | `46db1ac` | home/main: 리뷰 반영 (exhaustive switch, userName dedup) |
 | `6aad00f` | home: `upcoming` 비었을 때 '다가오는 교체' 섹션 숨김 |
 | `ea97dbe` | test/widget: 탭 라벨 검증 갱신 |
+| `84636c0` | docs: REDESIGN_NOTES SHA 백필 |
+| `617a844` | chore: dart format 적용 |

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,13 +83,13 @@ class MainNavigationState extends State<MainNavigation> {
   }
 
   Widget _screenAt(int index) => switch (index) {
-        0 => const HomeScreen(),
-        1 => const GroupScreen(),
-        2 => const ItemsScreen(),
-        3 => const ReportsScreen(),
-        4 => const SettingsScreen(),
-        _ => throw StateError('No screen registered for tab $index'),
-      };
+    0 => const HomeScreen(),
+    1 => const GroupScreen(),
+    2 => const ItemsScreen(),
+    3 => const ReportsScreen(),
+    4 => const SettingsScreen(),
+    _ => throw StateError('No screen registered for tab $index'),
+  };
 
   Future<void> _openAddSheet() async {
     final choice = await showModalBottomSheet<_AddChoice>(
@@ -130,9 +130,9 @@ class MainNavigationState extends State<MainNavigation> {
           ),
         );
       case _AddChoice.manual:
-        Navigator.of(context).push(
-          MaterialPageRoute(builder: (_) => const AddItemScreen()),
-        );
+        Navigator.of(
+          context,
+        ).push(MaterialPageRoute(builder: (_) => const AddItemScreen()));
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'theme/app_theme.dart';
 import 'screens/home_screen.dart';
 import 'screens/group_screen.dart';
+import 'screens/items_screen.dart';
 import 'screens/scan_screen.dart';
 import 'screens/reports_screen.dart';
 import 'screens/settings_screen.dart';
@@ -56,39 +57,109 @@ class MainNavigation extends StatefulWidget {
   const MainNavigation({super.key});
 
   @override
-  State<MainNavigation> createState() => _MainNavigationState();
+  State<MainNavigation> createState() => MainNavigationState();
 }
 
-class _MainNavigationState extends State<MainNavigation> {
+/// 하단 탭 셸. 자식 화면이 `findAncestorStateOfType<MainNavigationState>()`로
+/// 찾아서 `switchTab(...)`을 호출할 수 있도록 의도적으로 public 이다.
+class MainNavigationState extends State<MainNavigation> {
   int _currentIndex = 0;
 
-  final _screens = const [
-    HomeScreen(),
-    GroupScreen(),
-    ScanScreen(),
-    ReportsScreen(),
-    SettingsScreen(),
+  static const _tabs = <_TabSpec>[
+    _TabSpec('홈', Icons.home_outlined, Icons.home),
+    _TabSpec('그룹', Icons.group_outlined, Icons.group),
+    _TabSpec('모든 제품', Icons.list_alt_outlined, Icons.list_alt),
+    _TabSpec('리포트', Icons.bar_chart_outlined, Icons.bar_chart),
+    _TabSpec('설정', Icons.settings_outlined, Icons.settings),
   ];
 
-  void _openAddItem() {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => const AddItemScreen()),
+  /// 자식 화면이 탭 인덱스를 강제 전환할 때 사용한다 (예: 홈의 "모두 보기").
+  void switchTab(int index) {
+    if (index < 0 || index >= _tabs.length) return;
+    setState(() => _currentIndex = index);
+  }
+
+  Widget _screenAt(int index) {
+    switch (index) {
+      case 0:
+        return const HomeScreen();
+      case 1:
+        return const GroupScreen();
+      case 2:
+        return const ItemsScreen();
+      case 3:
+        return const ReportsScreen();
+      case 4:
+        return const SettingsScreen();
+    }
+    return const HomeScreen();
+  }
+
+  Future<void> _openAddSheet() async {
+    final choice = await showModalBottomSheet<_AddChoice>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      barrierColor: Colors.black.withValues(alpha: 0.45),
+      builder: (_) => const _AddActionSheet(),
     );
+    if (!mounted || choice == null) return;
+    switch (choice) {
+      case _AddChoice.scan:
+        // ScanScreen 코드는 변경하지 않음. 자체 헤더가 있으니 AppBar 없이
+        // 그대로 push하고 floating close 버튼만 얹는다.
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (ctx) => Scaffold(
+              backgroundColor: AppColors.background,
+              body: Stack(
+                children: [
+                  const ScanScreen(),
+                  Positioned(
+                    top: MediaQuery.of(ctx).padding.top + 8,
+                    right: 12,
+                    child: Material(
+                      color: AppColors.surface,
+                      shape: const CircleBorder(),
+                      elevation: 1,
+                      child: IconButton(
+                        icon: const Icon(Icons.close, size: 18),
+                        color: AppColors.text,
+                        onPressed: () => Navigator.of(ctx).pop(),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      case _AddChoice.manual:
+        Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const AddItemScreen()),
+        );
+    }
   }
 
   @override
   Widget build(BuildContext context) {
+    final showFab = _currentIndex == 0 || _currentIndex == 2;
+
     return Scaffold(
-      body: IndexedStack(index: _currentIndex, children: _screens),
-      // 홈 탭에서만 FAB 표시
-      floatingActionButton: _currentIndex == 0
+      body: IndexedStack(
+        index: _currentIndex,
+        children: [for (var i = 0; i < _tabs.length; i++) _screenAt(i)],
+      ),
+      floatingActionButton: showFab
           ? FloatingActionButton(
-              onPressed: _openAddItem,
-              backgroundColor: AppColors.primary,
+              onPressed: _openAddSheet,
+              backgroundColor: AppColors.success,
               foregroundColor: Colors.white,
-              tooltip: '제품 직접 등록',
-              child: const Icon(Icons.add),
+              elevation: 6,
+              tooltip: '제품 추가',
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(18),
+              ),
+              child: const Icon(Icons.add, size: 26),
             )
           : null,
       bottomNavigationBar: Container(
@@ -98,34 +169,158 @@ class _MainNavigationState extends State<MainNavigation> {
         ),
         child: BottomNavigationBar(
           currentIndex: _currentIndex,
-          onTap: (index) => setState(() => _currentIndex = index),
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.home_outlined),
-              activeIcon: Icon(Icons.home),
-              label: '내 아이템',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.group_outlined),
-              activeIcon: Icon(Icons.group),
-              label: '그룹',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.document_scanner_outlined),
-              activeIcon: Icon(Icons.document_scanner),
-              label: '스캔',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.bar_chart_outlined),
-              activeIcon: Icon(Icons.bar_chart),
-              label: '리포트',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.settings_outlined),
-              activeIcon: Icon(Icons.settings),
-              label: '설정',
-            ),
+          onTap: switchTab,
+          items: [
+            for (final t in _tabs)
+              BottomNavigationBarItem(
+                icon: Icon(t.icon),
+                activeIcon: Icon(t.activeIcon),
+                label: t.label,
+              ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TabSpec {
+  const _TabSpec(this.label, this.icon, this.activeIcon);
+  final String label;
+  final IconData icon;
+  final IconData activeIcon;
+}
+
+enum _AddChoice { scan, manual }
+
+class _AddActionSheet extends StatelessWidget {
+  const _AddActionSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Container(
+              alignment: Alignment.center,
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppColors.border,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const _SheetAction(
+              choice: _AddChoice.scan,
+              icon: Icons.photo_camera_outlined,
+              accent: AppColors.primary,
+              title: '카메라 스캔',
+              sub: '영수증·라벨을 찍으면 자동 인식',
+            ),
+            const SizedBox(height: 10),
+            const _SheetAction(
+              choice: _AddChoice.manual,
+              icon: Icons.edit_outlined,
+              accent: AppColors.textSecondary,
+              title: '직접 등록',
+              sub: '이름·주기를 직접 입력',
+            ),
+            const SizedBox(height: 4),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetAction extends StatelessWidget {
+  const _SheetAction({
+    required this.choice,
+    required this.icon,
+    required this.accent,
+    required this.title,
+    required this.sub,
+  });
+
+  final _AddChoice choice;
+  final IconData icon;
+  final Color accent;
+  final String title;
+  final String sub;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(14),
+        onTap: () => Navigator.of(context).pop(choice),
+        child: Ink(
+          padding: const EdgeInsets.fromLTRB(12, 12, 14, 12),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: AppColors.border, width: 0.5),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.08),
+                blurRadius: 24,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 38,
+                height: 38,
+                decoration: BoxDecoration(
+                  color: accent,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(icon, color: Colors.white, size: 20),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: const TextStyle(
+                        fontSize: 14.5,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.text,
+                        letterSpacing: -0.1,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      sub,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: AppColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                size: 18,
+                color: AppColors.textMuted,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -65,6 +65,9 @@ class MainNavigation extends StatefulWidget {
 class MainNavigationState extends State<MainNavigation> {
   int _currentIndex = 0;
 
+  /// 자식 화면이 탭 전환 시 참조할 수 있도록 노출하는 인덱스 상수.
+  static const int kItemsTabIndex = 2;
+
   static const _tabs = <_TabSpec>[
     _TabSpec('홈', Icons.home_outlined, Icons.home),
     _TabSpec('그룹', Icons.group_outlined, Icons.group),
@@ -79,21 +82,14 @@ class MainNavigationState extends State<MainNavigation> {
     setState(() => _currentIndex = index);
   }
 
-  Widget _screenAt(int index) {
-    switch (index) {
-      case 0:
-        return const HomeScreen();
-      case 1:
-        return const GroupScreen();
-      case 2:
-        return const ItemsScreen();
-      case 3:
-        return const ReportsScreen();
-      case 4:
-        return const SettingsScreen();
-    }
-    return const HomeScreen();
-  }
+  Widget _screenAt(int index) => switch (index) {
+        0 => const HomeScreen(),
+        1 => const GroupScreen(),
+        2 => const ItemsScreen(),
+        3 => const ReportsScreen(),
+        4 => const SettingsScreen(),
+        _ => throw StateError('No screen registered for tab $index'),
+      };
 
   Future<void> _openAddSheet() async {
     final choice = await showModalBottomSheet<_AddChoice>(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -30,8 +30,9 @@ class _HomeScreenState extends State<HomeScreen> {
   void _goToItemsTab() {
     final root = context.findAncestorStateOfType<MainNavigationState>();
     if (root != null) {
-      root.switchTab(2);
+      root.switchTab(MainNavigationState.kItemsTabIndex);
     } else {
+      // 위젯 테스트나 MainNavigation 외부 컨텍스트 폴백.
       Navigator.of(context).push(
         MaterialPageRoute(builder: (_) => const ItemsScreen(showBack: true)),
       );
@@ -59,7 +60,7 @@ class _HomeScreenState extends State<HomeScreen> {
         valueListenable: ItemStore.instance,
         builder: (context, items, _) {
           if (items.isEmpty) {
-            return _EmptyHome(onAdd: _goToItemsTab);
+            return _EmptyHome(onAdd: _goToItemsTab, userName: _userName);
           }
 
           final sorted = List.of(items)
@@ -130,6 +131,8 @@ class _HomeScreenState extends State<HomeScreen> {
               const SliverToBoxAdapter(
                 child: _SectionHeader(title: '최근 기록'),
               ),
+              // TODO: 디자인 프로토타입 mock. 실제 활동 로그(ItemStore 변경
+              // 이력 등) 연결 시 교체.
               const SliverPadding(
                 padding: EdgeInsets.fromLTRB(20, 10, 20, 8),
                 sliver: SliverToBoxAdapter(
@@ -263,6 +266,8 @@ class _AiInsightCard extends StatelessWidget {
                     ),
                   ),
                   SizedBox(height: 3),
+                  // TODO: 디자인 프로토타입 mock 카피. 실제 AI 인사이트
+                  // 데이터 소스 연결 시 교체.
                   Text(
                     '평균 90일 주기지만 최근엔 85일에 교체하셨어요. 4개월 전보다 사용량이 6% 늘었어요.',
                     style: TextStyle(
@@ -353,9 +358,10 @@ class _LedgerRow extends StatelessWidget {
 }
 
 class _EmptyHome extends StatelessWidget {
-  const _EmptyHome({required this.onAdd});
+  const _EmptyHome({required this.onAdd, required this.userName});
 
   final VoidCallback onAdd;
+  final String userName;
 
   @override
   Widget build(BuildContext context) {
@@ -364,11 +370,11 @@ class _EmptyHome extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const Padding(
-            padding: EdgeInsets.fromLTRB(0, 8, 0, 0),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
             child: Text(
-              '안녕하세요, 지민님',
-              style: TextStyle(
+              '안녕하세요, $userName님',
+              style: const TextStyle(
                 fontSize: 22,
                 fontWeight: FontWeight.w700,
                 color: AppColors.text,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -67,8 +67,7 @@ class _HomeScreenState extends State<HomeScreen> {
             ..sort((a, b) => a.daysRemaining.compareTo(b.daysRemaining));
           final hero = sorted.first;
           final upcoming = sorted.skip(1).take(4).toList();
-          final weekCount =
-              items.where((i) => i.daysRemaining <= 7).length;
+          final weekCount = items.where((i) => i.daysRemaining <= 7).length;
 
           return CustomScrollView(
             slivers: [
@@ -80,10 +79,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
               SliverToBoxAdapter(
-                child: HomeHeroCard(
-                  item: hero,
-                  onTap: () => _openDetail(hero),
-                ),
+                child: HomeHeroCard(item: hero, onTap: () => _openDetail(hero)),
               ),
               const SliverToBoxAdapter(child: _AiInsightCard()),
               if (upcoming.isNotEmpty) ...[
@@ -127,9 +123,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   ),
                 ),
               ],
-              const SliverToBoxAdapter(
-                child: _SectionHeader(title: '최근 기록'),
-              ),
+              const SliverToBoxAdapter(child: _SectionHeader(title: '최근 기록')),
               // TODO: 디자인 프로토타입 mock. 실제 활동 로그(ItemStore 변경
               // 이력 등) 연결 시 교체.
               const SliverPadding(
@@ -137,15 +131,9 @@ class _HomeScreenState extends State<HomeScreen> {
                 sliver: SliverToBoxAdapter(
                   child: Column(
                     children: [
-                      _LedgerRow(
-                        time: '오늘 14:22',
-                        text: '이마트 영수증 3개 항목 자동 추가',
-                      ),
+                      _LedgerRow(time: '오늘 14:22', text: '이마트 영수증 3개 항목 자동 추가'),
                       _LedgerRow(time: '04.18', text: '치약 구매 기록됨'),
-                      _LedgerRow(
-                        time: '04.01',
-                        text: '세탁세제 주기 45일로 업데이트',
-                      ),
+                      _LedgerRow(time: '04.01', text: '세탁세제 주기 45일로 업데이트'),
                     ],
                   ),
                 ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -86,37 +86,35 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
               const SliverToBoxAdapter(child: _AiInsightCard()),
-              SliverToBoxAdapter(
-                child: _SectionHeader(
-                  title: '다가오는 교체',
-                  trailing: TextButton(
-                    onPressed: _goToItemsTab,
-                    style: TextButton.styleFrom(
-                      foregroundColor: AppColors.primary,
-                      padding: const EdgeInsets.symmetric(horizontal: 4),
-                      minimumSize: const Size(0, 0),
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                    child: const Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          '모두 보기',
-                          style: TextStyle(
-                            fontSize: 12,
-                            fontWeight: FontWeight.w600,
+              if (upcoming.isNotEmpty) ...[
+                SliverToBoxAdapter(
+                  child: _SectionHeader(
+                    title: '다가오는 교체',
+                    trailing: TextButton(
+                      onPressed: _goToItemsTab,
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppColors.primary,
+                        padding: const EdgeInsets.symmetric(horizontal: 4),
+                        minimumSize: const Size(0, 0),
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            '모두 보기',
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
                           ),
-                        ),
-                        SizedBox(width: 2),
-                        Icon(Icons.chevron_right, size: 14),
-                      ],
+                          SizedBox(width: 2),
+                          Icon(Icons.chevron_right, size: 14),
+                        ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-              if (upcoming.isEmpty)
-                const SliverToBoxAdapter(child: SizedBox.shrink())
-              else
                 SliverPadding(
                   padding: const EdgeInsets.fromLTRB(20, 12, 20, 8),
                   sliver: SliverList.separated(
@@ -128,6 +126,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     ),
                   ),
                 ),
+              ],
               const SliverToBoxAdapter(
                 child: _SectionHeader(title: '최근 기록'),
               ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,10 +1,22 @@
 import 'package:flutter/material.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
-import '../theme/app_theme.dart';
-import '../widgets/item_card.dart';
+import '../main.dart';
 import '../models/item.dart';
+import '../services/item_store.dart';
+import '../theme/app_theme.dart';
+import '../widgets/home/home_hero_card.dart';
+import '../widgets/home/upcoming_item_row.dart';
 import 'item_detail_screen.dart';
+import 'items_screen.dart';
 
+/// 홈 — 큐레이팅 다이제스트.
+///
+/// 인사말 → 히어로 카드(가장 시급) → AI 인사이트 → 다가오는 교체 4건 →
+/// 최근 기록. 전체 품목 목록은 `모든 제품` 탭이 담당.
+///
+/// 데이터는 `ItemStore` 단일 소스 구독. `AddItemScreen`/`ItemDetailScreen`
+/// 의 add/update/delete가 이 화면에 즉시 반영된다.
+///
+/// 디자인/의사결정 사유: `docs/REDESIGN_NOTES.md`
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
@@ -13,218 +25,404 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  final _supabase = Supabase.instance.client;
+  static const _userName = '지민';
 
-  // 인피니티 스크롤 전용 컨트롤 및 변수
-  final ScrollController _scrollController = ScrollController();
-  List<ConsumableItem> _items = [];
-  bool _isLoading = true; // 첫 로딩 상태
-  bool _isMoreLoading = false; // 추가 페이지 로딩 상태
-  bool _hasNextPage = true; // 더 가져올 데이터가 있는지 여부
-  int _currentPage = 0; // 현재 페이지 번호
-  final int _pageSize = 10; // 한 번에 가져올 아이템 수
-
-  @override
-  void initState() {
-    super.initState();
-    _fetchDbData(isInitial: true);
-
-    // 스크롤 리스너 등록: 사용자가 끝까지 내렸는지 확인
-    _scrollController.addListener(() {
-      if (_scrollController.position.pixels >=
-              _scrollController.position.maxScrollExtent * 0.9 &&
-          !_isMoreLoading &&
-          _hasNextPage) {
-        _fetchDbData(); // 다음 페이지 호출
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _scrollController.dispose(); // 메모리 누수 방지
-    super.dispose();
-  }
-
-  // Supabase 페이지네이션 쿼리 함수
-  Future<void> _fetchDbData({bool isInitial = false}) async {
-    if (isInitial) {
-      setState(() {
-        _isLoading = true;
-        _currentPage = 0;
-        _hasNextPage = true;
-        _items = [];
-      });
+  void _goToItemsTab() {
+    final root = context.findAncestorStateOfType<MainNavigationState>();
+    if (root != null) {
+      root.switchTab(2);
     } else {
-      setState(() => _isMoreLoading = true);
+      Navigator.of(context).push(
+        MaterialPageRoute(builder: (_) => const ItemsScreen(showBack: true)),
+      );
     }
+  }
 
-    try {
-      // 시작 지점(from)과 끝 지점(to) 계산
-      final from = _currentPage * _pageSize;
-      final to = from + _pageSize - 1;
+  void _openDetail(ConsumableItem item) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => ItemDetailScreen(item: item)),
+    );
+  }
 
-      final response = await _supabase
-          .from('product_items')
-          .select('*, purchases(*)')
-          .order('created_at', ascending: false)
-          .range(from, to);
-
-      final List<dynamic> data = response;
-      final newItems = data
-          .map((json) => ConsumableItem.fromJson(json))
-          .toList();
-
-      setState(() {
-        _items.addAll(newItems);
-        _isLoading = false;
-        _isMoreLoading = false;
-
-        // 가져온 데이터가 요청한 개수보다 적으면 '마지막 페이지'로 간주
-        if (newItems.length < _pageSize) {
-          _hasNextPage = false;
-        } else {
-          _currentPage++;
-        }
-      });
-    } catch (e) {
-      debugPrint('데이터 로딩 에러: $e');
-      setState(() {
-        _isLoading = false;
-        _isMoreLoading = false;
-      });
-    }
+  String _formattedDate() {
+    const weekdays = ['월요일', '화요일', '수요일', '목요일', '금요일', '토요일', '일요일'];
+    final now = DateTime.now();
+    final wd = weekdays[(now.weekday - 1).clamp(0, 6)];
+    return '${now.year}년 ${now.month}월 ${now.day}일 $wd';
   }
 
   @override
   Widget build(BuildContext context) {
-    // D-Day 순 정렬
-    final upcoming = List.of(_items)
-      ..sort((a, b) => a.daysRemaining.compareTo(b.daysRemaining));
-
     return SafeArea(
-      child: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : CustomScrollView(
-              controller: _scrollController, // 컨트롤러 연결
-              slivers: [
-                SliverToBoxAdapter(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '안녕하세요, 사용자님',
-                          style: Theme.of(context).textTheme.headlineMedium,
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          '오늘도 스마트한 소비 관리를 시작해볼까요?',
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
+      child: ValueListenableBuilder<List<ConsumableItem>>(
+        valueListenable: ItemStore.instance,
+        builder: (context, items, _) {
+          if (items.isEmpty) {
+            return _EmptyHome(onAdd: _goToItemsTab);
+          }
 
-                SliverToBoxAdapter(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 28, 20, 14),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          final sorted = List.of(items)
+            ..sort((a, b) => a.daysRemaining.compareTo(b.daysRemaining));
+          final hero = sorted.first;
+          final upcoming = sorted.skip(1).take(4).toList();
+          final weekCount =
+              items.where((i) => i.daysRemaining <= 7).length;
+
+          return CustomScrollView(
+            slivers: [
+              SliverToBoxAdapter(
+                child: _Greeting(
+                  date: _formattedDate(),
+                  name: _userName,
+                  weekCount: weekCount,
+                ),
+              ),
+              SliverToBoxAdapter(
+                child: HomeHeroCard(
+                  item: hero,
+                  onTap: () => _openDetail(hero),
+                ),
+              ),
+              const SliverToBoxAdapter(child: _AiInsightCard()),
+              SliverToBoxAdapter(
+                child: _SectionHeader(
+                  title: '다가오는 교체',
+                  trailing: TextButton(
+                    onPressed: _goToItemsTab,
+                    style: TextButton.styleFrom(
+                      foregroundColor: AppColors.primary,
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                      minimumSize: const Size(0, 0),
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: const Row(
+                      mainAxisSize: MainAxisSize.min,
                       children: [
                         Text(
-                          '교체 임박',
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                        Text(
-                          '${upcoming.where((i) => i.daysRemaining <= 14).length}개',
-                          style: const TextStyle(
-                            fontSize: 14,
+                          '모두 보기',
+                          style: TextStyle(
+                            fontSize: 12,
                             fontWeight: FontWeight.w600,
-                            color: AppColors.primary,
                           ),
                         ),
+                        SizedBox(width: 2),
+                        Icon(Icons.chevron_right, size: 14),
                       ],
                     ),
                   ),
                 ),
-                SliverToBoxAdapter(
-                  child: SizedBox(
-                    height: 185,
-                    child: upcoming.isEmpty
-                        ? const Center(child: Text('등록된 아이템이 없습니다.'))
-                        : ListView.separated(
-                            scrollDirection: Axis.horizontal,
-                            padding: const EdgeInsets.symmetric(horizontal: 20),
-                            itemCount: upcoming.length,
-                            separatorBuilder: (_, __) =>
-                                const SizedBox(width: 12),
-                            itemBuilder: (context, index) => ItemCard(
-                              item: upcoming[index],
-                              onTap: () => Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (_) =>
-                                      ItemDetailScreen(item: upcoming[index]),
-                                ),
-                              ),
-                            ),
-                          ),
-                  ),
-                ),
-
-                // 최근 구매 리스트 영역
-                SliverToBoxAdapter(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 28, 20, 14),
-                    child: Text(
-                      '전체 품목 리스트',
-                      style: Theme.of(context).textTheme.titleLarge,
-                    ), // 인피니트 스크롤 확인을 위해 전체 리스트로 표시
-                  ),
-                ),
-
-                _items.isEmpty
-                    ? const SliverToBoxAdapter(
-                        child: Center(child: Text('내역이 없습니다.')),
-                      )
-                    : SliverPadding(
-                        padding: const EdgeInsets.symmetric(horizontal: 20),
-                        sliver: SliverList.separated(
-                          itemCount: _items.length,
-                          separatorBuilder: (_, __) =>
-                              const SizedBox(height: 10),
-                          itemBuilder: (context, index) {
-                            final item = _items[index];
-                            return PurchaseListItem(
-                              // 리스트 형태의 아이템 위젯
-                              item: item,
-                              onTap: () => Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (_) => ItemDetailScreen(item: item),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-
-                // 스크롤 하단 로딩 인디케이터
-                if (_isMoreLoading)
-                  const SliverToBoxAdapter(
-                    child: Padding(
-                      padding: EdgeInsets.symmetric(vertical: 20),
-                      child: Center(child: CircularProgressIndicator()),
+              ),
+              if (upcoming.isEmpty)
+                const SliverToBoxAdapter(child: SizedBox.shrink())
+              else
+                SliverPadding(
+                  padding: const EdgeInsets.fromLTRB(20, 12, 20, 8),
+                  sliver: SliverList.separated(
+                    itemCount: upcoming.length,
+                    separatorBuilder: (_, _) => const SizedBox(height: 8),
+                    itemBuilder: (context, index) => UpcomingItemRow(
+                      item: upcoming[index],
+                      onTap: () => _openDetail(upcoming[index]),
                     ),
                   ),
+                ),
+              const SliverToBoxAdapter(
+                child: _SectionHeader(title: '최근 기록'),
+              ),
+              const SliverPadding(
+                padding: EdgeInsets.fromLTRB(20, 10, 20, 8),
+                sliver: SliverToBoxAdapter(
+                  child: Column(
+                    children: [
+                      _LedgerRow(
+                        time: '오늘 14:22',
+                        text: '이마트 영수증 3개 항목 자동 추가',
+                      ),
+                      _LedgerRow(time: '04.18', text: '치약 구매 기록됨'),
+                      _LedgerRow(
+                        time: '04.01',
+                        text: '세탁세제 주기 45일로 업데이트',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SliverToBoxAdapter(child: SizedBox(height: 28)),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
 
-                // 마지막 여백
-                const SliverToBoxAdapter(child: SizedBox(height: 50)),
+class _Greeting extends StatelessWidget {
+  const _Greeting({
+    required this.date,
+    required this.name,
+    required this.weekCount,
+  });
+
+  final String date;
+  final String name;
+  final int weekCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            date,
+            style: const TextStyle(fontSize: 12, color: AppColors.textMuted),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '안녕하세요, $name님',
+            style: const TextStyle(
+              fontSize: 26,
+              fontWeight: FontWeight.w700,
+              color: AppColors.text,
+              letterSpacing: -0.7,
+            ),
+          ),
+          const SizedBox(height: 4),
+          RichText(
+            text: TextSpan(
+              style: const TextStyle(
+                fontSize: 14,
+                color: AppColors.textSecondary,
+              ),
+              children: [
+                const TextSpan(text: '이번 주 교체 예정인 소모품 '),
+                TextSpan(
+                  text: '$weekCount개',
+                  style: const TextStyle(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const TextSpan(text: '가 있어요'),
               ],
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AiInsightCard extends StatelessWidget {
+  const _AiInsightCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.successLight,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: AppColors.success.withValues(alpha: 0.18),
+            width: 0.5,
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: AppColors.success,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Icon(
+                Icons.auto_awesome,
+                size: 14,
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(width: 10),
+            const Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'AI 인사이트',
+                    style: TextStyle(
+                      fontSize: 12.5,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.success,
+                      letterSpacing: -0.1,
+                    ),
+                  ),
+                  SizedBox(height: 3),
+                  Text(
+                    '평균 90일 주기지만 최근엔 85일에 교체하셨어요. 4개월 전보다 사용량이 6% 늘었어요.',
+                    style: TextStyle(
+                      fontSize: 12.5,
+                      height: 1.5,
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title, this.trailing});
+
+  final String title;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              style: const TextStyle(
+                fontSize: 17,
+                fontWeight: FontWeight.w700,
+                color: AppColors.text,
+                letterSpacing: -0.4,
+              ),
+            ),
+          ),
+          ?trailing,
+        ],
+      ),
+    );
+  }
+}
+
+class _LedgerRow extends StatelessWidget {
+  const _LedgerRow({required this.time, required this.text});
+
+  final String time;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 64,
+            child: Text(
+              time,
+              style: const TextStyle(
+                fontSize: 11,
+                color: AppColors.textMuted,
+                fontFeatures: [FontFeature.tabularFigures()],
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.text,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyHome extends StatelessWidget {
+  const _EmptyHome({required this.onAdd});
+
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(28),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Padding(
+            padding: EdgeInsets.fromLTRB(0, 8, 0, 0),
+            child: Text(
+              '안녕하세요, 지민님',
+              style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.w700,
+                color: AppColors.text,
+                letterSpacing: -0.6,
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            '아직 등록된 아이템이 없어요',
+            style: TextStyle(fontSize: 14, color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 32),
+          GestureDetector(
+            onTap: onAdd,
+            child: Container(
+              padding: const EdgeInsets.all(28),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(color: AppColors.border, width: 1),
+              ),
+              child: const Column(
+                children: [
+                  Icon(
+                    Icons.receipt_long_outlined,
+                    size: 38,
+                    color: AppColors.textMuted,
+                  ),
+                  SizedBox(height: 12),
+                  Text(
+                    '영수증 한 장으로 시작하세요',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.text,
+                    ),
+                  ),
+                  SizedBox(height: 4),
+                  Text(
+                    '하단 + 버튼으로 카메라 스캔이나 직접 등록을 시작할 수 있어요',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontSize: 12.5,
+                      color: AppColors.textMuted,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -71,8 +71,20 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
     );
 
     if (confirmed == true) {
-      await ItemStore.instance.delete(_item.id);
-      // _onStoreChanged가 자동으로 pop 처리
+      try {
+        await ItemStore.instance.delete(_item.id);
+        // _onStoreChanged가 자동으로 pop 처리
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: const Text('제품을 삭제하지 못했어요. 잠시 후 다시 시도해주세요.'),
+              behavior: SnackBarBehavior.floating,
+              backgroundColor: AppColors.danger,
+            ),
+          );
+        }
+      }
     }
   }
 

--- a/lib/screens/items_screen.dart
+++ b/lib/screens/items_screen.dart
@@ -1,0 +1,339 @@
+import 'package:flutter/material.dart';
+import '../models/item.dart';
+import '../services/item_store.dart';
+import '../theme/app_theme.dart';
+import '../widgets/dday_badge.dart';
+import 'item_detail_screen.dart';
+
+/// "모든 제품" tab — full list with filter chips (전체 / 긴급 / 곧 / 여유).
+class ItemsScreen extends StatefulWidget {
+  const ItemsScreen({super.key, this.showBack = false});
+
+  /// When pushed on top of the stack (e.g. from home's "모두 보기"), show
+  /// a back button instead of the bare title block.
+  final bool showBack;
+
+  @override
+  State<ItemsScreen> createState() => _ItemsScreenState();
+}
+
+enum _Filter { all, urgent, soon, fresh }
+
+class _ItemsScreenState extends State<ItemsScreen> {
+  _Filter _filter = _Filter.all;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: widget.showBack
+          ? AppBar(
+              backgroundColor: AppColors.background,
+              elevation: 0,
+              scrolledUnderElevation: 0,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back_ios_new, size: 18),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              title: const Text('모든 제품'),
+            )
+          : null,
+      body: SafeArea(
+        top: !widget.showBack,
+        child: ValueListenableBuilder<List<ConsumableItem>>(
+          valueListenable: ItemStore.instance,
+          builder: (context, items, _) {
+            final counts = _counts(items);
+            final filtered = _applyFilter(items)
+              ..sort((a, b) => a.daysRemaining.compareTo(b.daysRemaining));
+
+            return CustomScrollView(
+              slivers: [
+                if (!widget.showBack)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 8, 20, 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '모든 제품',
+                            style: Theme.of(context).textTheme.headlineLarge,
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            '전체 ${items.length}개 · 이번 주 교체 ${counts[_Filter.urgent]}개',
+                            style: const TextStyle(
+                              fontSize: 13,
+                              color: AppColors.textMuted,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+                    child: Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        for (final f in _Filter.values)
+                          _FilterChip(
+                            label: _labelOf(f),
+                            count: counts[f] ?? 0,
+                            active: _filter == f,
+                            onTap: () => setState(() => _filter = f),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+                if (filtered.isEmpty)
+                  const SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: _EmptyView(),
+                  )
+                else
+                  SliverPadding(
+                    padding: const EdgeInsets.fromLTRB(20, 4, 20, 28),
+                    sliver: SliverList.separated(
+                      itemCount: filtered.length,
+                      separatorBuilder: (_, _) => const SizedBox(height: 8),
+                      itemBuilder: (context, index) =>
+                          ItemRow(item: filtered[index]),
+                    ),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Map<_Filter, int> _counts(List<ConsumableItem> items) => {
+    _Filter.all: items.length,
+    _Filter.urgent: items.where((i) => i.daysRemaining <= 7).length,
+    _Filter.soon: items
+        .where((i) => i.daysRemaining > 7 && i.daysRemaining <= 30)
+        .length,
+    _Filter.fresh: items.where((i) => i.daysRemaining > 30).length,
+  };
+
+  List<ConsumableItem> _applyFilter(List<ConsumableItem> items) =>
+      switch (_filter) {
+        _Filter.all => List.of(items),
+        _Filter.urgent => items.where((i) => i.daysRemaining <= 7).toList(),
+        _Filter.soon => items
+            .where((i) => i.daysRemaining > 7 && i.daysRemaining <= 30)
+            .toList(),
+        _Filter.fresh => items.where((i) => i.daysRemaining > 30).toList(),
+      };
+
+  String _labelOf(_Filter f) => switch (f) {
+    _Filter.all => '전체',
+    _Filter.urgent => '긴급',
+    _Filter.soon => '곧',
+    _Filter.fresh => '여유',
+  };
+}
+
+class _FilterChip extends StatelessWidget {
+  const _FilterChip({
+    required this.label,
+    required this.count,
+    required this.active,
+    required this.onTap,
+  });
+
+  final String label;
+  final int count;
+  final bool active;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: active ? AppColors.primary : AppColors.surface,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: active ? AppColors.primary : AppColors.border,
+            width: 0.5,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w600,
+                color: active ? Colors.white : AppColors.textSecondary,
+                letterSpacing: -0.1,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              '$count',
+              style: TextStyle(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w500,
+                color: (active ? Colors.white : AppColors.textSecondary)
+                    .withValues(alpha: 0.7),
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Compact item row used in the items list and "다가오는 교체" home section.
+class ItemRow extends StatelessWidget {
+  const ItemRow({
+    super.key,
+    required this.item,
+    this.dense = false,
+    this.onTap,
+  });
+
+  final ConsumableItem item;
+  final bool dense;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tile = dense ? 36.0 : 40.0;
+    final iconSize = dense ? 18.0 : 20.0;
+    final cyclePart = item.aiPredictedDays ?? item.cycleDays;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap:
+            onTap ??
+            () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => ItemDetailScreen(item: item)),
+            ),
+        child: Ink(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: AppColors.border, width: 0.5),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: tile,
+                height: tile,
+                decoration: BoxDecoration(
+                  color: AppColors.surfaceAlt,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  item.icon,
+                  size: iconSize,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.text,
+                        letterSpacing: -0.1,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '${item.brand} · 주기 $cyclePart일',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 11.5,
+                        color: AppColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              DdayBadge(daysRemaining: item.daysRemaining),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyView extends StatelessWidget {
+  const _EmptyView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(
+                  color: AppColors.border,
+                  width: 1,
+                  style: BorderStyle.solid,
+                ),
+              ),
+              child: const Icon(
+                Icons.inventory_2_outlined,
+                size: 30,
+                color: AppColors.textSoft,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              '해당 조건의 제품이 없어요',
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: FontWeight.w700,
+                color: AppColors.text,
+                letterSpacing: -0.2,
+              ),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              '필터를 바꾸거나 제품을 새로 추가해보세요',
+              style: TextStyle(fontSize: 13, color: AppColors.textMuted),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/items_screen.dart
+++ b/lib/screens/items_screen.dart
@@ -126,9 +126,10 @@ class _ItemsScreenState extends State<ItemsScreen> {
       switch (_filter) {
         _Filter.all => List.of(items),
         _Filter.urgent => items.where((i) => i.daysRemaining <= 7).toList(),
-        _Filter.soon => items
-            .where((i) => i.daysRemaining > 7 && i.daysRemaining <= 30)
-            .toList(),
+        _Filter.soon =>
+          items
+              .where((i) => i.daysRemaining > 7 && i.daysRemaining <= 30)
+              .toList(),
         _Filter.fresh => items.where((i) => i.daysRemaining > 30).toList(),
       };
 

--- a/lib/services/item_store.dart
+++ b/lib/services/item_store.dart
@@ -5,7 +5,8 @@ import 'supabase_service.dart';
 /// 제품 상태 저장소
 ///
 /// [ValueNotifier]를 상속하여 [ValueListenableBuilder]로 UI가 자동 갱신됩니다.
-/// add / update / delete는 로컬 상태를 즉시 반영한 뒤 Supabase에 비동기 동기화합니다.
+/// add / update / delete는 로컬 상태를 즉시 반영한 뒤 Supabase에 동기화합니다.
+/// Supabase가 실패하면 이전 상태로 롤백하고 예외를 호출자에게 rethrow 합니다.
 class ItemStore extends ValueNotifier<List<ConsumableItem>> {
   static final ItemStore instance = ItemStore._();
   ItemStore._() : super([]);
@@ -20,24 +21,42 @@ class ItemStore extends ValueNotifier<List<ConsumableItem>> {
     debugPrint('[ItemStore] 초기 로드 완료: ${value.length}개');
   }
 
-  /// 새 제품 추가 — 로컬 즉시 반영 후 Supabase 동기화
+  /// 새 제품 추가 — 로컬 즉시 반영 후 Supabase 동기화. 실패 시 롤백.
   Future<void> add(ConsumableItem item) async {
+    final previous = List<ConsumableItem>.unmodifiable(value);
     value = [...value, item];
-    await SupabaseService.saveItem(item);
+    try {
+      await SupabaseService.saveItem(item);
+    } catch (e) {
+      value = List.of(previous);
+      rethrow;
+    }
   }
 
-  /// 기존 제품 수정 — 로컬 즉시 반영 후 Supabase 동기화
+  /// 기존 제품 수정 — 로컬 즉시 반영 후 Supabase 동기화. 실패 시 롤백.
   Future<void> update(ConsumableItem updated) async {
+    final previous = List<ConsumableItem>.unmodifiable(value);
     value = value
         .map((item) => item.id == updated.id ? updated : item)
         .toList();
-    await SupabaseService.saveItem(updated);
+    try {
+      await SupabaseService.saveItem(updated);
+    } catch (e) {
+      value = List.of(previous);
+      rethrow;
+    }
   }
 
-  /// 제품 삭제 — 로컬 즉시 반영 후 Supabase 동기화
+  /// 제품 삭제 — 로컬 즉시 반영 후 Supabase 동기화. 실패 시 롤백.
   Future<void> delete(String id) async {
+    final previous = List<ConsumableItem>.unmodifiable(value);
     value = value.where((item) => item.id != id).toList();
-    await SupabaseService.deleteItem(id);
+    try {
+      await SupabaseService.deleteItem(id);
+    } catch (e) {
+      value = List.of(previous);
+      rethrow;
+    }
   }
 
   /// id로 제품 조회 (없으면 null)

--- a/lib/services/item_store.dart
+++ b/lib/services/item_store.dart
@@ -22,6 +22,8 @@ class ItemStore extends ValueNotifier<List<ConsumableItem>> {
   }
 
   /// 새 제품 추가 — 로컬 즉시 반영 후 Supabase 동기화. 실패 시 롤백.
+  ///
+  /// ConsumableItem은 모든 필드가 final인 불변 객체이므로, 스냅샷을 얕은 복사(List.unmodifiable)로 저장해도 안전합니다.
   Future<void> add(ConsumableItem item) async {
     final previous = List<ConsumableItem>.unmodifiable(value);
     value = [...value, item];

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,24 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
+/// buylog warm-neutral palette — 아이보리 + 테라코타 + 세이지 모스.
+///
+/// 디자인 핸드오프 `tokens.js`의 `warm` 팔레트 매핑.
+/// **식별자는 develop 시점과 동일**하게 유지 — 모든 화면이 토큰 경유로 색을
+/// 사용하므로 이 파일만 바꾸면 자동으로 새 팔레트가 적용된다. 자세한 변경
+/// 의도는 `docs/REDESIGN_NOTES.md` 참고.
 class AppColors {
-  static const primary = Color(0xFF0891B2);
-  static const primaryLight = Color(0xFF22D3EE);
-  static const primaryDark = Color(0xFF0E7490);
-  static const background = Color(0xFFF7F6F3);
-  static const surface = Color(0xFFFFFFFF);
-  static const surfaceAlt = Color(0xFFF0EFEC);
-  static const text = Color(0xFF1E293B);
-  static const textSecondary = Color(0xFF64748B);
-  static const textMuted = Color(0xFF94A3B8);
-  static const border = Color(0xFFE2E8F0);
-  static const success = Color(0xFF059669);
-  static const warning = Color(0xFFD97706);
-  static const danger = Color(0xFFDC2626);
-  static const dangerLight = Color(0xFFFEE2E2);
-  static const warningLight = Color(0xFFFEF3C7);
-  static const successLight = Color(0xFFD1FAE5);
-  static const primaryLight2 = Color(0xFFCFFAFE);
+  // Brand — terracotta ("정돈된 도구" 톤)
+  static const primary = Color(0xFFC25A4A);
+  static const primaryDark = Color(0xFFA0432F);
+  static const primaryLight = Color(0xFFE89B8C);
+  // 기존 코드가 참조하는 "primary 위 약한 틴트" 슬롯. 디자인의 primarySoft에 매핑.
+  static const primaryLight2 = Color(0xFFF2DDD4);
+
+  // Surfaces — bone cream + ivory
+  static const background = Color(0xFFF7F2E9);
+  static const surface = Color(0xFFFBF8F1);
+  static const surfaceAlt = Color(0xFFEFE8DA);
+
+  // Ink ramp (text → textSecondary → textMuted → textSoft 순으로 옅어짐)
+  static const text = Color(0xFF2A2620);
+  static const textSecondary = Color(0xFF5C544A);
+  static const textMuted = Color(0xFF8E8472);
+  static const textSoft = Color(0xFFB5AC97);
+
+  // Hairlines
+  static const border = Color(0xFFDCD3BF);
+
+  // Status — warm-tier values, 동일 식별자
+  static const success = Color(0xFF5A8A6B);
+  static const successLight = Color(0xFFD8E5DA);
+  static const warning = Color(0xFFB98430);
+  static const warningLight = Color(0xFFF2E2C0);
+  static const danger = Color(0xFFC25A4A);
+  static const dangerLight = Color(0xFFF2DDD4);
 }
 
 class AppTheme {
@@ -40,29 +57,33 @@ class AppTheme {
           color: AppColors.text,
           fontWeight: FontWeight.w700,
           fontSize: 28,
+          letterSpacing: -0.8,
         ),
         headlineMedium: textTheme.headlineMedium?.copyWith(
           color: AppColors.text,
-          fontWeight: FontWeight.w600,
+          fontWeight: FontWeight.w700,
           fontSize: 22,
+          letterSpacing: -0.6,
         ),
         titleLarge: textTheme.titleLarge?.copyWith(
           color: AppColors.text,
-          fontWeight: FontWeight.w600,
-          fontSize: 18,
+          fontWeight: FontWeight.w700,
+          fontSize: 17,
+          letterSpacing: -0.3,
         ),
         titleMedium: textTheme.titleMedium?.copyWith(
           color: AppColors.text,
-          fontWeight: FontWeight.w500,
-          fontSize: 16,
+          fontWeight: FontWeight.w600,
+          fontSize: 15,
+          letterSpacing: -0.2,
         ),
         bodyLarge: textTheme.bodyLarge?.copyWith(
           color: AppColors.text,
-          fontSize: 16,
+          fontSize: 15,
         ),
         bodyMedium: textTheme.bodyMedium?.copyWith(
           color: AppColors.textSecondary,
-          fontSize: 14,
+          fontSize: 13.5,
         ),
         bodySmall: textTheme.bodySmall?.copyWith(
           color: AppColors.textMuted,
@@ -84,8 +105,9 @@ class AppTheme {
         scrolledUnderElevation: 0,
         titleTextStyle: GoogleFonts.notoSans(
           color: AppColors.text,
-          fontSize: 20,
-          fontWeight: FontWeight.w600,
+          fontSize: 18,
+          fontWeight: FontWeight.w700,
+          letterSpacing: -0.3,
         ),
         iconTheme: const IconThemeData(color: AppColors.text),
       ),
@@ -96,10 +118,14 @@ class AppTheme {
         type: BottomNavigationBarType.fixed,
         elevation: 0,
         selectedLabelStyle: TextStyle(
-          fontSize: 11,
-          fontWeight: FontWeight.w600,
+          fontSize: 10.5,
+          fontWeight: FontWeight.w700,
+          letterSpacing: -0.1,
         ),
-        unselectedLabelStyle: TextStyle(fontSize: 11),
+        unselectedLabelStyle: TextStyle(
+          fontSize: 10.5,
+          fontWeight: FontWeight.w500,
+        ),
       ),
     );
   }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -35,7 +35,7 @@ class AppColors {
   static const warning = Color(0xFFB98430);
   static const warningLight = Color(0xFFF2E2C0);
   static const danger = Color(0xFFB0392E);
-  static const dangerLight = Color(0xFFF6D5CD);
+  static const dangerLight = Color(0xFFEFC5B6);
 }
 
 class AppTheme {

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -34,8 +34,8 @@ class AppColors {
   static const successLight = Color(0xFFD8E5DA);
   static const warning = Color(0xFFB98430);
   static const warningLight = Color(0xFFF2E2C0);
-  static const danger = Color(0xFFC25A4A);
-  static const dangerLight = Color(0xFFF2DDD4);
+  static const danger = Color(0xFFB0392E);
+  static const dangerLight = Color(0xFFF6D5CD);
 }
 
 class AppTheme {

--- a/lib/widgets/home/home_hero_card.dart
+++ b/lib/widgets/home/home_hero_card.dart
@@ -13,11 +13,16 @@ class HomeHeroCard extends StatelessWidget {
     super.key,
     required this.item,
     required this.onTap,
+    this.onDetailTap,
     this.onOrderTap,
   });
 
   final ConsumableItem item;
+  /// 카드 본체(영역) 탭 시 호출. 일반적으로 상세 화면 진입.
   final VoidCallback onTap;
+  /// "자세히" 버튼 전용 핸들러. null이면 [onTap]로 폴백.
+  final VoidCallback? onDetailTap;
+  /// "지금 주문" 핸들러. null이면 버튼 자체를 렌더링하지 않는다.
   final VoidCallback? onOrderTap;
 
   Color get _tierBg {
@@ -27,7 +32,7 @@ class HomeHeroCard extends StatelessWidget {
     return AppColors.successLight;
   }
 
-  String _ymd(DateTime d) =>
+  static String _ymd(DateTime d) =>
       '${d.year}.${d.month.toString().padLeft(2, '0')}.${d.day.toString().padLeft(2, '0')}';
 
   @override
@@ -37,7 +42,7 @@ class HomeHeroCard extends StatelessWidget {
         : null;
     final aiPct = item.aiConfidence == null
         ? null
-        : (item.aiConfidence! * 100).round();
+        : (item.aiConfidence!.clamp(0.0, 1.0) * 100).round();
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
@@ -132,22 +137,24 @@ class HomeHeroCard extends StatelessWidget {
                       Expanded(
                         child: _HeroButton(
                           label: '자세히',
-                          background: Colors.white,
+                          background: AppColors.surface,
                           foreground: AppColors.textSecondary,
                           border: AppColors.border,
-                          onTap: onTap,
+                          onTap: onDetailTap ?? onTap,
                         ),
                       ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: _HeroButton(
-                          label: '지금 주문',
-                          icon: Icons.storefront_outlined,
-                          background: AppColors.success,
-                          foreground: Colors.white,
-                          onTap: onOrderTap ?? () {},
+                      if (onOrderTap != null) ...[
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: _HeroButton(
+                            label: '지금 주문',
+                            icon: Icons.storefront_outlined,
+                            background: AppColors.success,
+                            foreground: Colors.white,
+                            onTap: onOrderTap!,
+                          ),
                         ),
-                      ),
+                      ],
                     ],
                   ),
                 ],
@@ -172,7 +179,7 @@ class _MiniPill extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
       decoration: BoxDecoration(
-        color: Colors.white,
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(

--- a/lib/widgets/home/home_hero_card.dart
+++ b/lib/widgets/home/home_hero_card.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import '../../models/item.dart';
+import '../../theme/app_theme.dart';
+import '../countdown_ring.dart';
+
+/// 홈 화면 최상단 히어로 카드 — 가장 시급한 교체 한 건을 강조.
+///
+/// 디자인 핸드오프 prototype.html `screens-a.jsx::HomeScreen`의 hero 카드 매핑.
+/// 팀원 위젯(`widgets/item_card.dart`의 `ItemCard`/`PurchaseListItem`)과
+/// 구조적으로 다르므로 별도 파일로 분리. 색은 모두 `AppColors` 토큰 경유.
+class HomeHeroCard extends StatelessWidget {
+  const HomeHeroCard({
+    super.key,
+    required this.item,
+    required this.onTap,
+    this.onOrderTap,
+  });
+
+  final ConsumableItem item;
+  final VoidCallback onTap;
+  final VoidCallback? onOrderTap;
+
+  Color get _tierBg {
+    if (item.daysRemaining <= 3) return AppColors.dangerLight;
+    if (item.daysRemaining <= 7) return AppColors.warningLight;
+    if (item.daysRemaining <= 14) return AppColors.primaryLight2;
+    return AppColors.successLight;
+  }
+
+  String _ymd(DateTime d) =>
+      '${d.year}.${d.month.toString().padLeft(2, '0')}.${d.day.toString().padLeft(2, '0')}';
+
+  @override
+  Widget build(BuildContext context) {
+    final lastPurchase = item.purchaseHistory.isNotEmpty
+        ? item.purchaseHistory.first.date
+        : null;
+    final aiPct = item.aiConfidence == null
+        ? null
+        : (item.aiConfidence! * 100).round();
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: onTap,
+          child: Ink(
+            decoration: BoxDecoration(
+              color: _tierBg,
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(
+                color: AppColors.primary.withValues(alpha: 0.18),
+                width: 0.5,
+              ),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                    decoration: BoxDecoration(
+                      color: AppColors.primary,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Text(
+                      '가장 시급한 교체',
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                        color: Colors.white,
+                        letterSpacing: 0.4,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      CountdownRing(
+                        daysRemaining: item.daysRemaining,
+                        totalDays: item.cycleDays,
+                        size: 84,
+                      ),
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              item.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.w700,
+                                color: AppColors.text,
+                                letterSpacing: -0.4,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              lastPurchase == null
+                                  ? item.brand
+                                  : '${item.brand} · 마지막 구매 ${_ymd(lastPurchase)}',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: AppColors.textMuted,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            if (aiPct != null)
+                              _MiniPill(
+                                icon: Icons.auto_awesome,
+                                label: 'AI 예측 $aiPct%',
+                                fg: AppColors.textSecondary,
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 14),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: _HeroButton(
+                          label: '자세히',
+                          background: Colors.white,
+                          foreground: AppColors.textSecondary,
+                          border: AppColors.border,
+                          onTap: onTap,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: _HeroButton(
+                          label: '지금 주문',
+                          icon: Icons.storefront_outlined,
+                          background: AppColors.success,
+                          foreground: Colors.white,
+                          onTap: onOrderTap ?? () {},
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniPill extends StatelessWidget {
+  const _MiniPill({this.icon, required this.label, required this.fg});
+
+  final IconData? icon;
+  final String label;
+  final Color fg;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 11, color: AppColors.primary),
+            const SizedBox(width: 4),
+          ],
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: fg,
+              letterSpacing: -0.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroButton extends StatelessWidget {
+  const _HeroButton({
+    required this.label,
+    required this.background,
+    required this.foreground,
+    required this.onTap,
+    this.icon,
+    this.border,
+  });
+
+  final String label;
+  final IconData? icon;
+  final Color background;
+  final Color foreground;
+  final Color? border;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Ink(
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(12),
+            border:
+                border == null ? null : Border.all(color: border!, width: 1),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: 14, color: foreground),
+                const SizedBox(width: 6),
+              ],
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                  color: foreground,
+                  letterSpacing: -0.1,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/home/home_hero_card.dart
+++ b/lib/widgets/home/home_hero_card.dart
@@ -18,10 +18,13 @@ class HomeHeroCard extends StatelessWidget {
   });
 
   final ConsumableItem item;
+
   /// 카드 본체(영역) 탭 시 호출. 일반적으로 상세 화면 진입.
   final VoidCallback onTap;
+
   /// "자세히" 버튼 전용 핸들러. null이면 [onTap]로 폴백.
   final VoidCallback? onDetailTap;
+
   /// "지금 주문" 핸들러. null이면 버튼 자체를 렌더링하지 않는다.
   final VoidCallback? onOrderTap;
 
@@ -66,8 +69,10 @@ class HomeHeroCard extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 3,
+                    ),
                     decoration: BoxDecoration(
                       color: AppColors.primary,
                       borderRadius: BorderRadius.circular(8),
@@ -233,8 +238,9 @@ class _HeroButton extends StatelessWidget {
           decoration: BoxDecoration(
             color: background,
             borderRadius: BorderRadius.circular(12),
-            border:
-                border == null ? null : Border.all(color: border!, width: 1),
+            border: border == null
+                ? null
+                : Border.all(color: border!, width: 1),
           ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/widgets/home/upcoming_item_row.dart
+++ b/lib/widgets/home/upcoming_item_row.dart
@@ -8,11 +8,7 @@ import '../dday_badge.dart';
 /// `widgets/item_card.dart::PurchaseListItem`과 비슷하지만 D-day 강조 + 더
 /// 컴팩트한 패딩이라 별도 위젯으로 둔다. 팀원 코드를 수정하지 않기 위함.
 class UpcomingItemRow extends StatelessWidget {
-  const UpcomingItemRow({
-    super.key,
-    required this.item,
-    required this.onTap,
-  });
+  const UpcomingItemRow({super.key, required this.item, required this.onTap});
 
   final ConsumableItem item;
   final VoidCallback onTap;

--- a/lib/widgets/home/upcoming_item_row.dart
+++ b/lib/widgets/home/upcoming_item_row.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../../models/item.dart';
+import '../../theme/app_theme.dart';
+import '../dday_badge.dart';
+
+/// 홈 "다가오는 교체" 섹션의 컴팩트 행 (40 px 아이콘 타일 + 이름·메타 + D-day 배지).
+///
+/// `widgets/item_card.dart::PurchaseListItem`과 비슷하지만 D-day 강조 + 더
+/// 컴팩트한 패딩이라 별도 위젯으로 둔다. 팀원 코드를 수정하지 않기 위함.
+class UpcomingItemRow extends StatelessWidget {
+  const UpcomingItemRow({
+    super.key,
+    required this.item,
+    required this.onTap,
+  });
+
+  final ConsumableItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cyclePart = item.aiPredictedDays ?? item.cycleDays;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: Ink(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: AppColors.border, width: 0.5),
+          ),
+          child: Row(
+            children: [
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: AppColors.surfaceAlt,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  item.icon,
+                  size: 18,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.text,
+                        letterSpacing: -0.1,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '${item.brand} · 주기 $cyclePart일',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        fontSize: 11.5,
+                        color: AppColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              DdayBadge(daysRemaining: item.daysRemaining),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/services/item_store_test.dart
+++ b/test/services/item_store_test.dart
@@ -16,6 +16,10 @@ ConsumableItem _seed(String id, {String name = 'X', int days = 10}) =>
 
 void main() {
   group('ItemStore rollback', () {
+    setUp(() {
+      ItemStore.instance.value = [];
+    });
+
     test('add: Supabase 실패 시 이전 리스트 상태로 복원되고 rethrow', () async {
       ItemStore.instance.value = [_seed('a')];
       final before = List.of(ItemStore.instance.value);
@@ -23,7 +27,7 @@ void main() {
       // SupabaseService 미초기화 → saveItem 내부에서 throw
       await expectLater(
         ItemStore.instance.add(_seed('b')),
-        throwsA(isA<Object>()),
+        throwsA(anything),
       );
 
       expect(
@@ -38,7 +42,7 @@ void main() {
 
       await expectLater(
         ItemStore.instance.delete('a'),
-        throwsA(isA<Object>()),
+        throwsA(anything),
       );
 
       expect(
@@ -54,7 +58,7 @@ void main() {
 
       await expectLater(
         ItemStore.instance.update(_seed('a', name: 'new')),
-        throwsA(isA<Object>()),
+        throwsA(anything),
       );
 
       expect(ItemStore.instance.value.single.name, 'old');

--- a/test/services/item_store_test.dart
+++ b/test/services/item_store_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:buylog/models/item.dart';
+import 'package:buylog/services/item_store.dart';
+
+ConsumableItem _seed(String id, {String name = 'X', int days = 10}) =>
+    ConsumableItem(
+      id: id,
+      name: name,
+      brand: 'B',
+      category: '기타',
+      icon: ConsumableItem.iconForCategory('기타'),
+      daysRemaining: days,
+      cycleDays: 30,
+      progress: 0.5,
+    );
+
+void main() {
+  group('ItemStore rollback', () {
+    test('add: Supabase 실패 시 이전 리스트 상태로 복원되고 rethrow', () async {
+      ItemStore.instance.value = [_seed('a')];
+      final before = List.of(ItemStore.instance.value);
+
+      // SupabaseService 미초기화 → saveItem 내부에서 throw
+      await expectLater(
+        ItemStore.instance.add(_seed('b')),
+        throwsA(isA<Object>()),
+      );
+
+      expect(
+        ItemStore.instance.value.map((e) => e.id).toList(),
+        before.map((e) => e.id).toList(),
+        reason: '실패 후 리스트가 원상복구되어야 한다',
+      );
+    });
+
+    test('delete: Supabase 실패 시 삭제된 아이템이 복원된다', () async {
+      ItemStore.instance.value = [_seed('a'), _seed('b')];
+
+      await expectLater(
+        ItemStore.instance.delete('a'),
+        throwsA(isA<Object>()),
+      );
+
+      expect(
+        ItemStore.instance.value.map((e) => e.id).toSet(),
+        {'a', 'b'},
+        reason: '실패 후 삭제된 항목이 복원되어야 한다',
+      );
+    });
+
+    test('update: Supabase 실패 시 이전 항목 값이 유지된다', () async {
+      final original = _seed('a', name: 'old');
+      ItemStore.instance.value = [original];
+
+      await expectLater(
+        ItemStore.instance.update(_seed('a', name: 'new')),
+        throwsA(isA<Object>()),
+      );
+
+      expect(ItemStore.instance.value.single.name, 'old');
+    });
+  });
+}

--- a/test/services/item_store_test.dart
+++ b/test/services/item_store_test.dart
@@ -25,10 +25,7 @@ void main() {
       final before = List.of(ItemStore.instance.value);
 
       // SupabaseService 미초기화 → saveItem 내부에서 throw
-      await expectLater(
-        ItemStore.instance.add(_seed('b')),
-        throwsA(anything),
-      );
+      await expectLater(ItemStore.instance.add(_seed('b')), throwsA(anything));
 
       expect(
         ItemStore.instance.value.map((e) => e.id).toList(),
@@ -40,10 +37,7 @@ void main() {
     test('delete: Supabase 실패 시 삭제된 아이템이 복원된다', () async {
       ItemStore.instance.value = [_seed('a'), _seed('b')];
 
-      await expectLater(
-        ItemStore.instance.delete('a'),
-        throwsA(anything),
-      );
+      await expectLater(ItemStore.instance.delete('a'), throwsA(anything));
 
       expect(
         ItemStore.instance.value.map((e) => e.id).toSet(),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -35,7 +35,7 @@ void main() {
     // 앱을 렌더링합니다.
     await tester.pumpWidget(const BuylogApp());
 
-    // 화면에 '내 아이템'이 있는지 확인합니다.
-    expect(find.text('내 아이템'), findsOneWidget);
+    // 하단 탭의 '모든 제품' 라벨로 새 디자인 셸이 렌더링되었는지 확인합니다.
+    expect(find.text('모든 제품'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 변경 사항

- 홈 화면을 전체 품목 무한 스크롤에서 다이제스트 중심 구조로 재구성했습니다.
- `모든 제품` 탭과 `ItemsScreen`을 추가해 전체 품목 목록을 별도 화면에서 다룹니다.
- 홈 전용 위젯 `HomeHeroCard`, `UpcomingItemRow`를 추가했습니다.
- 따뜻한 뉴트럴 톤으로 앱 테마 토큰 값을 조정했습니다.
- `ItemStore` 롤백 테스트와 하단 탭 라벨 테스트를 갱신했습니다.
- 최신 `develop` 변경을 반영하고 홈 화면 충돌을 해결했습니다.

## 변경 이유

- 홈 화면은 오늘 확인해야 할 교체 항목과 최근 기록을 빠르게 파악하는 역할에 집중하도록 분리했습니다.
- 전체 품목 탐색은 별도 탭으로 이동시켜 정보 위계를 명확히 했습니다.
- `ItemStore` 기반 구독 구조를 유지해 등록, 수정, 삭제 결과가 홈 화면에 즉시 반영되도록 했습니다.

## 테스트

- `git diff --check`
- `dart format --set-exit-if-changed lib/screens/add_item_screen.dart lib/screens/item_detail_screen.dart lib/screens/scan_screen.dart lib/services/supabase_service.dart lib/screens/home_screen.dart`
- `flutter analyze --no-fatal-infos`
- `flutter test`

## 참고 사항

- 기본 `flutter analyze`는 기존 info 레벨 경고 16개 때문에 실패 코드가 날 수 있어, 현재 CI 기준과 맞춘 `--no-fatal-infos`로 검증했습니다.
- 수동 기기 UI 플로우는 아직 별도로 확인하지 않았습니다.