### PR TITLE
실데이터형 데모 데이터와 리포트/이미지 저장 흐름 개선

### DIFF
--- a/docs/demo-data.md
+++ b/docs/demo-data.md
@@ -1,0 +1,33 @@
+# Demo Data
+
+Buylog uses one deterministic demo user for manual QA and screen demos:
+
+- User id: `00000000-0000-4000-8000-000000000101`
+- Email: `demo.user+buylog@example.com`
+- Display name: `사용자`
+
+The curated Supabase demo dataset is intentionally small:
+
+- 7 household consumables
+- 27 purchase records
+- Relative purchase dates based on `current_date`
+- Realistic store names and prices
+
+Curated products:
+
+- `정수기 필터` / `코웨이`: high-priority filter replacement
+- `주방 세제` / `자연퐁`: frequent kitchen consumable
+- `세탁 세제` / `퍼실`: medium-cycle laundry item
+- `화장지` / `코디`: common bulk household purchase
+- `치약` / `덴티스테`: slower hygiene cycle
+- `샴푸` / `케라시스`: personal-care item
+- `샤워기 필터` / `바디럽`: second filter item with a longer cycle
+
+The seed is scoped to the deterministic demo user. Do not broaden cleanup SQL to all users or all purchases.
+
+When changing demo data, keep these screens in mind:
+
+- Home: replacement urgency and recent records
+- Items: product list and detail
+- Reports: monthly spend aggregation
+- Settings/group screens: neutral user naming

--- a/lib/data/sample_data.dart
+++ b/lib/data/sample_data.dart
@@ -1,117 +1,265 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+
 import '../models/item.dart';
 
 class SampleData {
-  static final List<ConsumableItem> items = [
-    ConsumableItem(
-      id: '1',
-      name: '정수기 필터',
-      brand: '코웨이',
-      category: '필터',
-      icon: Icons.water_drop_outlined,
-      daysRemaining: 3,
-      cycleDays: 90,
-      progress: 0.97,
-      aiPredictedDays: 85,
-      aiConfidence: 0.92,
-      purchaseHistory: [
-        PurchaseRecord(date: DateTime(2026, 1, 5), price: 35000, store: '쿠팡'),
-        PurchaseRecord(date: DateTime(2025, 10, 8), price: 37000, store: '네이버'),
-        PurchaseRecord(date: DateTime(2025, 7, 12), price: 34500, store: '쿠팡'),
-      ],
-    ),
-    ConsumableItem(
-      id: '2',
-      name: '세탁세제',
-      brand: '피죤',
-      category: '세탁',
-      icon: Icons.local_laundry_service_outlined,
-      daysRemaining: 12,
-      cycleDays: 45,
-      progress: 0.73,
-      aiPredictedDays: 42,
-      aiConfidence: 0.87,
-      purchaseHistory: [
-        PurchaseRecord(date: DateTime(2026, 3, 1), price: 15900, store: '이마트'),
-        PurchaseRecord(date: DateTime(2026, 1, 15), price: 16500, store: '쿠팡'),
-      ],
-    ),
-    ConsumableItem(
-      id: '3',
-      name: '칫솔',
-      brand: '오랄비',
-      category: '위생',
-      icon: Icons.brush_outlined,
-      daysRemaining: 25,
-      cycleDays: 90,
-      progress: 0.72,
-      aiPredictedDays: 88,
-      aiConfidence: 0.78,
-      purchaseHistory: [
-        PurchaseRecord(date: DateTime(2026, 2, 20), price: 8900, store: '다이소'),
-      ],
-    ),
-    ConsumableItem(
-      id: '4',
-      name: '에어컨 필터',
-      brand: '삼성',
-      category: '필터',
-      icon: Icons.air_outlined,
-      daysRemaining: 45,
-      cycleDays: 180,
-      progress: 0.75,
-      aiPredictedDays: 170,
-      aiConfidence: 0.65,
-      purchaseHistory: [
-        PurchaseRecord(date: DateTime(2025, 12, 1), price: 22000, store: '삼성몰'),
-      ],
-    ),
-    ConsumableItem(
-      id: '5',
-      name: '주방세제',
-      brand: '퐁퐁',
-      category: '주방',
-      icon: Icons.kitchen_outlined,
-      daysRemaining: 7,
-      cycleDays: 30,
-      progress: 0.77,
-      aiPredictedDays: 28,
-      aiConfidence: 0.91,
-      purchaseHistory: [
-        PurchaseRecord(date: DateTime(2026, 3, 20), price: 4500, store: '이마트'),
-        PurchaseRecord(date: DateTime(2026, 2, 18), price: 4200, store: '쿠팡'),
-      ],
-    ),
-    ConsumableItem(
-      id: '6',
-      name: '샴푸',
-      brand: '케라시스',
-      category: '위생',
-      icon: Icons.shower_outlined,
-      daysRemaining: 18,
-      cycleDays: 60,
-      progress: 0.70,
-      purchaseHistory: [
-        PurchaseRecord(
-          date: DateTime(2026, 2, 10),
-          price: 12800,
-          store: '올리브영',
-        ),
-      ],
-    ),
+  static List<ConsumableItem> get items => itemsFor(DateTime.now());
+
+  @visibleForTesting
+  static List<ConsumableItem> itemsFor(DateTime now) {
+    final today = _normalizedDate(now);
+
+    return [
+      _item(
+        today: today,
+        id: '1',
+        name: '정수기 필터',
+        brand: '코웨이',
+        category: '가전/필터',
+        cycleDays: 90,
+        aiPredictedDays: 88,
+        aiConfidence: 0.93,
+        purchaseHistory: [
+          _purchase(today, 14, 34900, '코웨이몰'),
+          _purchase(today, 104, 35900, '쿠팡'),
+          _purchase(today, 196, 34500, '네이버쇼핑'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '2',
+        name: '주방 세제',
+        brand: '자연퐁',
+        category: '주방/세제',
+        cycleDays: 32,
+        aiPredictedDays: 30,
+        aiConfidence: 0.89,
+        purchaseHistory: [
+          _purchase(today, 8, 4980, '이마트'),
+          _purchase(today, 39, 4700, '쿠팡'),
+          _purchase(today, 71, 5200, '홈플러스'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '3',
+        name: '세탁 세제',
+        brand: '퍼실',
+        category: '세탁/청소',
+        cycleDays: 48,
+        aiPredictedDays: 45,
+        aiConfidence: 0.87,
+        purchaseHistory: [
+          _purchase(today, 11, 18900, '쿠팡'),
+          _purchase(today, 58, 19200, 'SSG닷컴'),
+          _purchase(today, 102, 18500, '코스트코'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '4',
+        name: '화장지',
+        brand: '코디',
+        category: '욕실/위생',
+        cycleDays: 36,
+        aiPredictedDays: 34,
+        aiConfidence: 0.86,
+        purchaseHistory: [
+          _purchase(today, 6, 15900, '마켓컬리'),
+          _purchase(today, 33, 15400, '쿠팡'),
+          _purchase(today, 65, 16200, '이마트'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '5',
+        name: '치약',
+        brand: '덴티스테',
+        category: '욕실/위생',
+        cycleDays: 70,
+        aiPredictedDays: 68,
+        aiConfidence: 0.84,
+        purchaseHistory: [
+          _purchase(today, 16, 9900, '올리브영'),
+          _purchase(today, 81, 9800, '쿠팡'),
+          _purchase(today, 149, 9500, '네이버쇼핑'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '6',
+        name: '샴푸',
+        brand: '케라시스',
+        category: '헤어/바디',
+        cycleDays: 65,
+        aiPredictedDays: 63,
+        aiConfidence: 0.82,
+        purchaseHistory: [
+          _purchase(today, 10, 12900, '올리브영'),
+          _purchase(today, 72, 12500, '쿠팡'),
+          _purchase(today, 138, 13100, '롯데온'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '7',
+        name: '샤워기 필터',
+        brand: '바디럽',
+        category: '가전/필터',
+        cycleDays: 100,
+        aiPredictedDays: 96,
+        aiConfidence: 0.85,
+        purchaseHistory: [
+          _purchase(today, 19, 17900, '오늘의집'),
+          _purchase(today, 109, 17500, '쿠팡'),
+          _purchase(today, 202, 17200, '네이버쇼핑'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '8',
+        name: '식기세척기 세제',
+        brand: '프로쉬',
+        category: '주방/세제',
+        cycleDays: 45,
+        aiPredictedDays: 43,
+        aiConfidence: 0.88,
+        purchaseHistory: [
+          _purchase(today, 13, 11900, '쿠팡'),
+          _purchase(today, 55, 12200, 'SSG닷컴'),
+          _purchase(today, 97, 11800, '이마트'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '9',
+        name: '욕실 세정제',
+        brand: '홈스타',
+        category: '욕실/위생',
+        cycleDays: 40,
+        aiPredictedDays: 38,
+        aiConfidence: 0.83,
+        purchaseHistory: [
+          _purchase(today, 18, 6900, '홈플러스'),
+          _purchase(today, 51, 6500, '쿠팡'),
+          _purchase(today, 92, 6700, '이마트'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '10',
+        name: '건조기 시트',
+        brand: '다우니',
+        category: '세탁/청소',
+        cycleDays: 35,
+        aiPredictedDays: 33,
+        aiConfidence: 0.86,
+        purchaseHistory: [
+          _purchase(today, 9, 10900, '쿠팡'),
+          _purchase(today, 43, 11200, '마켓컬리'),
+          _purchase(today, 77, 10500, '롯데마트'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '11',
+        name: '에어컨 필터',
+        brand: '삼성',
+        category: '가전/필터',
+        cycleDays: 150,
+        aiPredictedDays: 145,
+        aiConfidence: 0.79,
+        purchaseHistory: [
+          _purchase(today, 20, 24900, '삼성닷컴'),
+          _purchase(today, 167, 24500, '쿠팡'),
+          _purchase(today, 348, 23900, '하이마트'),
+        ],
+      ),
+      _item(
+        today: today,
+        id: '12',
+        name: '바디워시',
+        brand: '해피바스',
+        category: '헤어/바디',
+        cycleDays: 38,
+        aiPredictedDays: 36,
+        aiConfidence: 0.81,
+        purchaseHistory: [
+          _purchase(today, 12, 8900, '올리브영'),
+          _purchase(today, 46, 9100, '쿠팡'),
+          _purchase(today, 88, 8700, '네이버쇼핑'),
+        ],
+      ),
+    ];
+  }
+
+  static const List<PriceComparison> priceComparisons = [
+    PriceComparison(store: '쿠팡', price: 32900, isLowest: true),
+    PriceComparison(store: '네이버쇼핑', price: 33800),
+    PriceComparison(store: '마켓컬리', price: 34900),
+    PriceComparison(store: 'SSG닷컴', price: 35500),
   ];
 
-  static final List<PriceComparison> priceComparisons = [
-    const PriceComparison(store: '쿠팡', price: 33500, isLowest: true),
-    const PriceComparison(store: '네이버', price: 35000),
-    const PriceComparison(store: '이마트', price: 36900),
-    const PriceComparison(store: '삼성몰', price: 37500),
+  static const List<GroupMember> groupMembers = [
+    GroupMember(name: '사용자', avatarColor: '0xFF0891B2'),
+    GroupMember(name: '가족 A', avatarColor: '0xFFD97706'),
+    GroupMember(name: '가족 B', avatarColor: '0xFF059669'),
+    GroupMember(name: '가족 C', avatarColor: '0xFF7C3AED'),
   ];
 
-  static final List<GroupMember> groupMembers = [
-    const GroupMember(name: '나', avatarColor: '0xFF0891B2'),
-    const GroupMember(name: '엄마', avatarColor: '0xFFD97706'),
-    const GroupMember(name: '아빠', avatarColor: '0xFF059669'),
-    const GroupMember(name: '동생', avatarColor: '0xFF7C3AED'),
-  ];
+  static ConsumableItem _item({
+    required DateTime today,
+    required String id,
+    required String name,
+    required String brand,
+    required String category,
+    required int cycleDays,
+    required List<PurchaseRecord> purchaseHistory,
+    int? aiPredictedDays,
+    double? aiConfidence,
+  }) {
+    final sortedHistory = List<PurchaseRecord>.from(purchaseHistory)
+      ..sort((a, b) => b.date.compareTo(a.date));
+    final daysSinceLastPurchase = today
+        .difference(sortedHistory.first.date)
+        .inDays;
+    final progress = (daysSinceLastPurchase / cycleDays)
+        .clamp(0.0, 1.0)
+        .toDouble();
+
+    return ConsumableItem(
+      id: id,
+      name: name,
+      brand: brand,
+      category: category,
+      icon: ConsumableItem.iconForCategory(category),
+      daysRemaining: cycleDays - daysSinceLastPurchase,
+      cycleDays: cycleDays,
+      progress: progress,
+      aiPredictedDays: aiPredictedDays,
+      aiConfidence: aiConfidence,
+      purchaseHistory: sortedHistory,
+    );
+  }
+
+  static PurchaseRecord _purchase(
+    DateTime today,
+    int daysAgo,
+    int price,
+    String store,
+  ) {
+    return PurchaseRecord(
+      date: _daysAgo(today, daysAgo),
+      price: price,
+      store: store,
+    );
+  }
+
+  static DateTime _daysAgo(DateTime today, int days) {
+    return DateTime(today.year, today.month, today.day - days);
+  }
+
+  static DateTime _normalizedDate(DateTime value) {
+    return DateTime(value.year, value.month, value.day);
+  }
 }

--- a/lib/screens/group_screen.dart
+++ b/lib/screens/group_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../data/sample_data.dart';
 import '../theme/app_theme.dart';
+import '../utils/dday_format.dart';
 
 class GroupScreen extends StatefulWidget {
   const GroupScreen({super.key});
@@ -201,7 +202,9 @@ class _GroupScreenState extends State<GroupScreen> {
                             boxShadow: !_showGroupItems
                                 ? [
                                     BoxShadow(
-                                      color: Colors.black.withOpacity(0.05),
+                                      color: Colors.black.withValues(
+                                        alpha: 0.05,
+                                      ),
                                       blurRadius: 4,
                                     ),
                                   ]
@@ -234,7 +237,9 @@ class _GroupScreenState extends State<GroupScreen> {
                             boxShadow: _showGroupItems
                                 ? [
                                     BoxShadow(
-                                      color: Colors.black.withOpacity(0.05),
+                                      color: Colors.black.withValues(
+                                        alpha: 0.05,
+                                      ),
                                       blurRadius: 4,
                                     ),
                                   ]
@@ -300,7 +305,7 @@ class _GroupScreenState extends State<GroupScreen> {
           padding: const EdgeInsets.symmetric(horizontal: 20),
           sliver: SliverList.separated(
             itemCount: categoryItems.length,
-            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            separatorBuilder: (context, index) => const SizedBox(height: 8),
             itemBuilder: (context, index) {
               final item = categoryItems[index];
               final updater = _showGroupItems
@@ -358,7 +363,7 @@ class _GroupScreenState extends State<GroupScreen> {
                       ),
                     ),
                     Text(
-                      'D-${item.daysRemaining}',
+                      formatDdayLabel(item.daysRemaining),
                       style: TextStyle(
                         fontSize: 13,
                         fontWeight: FontWeight.w600,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../main.dart';
 import '../models/item.dart';
 import '../services/item_store.dart';
+import '../services/recent_purchase_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/home/home_hero_card.dart';
 import '../widgets/home/upcoming_item_row.dart';
@@ -25,7 +26,7 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  static const _userName = '지민';
+  static const _userName = '사용자';
 
   void _goToItemsTab() {
     final root = context.findAncestorStateOfType<MainNavigationState>();
@@ -68,6 +69,7 @@ class _HomeScreenState extends State<HomeScreen> {
           final hero = sorted.first;
           final upcoming = sorted.skip(1).take(4).toList();
           final weekCount = items.where((i) => i.daysRemaining <= 7).length;
+          final recentRows = RecentPurchaseService.fromItems(items);
 
           return CustomScrollView(
             slivers: [
@@ -124,18 +126,20 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ],
               const SliverToBoxAdapter(child: _SectionHeader(title: '최근 기록')),
-              // TODO: 디자인 프로토타입 mock. 실제 활동 로그(ItemStore 변경
-              // 이력 등) 연결 시 교체.
-              const SliverPadding(
-                padding: EdgeInsets.fromLTRB(20, 10, 20, 8),
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(20, 10, 20, 8),
                 sliver: SliverToBoxAdapter(
-                  child: Column(
-                    children: [
-                      _LedgerRow(time: '오늘 14:22', text: '이마트 영수증 3개 항목 자동 추가'),
-                      _LedgerRow(time: '04.18', text: '치약 구매 기록됨'),
-                      _LedgerRow(time: '04.01', text: '세탁세제 주기 45일로 업데이트'),
-                    ],
-                  ),
+                  child: recentRows.isEmpty
+                      ? const _RecentEmptyState()
+                      : Column(
+                          children: [
+                            for (final row in recentRows)
+                              _LedgerRow(
+                                time: _formatRecentDate(row.date),
+                                text: _formatRecentText(row),
+                              ),
+                          ],
+                        ),
                 ),
               ),
               const SliverToBoxAdapter(child: SizedBox(height: 28)),
@@ -144,6 +148,36 @@ class _HomeScreenState extends State<HomeScreen> {
         },
       ),
     );
+  }
+
+  String _formatRecentDate(DateTime date) {
+    final today = DateTime.now();
+    if (date.year == today.year &&
+        date.month == today.month &&
+        date.day == today.day) {
+      return '오늘';
+    }
+
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '$month.$day';
+  }
+
+  String _formatRecentText(RecentPurchaseRecord record) {
+    final store = record.store.trim().isEmpty ? '구매처 미입력' : record.store;
+    return '${record.itemName} 구매 기록됨 · $store · ${_formatPrice(record.price)}';
+  }
+
+  String _formatPrice(int price) {
+    final digits = price.toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < digits.length; i++) {
+      if (i > 0 && (digits.length - i) % 3 == 0) {
+        buffer.write(',');
+      }
+      buffer.write(digits[i]);
+    }
+    return '$buffer원';
   }
 }
 
@@ -339,6 +373,28 @@ class _LedgerRow extends StatelessWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _RecentEmptyState extends StatelessWidget {
+  const _RecentEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 8, horizontal: 4),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          '최근 기록이 없습니다.',
+          style: TextStyle(
+            fontSize: 13,
+            height: 1.5,
+            color: AppColors.textMuted,
+          ),
+        ),
       ),
     );
   }

--- a/lib/screens/reports_screen.dart
+++ b/lib/screens/reports_screen.dart
@@ -8,6 +8,8 @@ import '../widgets/reports/month_filter_list_view.dart';
 import '../widgets/reports/monthly_bar_chart.dart';
 import '../widgets/reports/share_action_button.dart';
 
+enum _ReportPeriod { monthly, yearly }
+
 class ReportsScreen extends StatefulWidget {
   const ReportsScreen({super.key});
 
@@ -29,10 +31,27 @@ class _ReportsScreenState extends State<ReportsScreen> {
   // 는 16ms 프레임 예산 대비 무시 가능. async ReportService 도입 시
   // 캐싱은 repository 레이어로 이전한다.
   DateTime? _selectedMonth;
+  _ReportPeriod _period = _ReportPeriod.monthly;
+  int _selectedYear = DateTime.now().year;
 
   void _onMonthTap(DateTime m) {
     setState(() {
       _selectedMonth = _selectedMonth == m ? null : m;
+    });
+  }
+
+  void _onPeriodChanged(Set<_ReportPeriod> selected) {
+    if (selected.isEmpty) return;
+    setState(() {
+      _period = selected.first;
+      _selectedMonth = null;
+    });
+  }
+
+  void _changeYear(int delta) {
+    setState(() {
+      _selectedYear += delta;
+      _selectedMonth = null;
     });
   }
 
@@ -43,21 +62,26 @@ class _ReportsScreenState extends State<ReportsScreen> {
       if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
       buffer.write(str[i]);
     }
-    return '${buffer}원';
+    return '$buffer원';
   }
 
   @override
   Widget build(BuildContext context) {
     final service = ReportService.fromItems(SampleData.items);
     final months = service.aggregateRecentMonths();
+    final yearly = service.aggregateYear(_selectedYear);
     // 요약/파이/상세는 지출이 있는 최신 월을 우선 사용해 "빈 현재 월 → 0원"
     // UX 회귀를 피한다. 전부 0원이면 months.last로 fallback.
     final latest =
         service.latestMonthlyWithSpending() ??
         (months.isEmpty ? null : months.last);
-    final breakdown = latest == null
+    final monthlyBreakdown = latest == null
         ? const <CategoryBreakdown>[]
         : service.categoryBreakdownFor(latest.month);
+    final yearlyBreakdown = service.categoryBreakdownForYear(_selectedYear);
+    final isYearly = _period == _ReportPeriod.yearly;
+    final chartData = isYearly ? yearly.months : months;
+    final breakdown = isYearly ? yearlyBreakdown : monthlyBreakdown;
 
     // `_selectedMonth`는 순수 widget state 로 보관되므로 IndexedStack 하에서
     // 앱 수명만큼 유지된다. 월 경계 교차 또는 데이터 동기화로 aggregateRecentMonths
@@ -65,15 +89,26 @@ class _ReportsScreenState extends State<ReportsScreen> {
     // 해당 월이 없는" 모순 상태가 발생할 수 있다 (Codex review v3.2 HIGH finding).
     // 매 build 에서 months 와 교차 검증하여 유효 월만 하위 위젯으로 내려보낸다.
     final effectiveSelectedMonth =
-        _selectedMonth != null && months.any((m) => m.month == _selectedMonth)
+        _selectedMonth != null &&
+            chartData.any((m) => m.month == _selectedMonth)
         ? _selectedMonth
         : null;
 
-    final latestTitle = latest == null
+    final latestTitle = isYearly
+        ? '연간 지출 현황'
+        : latest == null
         ? '지출 현황'
         : '${latest.month.month}월 지출 현황';
-    final latestYear = latest == null ? '-' : '${latest.month.year}';
-    final latestTotal = latest?.totalAmount ?? 0;
+    final latestYear = isYearly
+        ? '$_selectedYear년'
+        : latest == null
+        ? '-'
+        : '${latest.month.year}';
+    final latestTotal = isYearly
+        ? yearly.totalAmount
+        : latest?.totalAmount ?? 0;
+    final chartTitle = isYearly ? '연간 월별 지출' : '월별 지출 추이';
+    final detailTitle = isYearly ? '연간 카테고리 상세' : '카테고리별 상세';
 
     return SafeArea(
       child: CustomScrollView(
@@ -89,6 +124,60 @@ class _ReportsScreenState extends State<ReportsScreen> {
                     style: Theme.of(context).textTheme.headlineMedium,
                   ),
                   ShareActionButton(service: service),
+                ],
+              ),
+            ),
+          ),
+
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: SegmentedButton<_ReportPeriod>(
+                      segments: const [
+                        ButtonSegment(
+                          value: _ReportPeriod.monthly,
+                          label: Text('월간'),
+                          icon: Icon(Icons.calendar_view_month_outlined),
+                        ),
+                        ButtonSegment(
+                          value: _ReportPeriod.yearly,
+                          label: Text('연간'),
+                          icon: Icon(Icons.calendar_today_outlined),
+                        ),
+                      ],
+                      selected: {_period},
+                      showSelectedIcon: false,
+                      onSelectionChanged: _onPeriodChanged,
+                      style: ButtonStyle(
+                        visualDensity: VisualDensity.compact,
+                        foregroundColor: WidgetStateProperty.resolveWith<Color>(
+                          (states) {
+                            return states.contains(WidgetState.selected)
+                                ? Colors.white
+                                : AppColors.textSecondary;
+                          },
+                        ),
+                        backgroundColor: WidgetStateProperty.resolveWith<Color>(
+                          (states) {
+                            return states.contains(WidgetState.selected)
+                                ? AppColors.primary
+                                : AppColors.surface;
+                          },
+                        ),
+                      ),
+                    ),
+                  ),
+                  if (isYearly) ...[
+                    const SizedBox(width: 10),
+                    _YearControl(
+                      year: _selectedYear,
+                      onPrevious: () => _changeYear(-1),
+                      onNext: () => _changeYear(1),
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -157,7 +246,7 @@ class _ReportsScreenState extends State<ReportsScreen> {
                   color: AppColors.primaryLight2,
                   borderRadius: BorderRadius.circular(14),
                   border: Border.all(
-                    color: AppColors.primary.withOpacity(0.2),
+                    color: AppColors.primary.withValues(alpha: 0.2),
                     width: 0.5,
                   ),
                 ),
@@ -167,7 +256,7 @@ class _ReportsScreenState extends State<ReportsScreen> {
                       width: 40,
                       height: 40,
                       decoration: BoxDecoration(
-                        color: AppColors.primary.withOpacity(0.15),
+                        color: AppColors.primary.withValues(alpha: 0.15),
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: const Icon(
@@ -207,7 +296,7 @@ class _ReportsScreenState extends State<ReportsScreen> {
             ),
           ),
 
-          // Monthly comparison bar chart
+          // Spending trend bar chart
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
@@ -221,9 +310,9 @@ class _ReportsScreenState extends State<ReportsScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text(
-                      '월별 지출 추이',
-                      style: TextStyle(
+                    Text(
+                      chartTitle,
+                      style: const TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w600,
                         color: AppColors.text,
@@ -231,9 +320,10 @@ class _ReportsScreenState extends State<ReportsScreen> {
                     ),
                     const SizedBox(height: 20),
                     MonthlyBarChart(
-                      data: months,
+                      data: chartData,
                       selectedMonth: effectiveSelectedMonth,
                       onMonthTap: _onMonthTap,
+                      highlightLatest: !isYearly,
                     ),
                   ],
                 ),
@@ -245,9 +335,9 @@ class _ReportsScreenState extends State<ReportsScreen> {
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 10),
-              child: const Text(
-                '카테고리별 상세',
-                style: TextStyle(
+              child: Text(
+                detailTitle,
+                style: const TextStyle(
                   fontSize: 16,
                   fontWeight: FontWeight.w600,
                   color: AppColors.text,
@@ -259,7 +349,7 @@ class _ReportsScreenState extends State<ReportsScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 20),
             sliver: SliverList.separated(
               itemCount: breakdown.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 8),
+              separatorBuilder: (context, index) => const SizedBox(height: 8),
               itemBuilder: (context, index) {
                 final c = breakdown[index];
                 final color = colorForCategory(c.category);
@@ -280,7 +370,7 @@ class _ReportsScreenState extends State<ReportsScreen> {
                         width: 38,
                         height: 38,
                         decoration: BoxDecoration(
-                          color: color.withOpacity(0.12),
+                          color: color.withValues(alpha: 0.12),
                           borderRadius: BorderRadius.circular(10),
                         ),
                         child: Center(
@@ -356,6 +446,59 @@ class _ReportsScreenState extends State<ReportsScreen> {
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 24)),
+        ],
+      ),
+    );
+  }
+}
+
+class _YearControl extends StatelessWidget {
+  const _YearControl({
+    required this.year,
+    required this.onPrevious,
+    required this.onNext,
+  });
+
+  final int year;
+  final VoidCallback onPrevious;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 40,
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            tooltip: '이전 연도',
+            constraints: const BoxConstraints.tightFor(width: 36, height: 40),
+            padding: EdgeInsets.zero,
+            onPressed: onPrevious,
+            icon: const Icon(Icons.chevron_left, size: 20),
+            color: AppColors.textSecondary,
+          ),
+          Text(
+            '$year년',
+            style: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: AppColors.text,
+            ),
+          ),
+          IconButton(
+            tooltip: '다음 연도',
+            constraints: const BoxConstraints.tightFor(width: 36, height: 40),
+            padding: EdgeInsets.zero,
+            onPressed: onNext,
+            icon: const Icon(Icons.chevron_right, size: 20),
+            color: AppColors.textSecondary,
+          ),
         ],
       ),
     );

--- a/lib/screens/scan_screen.dart
+++ b/lib/screens/scan_screen.dart
@@ -153,7 +153,7 @@ class _ScanScreenState extends State<ScanScreen>
                     child: Icon(
                       Icons.receipt_long_outlined,
                       size: 80,
-                      color: Colors.white.withOpacity(0.15),
+                      color: Colors.white.withValues(alpha: 0.15),
                     ),
                   ),
                   Positioned(
@@ -239,7 +239,7 @@ class _ScanScreenState extends State<ScanScreen>
                     shape: BoxShape.circle,
                     boxShadow: [
                       BoxShadow(
-                        color: AppColors.primary.withOpacity(0.2),
+                        color: AppColors.primary.withValues(alpha: 0.2),
                         blurRadius: 20 + _pulseController.value * 10,
                         spreadRadius: _pulseController.value * 5,
                       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -29,7 +29,7 @@ class SettingsScreen extends StatelessWidget {
                     radius: 28,
                     backgroundColor: AppColors.primary,
                     child: const Text(
-                      '민',
+                      '사',
                       style: TextStyle(
                         color: Colors.white,
                         fontSize: 20,
@@ -43,7 +43,7 @@ class SettingsScreen extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          '김민수',
+                          '사용자',
                           style: TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.w600,
@@ -52,7 +52,7 @@ class SettingsScreen extends StatelessWidget {
                         ),
                         SizedBox(height: 2),
                         Text(
-                          'minsu@email.com',
+                          '계정 정보 없음',
                           style: TextStyle(
                             fontSize: 13,
                             color: AppColors.textMuted,
@@ -103,7 +103,7 @@ class SettingsScreen extends StatelessWidget {
                 trailing: Switch(
                   value: true,
                   onChanged: (_) {},
-                  activeColor: AppColors.primary,
+                  activeThumbColor: AppColors.primary,
                 ),
               ),
               _settingsTile(
@@ -113,7 +113,7 @@ class SettingsScreen extends StatelessWidget {
                 trailing: Switch(
                   value: true,
                   onChanged: (_) {},
-                  activeColor: AppColors.primary,
+                  activeThumbColor: AppColors.primary,
                 ),
               ),
             ]),

--- a/lib/services/recent_purchase_service.dart
+++ b/lib/services/recent_purchase_service.dart
@@ -1,0 +1,175 @@
+import 'package:buylog/models/item.dart';
+import 'package:flutter/material.dart';
+
+class RecentPurchaseRecord {
+  const RecentPurchaseRecord({
+    required this.itemId,
+    required this.itemName,
+    required this.brand,
+    required this.icon,
+    required this.date,
+    required this.price,
+    required this.store,
+  });
+
+  final String itemId;
+  final String itemName;
+  final String brand;
+  final IconData icon;
+  final DateTime date;
+  final int price;
+  final String store;
+}
+
+class RecentPurchaseService {
+  static List<RecentPurchaseRecord> fromItems(
+    List<ConsumableItem> items, {
+    int limit = 3,
+  }) {
+    if (items.isEmpty || limit <= 0) {
+      return const <RecentPurchaseRecord>[];
+    }
+
+    final rows =
+        items
+            .expand(
+              (item) => item.purchaseHistory.map(
+                (purchase) => RecentPurchaseRecord(
+                  itemId: item.id,
+                  itemName: item.name,
+                  brand: item.brand,
+                  icon: item.icon,
+                  date: purchase.date,
+                  price: purchase.price,
+                  store: purchase.store,
+                ),
+              ),
+            )
+            .toList()
+          ..sort((a, b) => b.date.compareTo(a.date));
+
+    return _takeLimit(rows, limit);
+  }
+
+  static List<RecentPurchaseRecord> fromPurchaseRows(
+    List<Map<String, dynamic>> rows, {
+    int limit = 3,
+    String? userId,
+  }) {
+    if (rows.isEmpty || limit <= 0) {
+      return const <RecentPurchaseRecord>[];
+    }
+
+    final parsed = <_ParsedRecentPurchase>[];
+
+    for (final row in rows) {
+      final purchasedBy = row['purchased_by'] as String?;
+      if (userId != null && purchasedBy != userId) {
+        continue;
+      }
+
+      final product = _coerceSingleMap(row['product_items']);
+      if (product == null) {
+        continue;
+      }
+
+      final itemId = product['id'] as String?;
+      final itemName = product['name'] as String?;
+      final purchaseDate = _tryParseDateTime(row['purchase_date']);
+
+      if (itemId == null || itemName == null || purchaseDate == null) {
+        continue;
+      }
+
+      final category = _coerceSingleMap(product['categories']);
+      final categoryName = category?['name'] as String? ?? '기타';
+
+      parsed.add(
+        _ParsedRecentPurchase(
+          record: RecentPurchaseRecord(
+            itemId: itemId,
+            itemName: itemName,
+            brand: product['brand'] as String? ?? '',
+            icon: ConsumableItem.iconForCategory(categoryName),
+            date: purchaseDate,
+            price: (row['price'] as num?)?.toInt() ?? 0,
+            store: row['store_name'] as String? ?? '',
+          ),
+          createdAt: _tryParseDateTime(row['created_at']),
+        ),
+      );
+    }
+
+    parsed.sort((a, b) {
+      final byPurchaseDate = b.record.date.compareTo(a.record.date);
+      if (byPurchaseDate != 0) {
+        return byPurchaseDate;
+      }
+
+      if (a.createdAt == null && b.createdAt == null) {
+        return 0;
+      }
+      if (a.createdAt == null) {
+        return 1;
+      }
+      if (b.createdAt == null) {
+        return -1;
+      }
+      return b.createdAt!.compareTo(a.createdAt!);
+    });
+
+    return _takeLimit(parsed.map((entry) => entry.record).toList(), limit);
+  }
+
+  static DateTime? _tryParseDateTime(dynamic value) {
+    if (value is! String) {
+      return null;
+    }
+    return DateTime.tryParse(value);
+  }
+
+  static List<RecentPurchaseRecord> _takeLimit(
+    List<RecentPurchaseRecord> rows,
+    int limit,
+  ) {
+    if (rows.length <= limit) {
+      return rows;
+    }
+    return rows.take(limit).toList();
+  }
+
+  static Map<String, dynamic>? _coerceSingleMap(dynamic value) {
+    final direct = _asStringMap(value);
+    if (direct != null) {
+      return direct;
+    }
+
+    if (value is List) {
+      for (final entry in value) {
+        final map = _asStringMap(entry);
+        if (map != null) {
+          return map;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  static Map<String, dynamic>? _asStringMap(dynamic value) {
+    if (value is Map<String, dynamic>) {
+      return value;
+    }
+    if (value is Map) {
+      return value.map((key, entry) => MapEntry('$key', entry));
+    }
+    return null;
+  }
+}
+
+class _ParsedRecentPurchase {
+  const _ParsedRecentPurchase({required this.record, required this.createdAt});
+
+  final RecentPurchaseRecord record;
+  final DateTime? createdAt;
+}

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -58,6 +58,16 @@ class ReportService {
     }).toList();
   }
 
+  /// 선택 연도의 1월→12월 지출 집계.
+  YearlySpending aggregateYear(int year) {
+    final months = <MonthlySpending>[
+      for (var month = 1; month <= 12; month++)
+        _aggregateMonth(DateTime(year, month, 1)),
+    ];
+
+    return YearlySpending(year: year, months: months);
+  }
+
   /// 특정 월의 카테고리 breakdown (ratio 포함). 데이터 없으면 빈 리스트.
   List<CategoryBreakdown> categoryBreakdownFor(DateTime month) {
     final key = _monthKey(month);
@@ -67,6 +77,35 @@ class ReportService {
     for (final item in source) {
       for (final pr in item.purchaseHistory) {
         if (_monthKey(pr.date) == key) {
+          total += pr.price;
+          byCategory[item.category] =
+              (byCategory[item.category] ?? 0) + pr.price;
+        }
+      }
+    }
+
+    if (total == 0) return const <CategoryBreakdown>[];
+
+    return byCategory.entries
+        .map(
+          (e) => CategoryBreakdown(
+            category: e.key,
+            amount: e.value,
+            ratio: e.value / total,
+          ),
+        )
+        .toList()
+      ..sort((a, b) => b.amount.compareTo(a.amount));
+  }
+
+  /// 선택 연도 전체의 카테고리 breakdown.
+  List<CategoryBreakdown> categoryBreakdownForYear(int year) {
+    var total = 0;
+    final byCategory = <String, int>{};
+
+    for (final item in source) {
+      for (final pr in item.purchaseHistory) {
+        if (pr.date.year == year) {
           total += pr.price;
           byCategory[item.category] =
               (byCategory[item.category] ?? 0) + pr.price;
@@ -110,6 +149,32 @@ class ReportService {
         )
         .toList();
   }
+
+  MonthlySpending _aggregateMonth(DateTime bucket) {
+    var total = 0;
+    final byCategory = <String, int>{};
+    final itemsInBucket = <ConsumableItem>[];
+
+    for (final item in source) {
+      var matched = false;
+      for (final pr in item.purchaseHistory) {
+        if (_monthKey(pr.date) == bucket) {
+          total += pr.price;
+          byCategory[item.category] =
+              (byCategory[item.category] ?? 0) + pr.price;
+          matched = true;
+        }
+      }
+      if (matched) itemsInBucket.add(item);
+    }
+
+    return MonthlySpending(
+      month: bucket,
+      totalAmount: total,
+      byCategory: byCategory,
+      items: itemsInBucket,
+    );
+  }
 }
 
 class MonthlySpending {
@@ -124,6 +189,16 @@ class MonthlySpending {
     required this.byCategory,
     required this.items,
   });
+}
+
+class YearlySpending {
+  final int year;
+  final List<MonthlySpending> months;
+
+  const YearlySpending({required this.year, required this.months});
+
+  int get totalAmount =>
+      months.fold<int>(0, (sum, month) => sum + month.totalAmount);
 }
 
 class CategoryBreakdown {

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -11,19 +11,15 @@ import '../models/item.dart';
 class SupabaseService {
   static const _supabaseUrl = 'https://fervijwxdgkwjtcpzskx.supabase.co';
   static const _anonKey = 'sb_publishable_FO7WmA_Pu4RsGgsfRJzssQ_f0orCu7w';
-  // flutter run 시 --dart-define=SUPABASE_SERVICE_KEY=sb_secret_... 로 주입
-  static const _serviceKey = String.fromEnvironment('SUPABASE_SERVICE_KEY');
   static const _storageBucket = 'product-images';
 
   static SupabaseClient get _db => Supabase.instance.client;
 
-  /// Storage 업로드 전용 어드민 클라이언트 (service role — RLS 우회)
-  ///
-  /// ⚠️ 프로덕션에서는 서버사이드(Edge Function 등)에서만 사용해야 합니다.
-  static final _adminClient = SupabaseClient(_supabaseUrl, _serviceKey);
-
   /// 카테고리 이름 → UUID 로컬 캐시 (앱 세션 동안 유지)
   static final Map<String, String> _categoryCache = {};
+
+  @visibleForTesting
+  static ProductImageStorageGateway? debugImageStorageGateway;
 
   // ────────────────────────────────────────────────────────────────────────────
   // 초기화 & 인증
@@ -49,28 +45,26 @@ class SupabaseService {
   ///
   /// [imageBytes] 업로드할 이미지 바이트 (image_picker로 획득)
   /// [itemId]     제품 UUID (파일 경로에 사용)
-  static Future<String?> uploadItemImage({
+  static Future<String> uploadItemImage({
     required Uint8List imageBytes,
     required String itemId,
   }) async {
     try {
       final path = 'items/$itemId.jpg';
-      await _adminClient.storage
-          .from(_storageBucket)
-          .uploadBinary(
-            path,
-            imageBytes,
-            fileOptions: const FileOptions(
-              contentType: 'image/jpeg',
-              upsert: true,
-            ),
-          );
-      final url = _adminClient.storage.from(_storageBucket).getPublicUrl(path);
+      final storage =
+          debugImageStorageGateway ??
+          ProductImageStorageGateway.fromClient(_db, _storageBucket);
+      await storage.uploadBinary(
+        path,
+        imageBytes,
+        const FileOptions(contentType: 'image/jpeg', upsert: true),
+      );
+      final url = storage.getPublicUrl(path);
       debugPrint('[Supabase] 이미지 업로드 완료: $url');
       return url;
     } catch (e) {
       debugPrint('[Supabase] 이미지 업로드 오류: $e');
-      return null;
+      rethrow;
     }
   }
 
@@ -273,4 +267,42 @@ class SupabaseService {
       _ => 'category',
     };
   }
+}
+
+abstract class ProductImageStorageGateway {
+  factory ProductImageStorageGateway.fromClient(
+    SupabaseClient client,
+    String bucket,
+  ) = _SupabaseProductImageStorageGateway;
+
+  Future<void> uploadBinary(
+    String path,
+    Uint8List imageBytes,
+    FileOptions fileOptions,
+  );
+
+  String getPublicUrl(String path);
+}
+
+class _SupabaseProductImageStorageGateway
+    implements ProductImageStorageGateway {
+  _SupabaseProductImageStorageGateway(this._client, this._bucket);
+
+  final SupabaseClient _client;
+  final String _bucket;
+
+  @override
+  Future<void> uploadBinary(
+    String path,
+    Uint8List imageBytes,
+    FileOptions fileOptions,
+  ) async {
+    await _client.storage
+        .from(_bucket)
+        .uploadBinary(path, imageBytes, fileOptions: fileOptions);
+  }
+
+  @override
+  String getPublicUrl(String path) =>
+      _client.storage.from(_bucket).getPublicUrl(path);
 }

--- a/lib/utils/dday_format.dart
+++ b/lib/utils/dday_format.dart
@@ -1,0 +1,11 @@
+String formatDdayLabel(int daysRemaining) {
+  if (daysRemaining < 0) return 'D+${daysRemaining.abs()}';
+  if (daysRemaining == 0) return 'D-Day';
+  return 'D-$daysRemaining';
+}
+
+String formatDdayCaption(int daysRemaining) {
+  if (daysRemaining < 0) return '교체 지남';
+  if (daysRemaining == 0) return '오늘 교체';
+  return '교체까지';
+}

--- a/lib/widgets/countdown_ring.dart
+++ b/lib/widgets/countdown_ring.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
+import '../utils/dday_format.dart';
 
 class CountdownRing extends StatelessWidget {
   final int daysRemaining;
@@ -39,7 +40,7 @@ class CountdownRing extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                'D-$daysRemaining',
+                formatDdayLabel(daysRemaining),
                 style: TextStyle(
                   fontSize: size * 0.2,
                   fontWeight: FontWeight.w700,
@@ -48,7 +49,7 @@ class CountdownRing extends StatelessWidget {
               ),
               const SizedBox(height: 2),
               Text(
-                '교체까지',
+                formatDdayCaption(daysRemaining),
                 style: TextStyle(
                   fontSize: size * 0.1,
                   color: AppColors.textMuted,

--- a/lib/widgets/dday_badge.dart
+++ b/lib/widgets/dday_badge.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
+import '../utils/dday_format.dart';
 
 class DdayBadge extends StatelessWidget {
   final int daysRemaining;
@@ -30,7 +31,7 @@ class DdayBadge extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
       ),
       child: Text(
-        'D-$daysRemaining',
+        formatDdayLabel(daysRemaining),
         style: TextStyle(
           color: _textColor,
           fontSize: fontSize,

--- a/lib/widgets/item_card.dart
+++ b/lib/widgets/item_card.dart
@@ -96,7 +96,7 @@ class PurchaseListItem extends StatelessWidget {
       if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
       buffer.write(str[i]);
     }
-    return '${buffer}원';
+    return '$buffer원';
   }
 
   @override

--- a/lib/widgets/reports/category_pie_chart.dart
+++ b/lib/widgets/reports/category_pie_chart.dart
@@ -6,9 +6,14 @@ import '../../theme/app_theme.dart';
 
 const Map<String, Color> _categoryPalette = <String, Color>{
   '위생': Color(0xFF0891B2),
+  '욕실/위생': Color(0xFF0891B2),
   '필터': Color(0xFF059669),
+  '가전/필터': Color(0xFF059669),
   '세탁': Color(0xFFD97706),
+  '세탁/청소': Color(0xFFD97706),
   '주방': Color(0xFF7C3AED),
+  '주방/세제': Color(0xFF7C3AED),
+  '헤어/바디': Color(0xFFDB2777),
   '기타': Color(0xFFEC4899),
 };
 
@@ -76,9 +81,11 @@ class CategoryPieChart extends StatelessWidget {
                     ),
                     const SizedBox(width: 8),
                     SizedBox(
-                      width: 35,
+                      width: 72,
                       child: Text(
                         c.category,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
                           fontSize: 12,
                           color: AppColors.textSecondary,

--- a/lib/widgets/reports/month_filter_list_view.dart
+++ b/lib/widgets/reports/month_filter_list_view.dart
@@ -24,7 +24,7 @@ class MonthFilterListView extends StatelessWidget {
       if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
       buffer.write(str[i]);
     }
-    return '${buffer}원';
+    return '$buffer원';
   }
 
   @override
@@ -105,7 +105,7 @@ class MonthFilterListView extends StatelessWidget {
             width: 38,
             height: 38,
             decoration: BoxDecoration(
-              color: color.withOpacity(0.12),
+              color: color.withValues(alpha: 0.12),
               borderRadius: BorderRadius.circular(10),
             ),
             child: Icon(item.icon, color: color, size: 18),

--- a/lib/widgets/reports/monthly_bar_chart.dart
+++ b/lib/widgets/reports/monthly_bar_chart.dart
@@ -11,11 +11,13 @@ class MonthlyBarChart extends StatelessWidget {
     required this.data,
     this.onMonthTap,
     this.selectedMonth,
+    this.highlightLatest = true,
   });
 
   final List<MonthlySpending> data;
   final void Function(DateTime month)? onMonthTap;
   final DateTime? selectedMonth;
+  final bool highlightLatest;
 
   @override
   Widget build(BuildContext context) {
@@ -96,7 +98,7 @@ class MonthlyBarChart extends StatelessWidget {
             final isLatest = entry.key == data.length - 1;
             final isSelected =
                 selectedMonth != null && entry.value.month == selectedMonth;
-            final highlighted = isSelected || isLatest;
+            final highlighted = isSelected || (highlightLatest && isLatest);
             return BarChartGroupData(
               x: entry.key,
               barRods: [
@@ -105,7 +107,7 @@ class MonthlyBarChart extends StatelessWidget {
                   width: 28,
                   color: highlighted
                       ? AppColors.primary
-                      : AppColors.primary.withOpacity(0.3),
+                      : AppColors.primary.withValues(alpha: 0.3),
                   borderRadius: const BorderRadius.only(
                     topLeft: Radius.circular(6),
                     topRight: Radius.circular(6),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   gtk
   url_launcher_linux
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,11 +6,13 @@ import FlutterMacOS
 import Foundation
 
 import app_links
+import file_selector_macos
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/supabase/migrations/20260506155239_replace_demo_seed_with_curated_household.sql
+++ b/supabase/migrations/20260506155239_replace_demo_seed_with_curated_household.sql
@@ -1,0 +1,216 @@
+-- Replace the bulky generated demo seed with a curated household dataset.
+--
+-- This migration intentionally touches only the deterministic Buylog demo user:
+-- 00000000-0000-4000-8000-000000000101
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.users') is null then
+    raise exception 'public.users must exist before applying curated demo seed';
+  end if;
+
+  if to_regclass('public.categories') is null then
+    raise exception 'public.categories must exist before applying curated demo seed';
+  end if;
+
+  if to_regclass('public.product_items') is null then
+    raise exception 'public.product_items must exist before applying curated demo seed';
+  end if;
+
+  if to_regclass('public.purchases') is null then
+    raise exception 'public.purchases must exist before applying curated demo seed';
+  end if;
+
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'purchases'
+      and column_name = 'use_started_on'
+  ) then
+    raise exception 'public.purchases.use_started_on must exist before applying curated demo seed';
+  end if;
+
+  if (
+    select count(*)
+    from public.categories
+    where user_id is null
+      and group_id is null
+      and name in ('필터류', '주방용품', '세탁용품', '위생용품')
+  ) < 4 then
+    raise exception 'required system categories are missing before applying curated demo seed';
+  end if;
+end $$;
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values (
+  '00000000-0000-4000-8000-000000000101',
+  'authenticated',
+  'authenticated',
+  'demo.user+buylog@example.com',
+  now() - interval '420 days',
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"display_name":"사용자"}'::jsonb,
+  now() - interval '420 days',
+  now()
+)
+on conflict (id) do update
+set
+  email = excluded.email,
+  raw_app_meta_data = excluded.raw_app_meta_data,
+  raw_user_meta_data = excluded.raw_user_meta_data,
+  updated_at = now();
+
+insert into public.users (
+  id,
+  email,
+  display_name,
+  notification_enabled,
+  created_at
+)
+values (
+  '00000000-0000-4000-8000-000000000101',
+  'demo.user+buylog@example.com',
+  '사용자',
+  true,
+  now() - interval '420 days'
+)
+on conflict (id) do update
+set
+  email = excluded.email,
+  display_name = excluded.display_name,
+  notification_enabled = excluded.notification_enabled;
+
+delete from public.product_items
+where user_id = '00000000-0000-4000-8000-000000000101'::uuid;
+
+with curated_products(name, brand, category_name, replacement_cycle_days, created_days_ago) as (
+  values
+    ('정수기 필터', '코웨이', '필터류', 90, 360),
+    ('주방 세제', '자연퐁', '주방용품', 32, 330),
+    ('세탁 세제', '퍼실', '세탁용품', 48, 310),
+    ('휴지', '코디', '위생용품', 36, 300),
+    ('치약', '덴티스테', '위생용품', 70, 250),
+    ('샴푸', '케라시스', '위생용품', 65, 220),
+    ('샤워기 필터', '바디럽', '필터류', 95, 210)
+),
+resolved_products as (
+  select
+    '00000000-0000-4000-8000-000000000101'::uuid as user_id,
+    categories.id as category_id,
+    curated_products.name,
+    curated_products.brand,
+    curated_products.replacement_cycle_days,
+    (current_date - curated_products.created_days_ago)::timestamp with time zone + interval '10 hours' as created_at
+  from curated_products
+  join public.categories
+    on categories.name = curated_products.category_name
+   and categories.user_id is null
+   and categories.group_id is null
+)
+insert into public.product_items (
+  user_id,
+  category_id,
+  name,
+  brand,
+  replacement_cycle_days,
+  registered_by,
+  created_at,
+  updated_at
+)
+select
+  resolved_products.user_id,
+  resolved_products.category_id,
+  resolved_products.name,
+  resolved_products.brand,
+  resolved_products.replacement_cycle_days,
+  resolved_products.user_id,
+  resolved_products.created_at,
+  resolved_products.created_at
+from resolved_products;
+
+with curated_purchases(product_name, product_brand, days_ago, use_delay_days, price, store_name) as (
+  values
+    ('정수기 필터', '코웨이', 284, 1, 34900, '코웨이몰'),
+    ('정수기 필터', '코웨이', 193, 2, 35900, '쿠팡'),
+    ('정수기 필터', '코웨이', 103, 1, 34500, '네이버쇼핑'),
+    ('정수기 필터', '코웨이', 14, 2, 34900, '코웨이몰'),
+
+    ('주방 세제', '자연퐁', 132, 0, 5200, '홈플러스'),
+    ('주방 세제', '자연퐁', 98, 1, 4980, '이마트'),
+    ('주방 세제', '자연퐁', 67, 0, 4700, '쿠팡'),
+    ('주방 세제', '자연퐁', 39, 2, 5200, '이마트'),
+    ('주방 세제', '자연퐁', 8, 1, 4980, '이마트'),
+
+    ('세탁 세제', '퍼실', 151, 4, 18500, '코스트코'),
+    ('세탁 세제', '퍼실', 102, 3, 18900, 'SSG닷컴'),
+    ('세탁 세제', '퍼실', 58, 5, 19200, '쿠팡'),
+    ('세탁 세제', '퍼실', 11, 3, 18900, '쿠팡'),
+
+    ('휴지', '코디', 137, 0, 16200, '이마트'),
+    ('휴지', '코디', 101, 0, 15900, '쿠팡'),
+    ('휴지', '코디', 65, 0, 16200, '이마트'),
+    ('휴지', '코디', 33, 1, 15400, '쿠팡'),
+    ('휴지', '코디', 6, 0, 15900, '마켓컬리'),
+
+    ('치약', '덴티스테', 149, 3, 9500, '네이버쇼핑'),
+    ('치약', '덴티스테', 81, 1, 9800, '쿠팡'),
+    ('치약', '덴티스테', 16, 2, 9900, '올리브영'),
+
+    ('샴푸', '케라시스', 138, 5, 13100, '롯데온'),
+    ('샴푸', '케라시스', 72, 3, 12500, '쿠팡'),
+    ('샴푸', '케라시스', 10, 4, 12900, '올리브영'),
+
+    ('샤워기 필터', '바디럽', 202, 2, 17200, '네이버쇼핑'),
+    ('샤워기 필터', '바디럽', 109, 2, 17500, '쿠팡'),
+    ('샤워기 필터', '바디럽', 19, 3, 17900, '오늘의집')
+),
+resolved_purchases as (
+  select
+    product_items.id as product_item_id,
+    '00000000-0000-4000-8000-000000000101'::uuid as purchased_by,
+    (current_date - curated_purchases.days_ago)::date as purchase_date,
+    (current_date - curated_purchases.days_ago + curated_purchases.use_delay_days)::date as use_started_on,
+    curated_purchases.price,
+    curated_purchases.store_name,
+    (current_date - curated_purchases.days_ago)::timestamp with time zone + interval '13 hours' as created_at
+  from curated_purchases
+  join public.product_items
+    on product_items.user_id = '00000000-0000-4000-8000-000000000101'::uuid
+   and product_items.name = curated_purchases.product_name
+   and product_items.brand = curated_purchases.product_brand
+)
+insert into public.purchases (
+  product_item_id,
+  purchased_by,
+  purchase_date,
+  use_started_on,
+  price,
+  store_name,
+  quantity,
+  created_at
+)
+select
+  resolved_purchases.product_item_id,
+  resolved_purchases.purchased_by,
+  resolved_purchases.purchase_date,
+  resolved_purchases.use_started_on,
+  resolved_purchases.price,
+  resolved_purchases.store_name,
+  1,
+  resolved_purchases.created_at
+from resolved_purchases;
+
+commit;

--- a/supabase/migrations/20260506155649_align_curated_demo_tissue_name.sql
+++ b/supabase/migrations/20260506155649_align_curated_demo_tissue_name.sql
@@ -1,0 +1,13 @@
+-- Align the curated demo dataset with the documented household product name.
+--
+-- The first curated demo seed used "휴지" for the tissue item. The approved
+-- product set names the item "화장지", so this migration corrects only the
+-- deterministic demo user's row.
+
+update public.product_items
+set
+  name = '화장지',
+  updated_at = now()
+where user_id = '00000000-0000-4000-8000-000000000101'::uuid
+  and name = '휴지'
+  and brand = '코디';

--- a/supabase/migrations/20260506160914_curate_dev_user_product_items.sql
+++ b/supabase/migrations/20260506160914_curate_dev_user_product_items.sql
@@ -1,0 +1,346 @@
+-- Replace noisy development-user product_items with a realistic household set.
+--
+-- The Flutter app currently reads this fixed development user through
+-- SupabaseService.currentUserId. Keep this cleanup scoped to that user only.
+
+begin;
+
+do $$
+begin
+  if to_regclass('public.users') is null then
+    raise exception 'public.users must exist before applying curate_dev_user_product_items';
+  end if;
+
+  if to_regclass('public.categories') is null then
+    raise exception 'public.categories must exist before applying curate_dev_user_product_items';
+  end if;
+
+  if to_regclass('public.product_items') is null then
+    raise exception 'public.product_items must exist before applying curate_dev_user_product_items';
+  end if;
+
+  if to_regclass('public.purchases') is null then
+    raise exception 'public.purchases must exist before applying curate_dev_user_product_items';
+  end if;
+
+  if to_regclass('public.ai_predictions') is null then
+    raise exception 'public.ai_predictions must exist before applying curate_dev_user_product_items';
+  end if;
+
+  if not exists (
+    select 1
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'purchases'
+      and column_name = 'use_started_on'
+  ) then
+    raise exception 'public.purchases.use_started_on must exist before applying curate_dev_user_product_items';
+  end if;
+end $$;
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values (
+  '08cccfe3-766f-43bd-b06c-8d909e0f9fe8',
+  'authenticated',
+  'authenticated',
+  'dev.user+buylog@example.com',
+  now() - interval '420 days',
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  '{"display_name":"사용자"}'::jsonb,
+  now() - interval '420 days',
+  now()
+)
+on conflict (id) do update
+set
+  email = excluded.email,
+  raw_app_meta_data = excluded.raw_app_meta_data,
+  raw_user_meta_data = excluded.raw_user_meta_data,
+  updated_at = now();
+
+insert into public.users (
+  id,
+  email,
+  display_name,
+  notification_enabled,
+  created_at
+)
+values (
+  '08cccfe3-766f-43bd-b06c-8d909e0f9fe8',
+  'dev.user+buylog@example.com',
+  '사용자',
+  true,
+  now() - interval '420 days'
+)
+on conflict (id) do update
+set
+  email = excluded.email,
+  display_name = excluded.display_name,
+  notification_enabled = excluded.notification_enabled;
+
+create temporary table curate_dev_user_product_items_decision (
+  should_replace boolean not null
+) on commit drop;
+
+do $$
+declare
+  existing_product_count int;
+  noisy_product_count int;
+  curated_product_count int;
+  existing_purchase_count int;
+  existing_prediction_count int;
+begin
+  select
+    count(*)::int,
+    count(*) filter (
+      where name ilike '%test%'
+         or name ilike '%issue%'
+         or name like '테스트 물품%'
+         or name in ('삼다수2L', '테스트 세제', '테스트 필터')
+    )::int,
+    count(*) filter (
+      where (name, brand) in (
+        ('샤워기 필터', '바디럽'),
+        ('정수기 필터', '코웨이'),
+        ('주방 세제', '자연퐁'),
+        ('식기세척기 세제', '프로쉬'),
+        ('세탁 세제', '퍼실'),
+        ('화장지', '코디'),
+        ('치약', '덴티스테'),
+        ('샴푸', '케라시스')
+      )
+    )::int
+  into existing_product_count, noisy_product_count, curated_product_count
+  from public.product_items
+  where user_id = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid;
+
+  select count(*)::int
+  into existing_purchase_count
+  from public.purchases
+  join public.product_items
+    on product_items.id = purchases.product_item_id
+  where product_items.user_id = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid;
+
+  select count(*)::int
+  into existing_prediction_count
+  from public.ai_predictions
+  join public.product_items
+    on product_items.id = ai_predictions.product_item_id
+  where product_items.user_id = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid;
+
+  if existing_product_count > 0
+     and noisy_product_count = 0
+     and curated_product_count <> existing_product_count then
+    raise exception
+      'Refusing to replace % existing development-user product_items without noisy seed markers',
+      existing_product_count;
+  end if;
+
+  insert into curate_dev_user_product_items_decision (should_replace)
+  values (
+    existing_product_count = 0
+    or noisy_product_count > 0
+    or (
+      existing_product_count = 8
+      and curated_product_count = 8
+      and existing_purchase_count < 30
+      and existing_prediction_count = 0
+    )
+  );
+end $$;
+
+with desired_categories(name, icon, color, sort_order) as (
+  values
+    ('욕실/위생', 'bathroom', '#4A90D9', 10),
+    ('주방/세제', 'kitchen', '#E8913A', 20),
+    ('세탁/청소', 'laundry', '#9B59B6', 30),
+    ('헤어/바디', 'shower', '#2ECC71', 40),
+    ('가전/필터', 'air', '#45B7D1', 50)
+)
+insert into public.categories (
+  user_id,
+  name,
+  icon,
+  color,
+  sort_order
+)
+select
+  '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid,
+  desired_categories.name,
+  desired_categories.icon,
+  desired_categories.color,
+  desired_categories.sort_order
+from desired_categories
+where not exists (
+  select 1
+  from public.categories existing
+  where existing.user_id = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid
+    and existing.group_id is null
+    and existing.name = desired_categories.name
+);
+
+delete from public.product_items
+where user_id = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid
+  and exists (
+    select 1
+    from curate_dev_user_product_items_decision
+    where should_replace
+  );
+
+with curated_products(name, brand, category_name, replacement_cycle_days, created_days_ago) as (
+  values
+    ('샤워기 필터', '바디럽', '가전/필터', 95, 260),
+    ('정수기 필터', '코웨이', '가전/필터', 90, 340),
+    ('주방 세제', '자연퐁', '주방/세제', 32, 210),
+    ('식기세척기 세제', '프로쉬', '주방/세제', 45, 190),
+    ('세탁 세제', '퍼실', '세탁/청소', 48, 240),
+    ('화장지', '코디', '욕실/위생', 36, 180),
+    ('치약', '덴티스테', '욕실/위생', 70, 220),
+    ('샴푸', '케라시스', '헤어/바디', 65, 200)
+),
+category_candidates as (
+  select
+    categories.id,
+    categories.name,
+    row_number() over (
+      partition by categories.name
+      order by categories.created_at desc, categories.id
+    ) as rn
+  from public.categories
+  where categories.user_id = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid
+    and categories.group_id is null
+    and categories.name in (
+      '욕실/위생',
+      '주방/세제',
+      '세탁/청소',
+      '헤어/바디',
+      '가전/필터'
+    )
+),
+resolved_products as (
+  select
+    '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid as user_id,
+    category_candidates.id as category_id,
+    curated_products.name,
+    curated_products.brand,
+    curated_products.replacement_cycle_days,
+    (current_date - curated_products.created_days_ago)::timestamp with time zone + interval '10 hours' as created_at
+  from curated_products
+  cross join curate_dev_user_product_items_decision
+  join category_candidates
+    on category_candidates.name = curated_products.category_name
+   and category_candidates.rn = 1
+  where curate_dev_user_product_items_decision.should_replace
+)
+insert into public.product_items (
+  user_id,
+  category_id,
+  name,
+  brand,
+  replacement_cycle_days,
+  registered_by,
+  created_at,
+  updated_at
+)
+select
+  resolved_products.user_id,
+  resolved_products.category_id,
+  resolved_products.name,
+  resolved_products.brand,
+  resolved_products.replacement_cycle_days,
+  resolved_products.user_id,
+  resolved_products.created_at,
+  resolved_products.created_at
+from resolved_products;
+
+-- The current Flutter UI calculates D-day from purchase_date, so days_ago
+-- drives the visible overdue/near-due/future spread. use_delay_days only keeps
+-- use_started_on coherent for future consumers that distinguish actual use.
+with curated_purchases(product_name, product_brand, days_ago, use_delay_days, price, store_name) as (
+  values
+    ('샤워기 필터', '바디럽', 289, 2, 17200, '네이버쇼핑'),
+    ('샤워기 필터', '바디럽', 194, 2, 17500, '쿠팡'),
+    ('샤워기 필터', '바디럽', 101, 3, 17900, '오늘의집'),
+
+    ('정수기 필터', '코웨이', 354, 1, 34900, '코웨이몰'),
+    ('정수기 필터', '코웨이', 263, 2, 35900, '쿠팡'),
+    ('정수기 필터', '코웨이', 173, 1, 34500, '네이버쇼핑'),
+    ('정수기 필터', '코웨이', 83, 2, 34900, '코웨이몰'),
+
+    ('주방 세제', '자연퐁', 132, 0, 5200, '홈플러스'),
+    ('주방 세제', '자연퐁', 98, 1, 4980, '이마트'),
+    ('주방 세제', '자연퐁', 67, 0, 4700, '쿠팡'),
+    ('주방 세제', '자연퐁', 31, 1, 4980, '이마트'),
+
+    ('식기세척기 세제', '프로쉬', 181, 3, 11900, 'SSG닷컴'),
+    ('식기세척기 세제', '프로쉬', 135, 4, 12200, '마켓컬리'),
+    ('식기세척기 세제', '프로쉬', 88, 2, 11800, '쿠팡'),
+    ('식기세척기 세제', '프로쉬', 44, 3, 11900, '쿠팡'),
+
+    ('세탁 세제', '퍼실', 151, 4, 18500, '코스트코'),
+    ('세탁 세제', '퍼실', 102, 3, 18900, 'SSG닷컴'),
+    ('세탁 세제', '퍼실', 58, 5, 19200, '쿠팡'),
+    ('세탁 세제', '퍼실', 11, 3, 18900, '쿠팡'),
+
+    ('화장지', '코디', 137, 0, 16200, '이마트'),
+    ('화장지', '코디', 101, 0, 15900, '쿠팡'),
+    ('화장지', '코디', 65, 0, 16200, '이마트'),
+    ('화장지', '코디', 33, 1, 15400, '쿠팡'),
+    ('화장지', '코디', 6, 0, 15900, '마켓컬리'),
+
+    ('치약', '덴티스테', 188, 3, 9500, '네이버쇼핑'),
+    ('치약', '덴티스테', 121, 1, 9800, '쿠팡'),
+    ('치약', '덴티스테', 55, 2, 9900, '올리브영'),
+
+    ('샴푸', '케라시스', 195, 5, 13100, '롯데온'),
+    ('샴푸', '케라시스', 129, 3, 12500, '쿠팡'),
+    ('샴푸', '케라시스', 63, 4, 12900, '올리브영')
+),
+resolved_purchases as (
+  select
+    product_items.id as product_item_id,
+    '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid as purchased_by,
+    (current_date - curated_purchases.days_ago)::date as purchase_date,
+    (current_date - curated_purchases.days_ago + curated_purchases.use_delay_days)::date as use_started_on,
+    curated_purchases.price,
+    curated_purchases.store_name,
+    (current_date - curated_purchases.days_ago)::timestamp with time zone + interval '13 hours' as created_at
+  from curated_purchases
+  cross join curate_dev_user_product_items_decision
+  join public.product_items
+    on product_items.user_id = '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid
+   and product_items.name = curated_purchases.product_name
+   and product_items.brand = curated_purchases.product_brand
+  where curate_dev_user_product_items_decision.should_replace
+)
+insert into public.purchases (
+  product_item_id,
+  purchased_by,
+  purchase_date,
+  use_started_on,
+  price,
+  store_name,
+  quantity,
+  created_at
+)
+select
+  resolved_purchases.product_item_id,
+  resolved_purchases.purchased_by,
+  resolved_purchases.purchase_date,
+  resolved_purchases.use_started_on,
+  resolved_purchases.price,
+  resolved_purchases.store_name,
+  1,
+  resolved_purchases.created_at
+from resolved_purchases;
+
+commit;

--- a/supabase/migrations/20260506163244_allow_product_image_uploads.sql
+++ b/supabase/migrations/20260506163244_allow_product_image_uploads.sql
@@ -1,0 +1,56 @@
+-- Allow the Flutter app to upload product images without a client-side
+-- service-role key. The bucket is public for reads, while write policies are
+-- scoped to the product image path prefix used by SupabaseService.
+
+begin;
+
+insert into storage.buckets (
+  id,
+  name,
+  public
+)
+values (
+  'product-images',
+  'product-images',
+  true
+)
+on conflict (id) do update
+set
+  name = excluded.name,
+  public = excluded.public;
+
+drop policy if exists "Public read product images" on storage.objects;
+drop policy if exists "Upload product images" on storage.objects;
+drop policy if exists "Update product images" on storage.objects;
+
+create policy "Public read product images"
+on storage.objects
+for select
+to anon, authenticated
+using (
+  bucket_id = 'product-images'
+);
+
+create policy "Upload product images"
+on storage.objects
+for insert
+to anon, authenticated
+with check (
+  bucket_id = 'product-images'
+  and name like 'items/%'
+);
+
+create policy "Update product images"
+on storage.objects
+for update
+to anon, authenticated
+using (
+  bucket_id = 'product-images'
+  and name like 'items/%'
+)
+with check (
+  bucket_id = 'product-images'
+  and name like 'items/%'
+);
+
+commit;

--- a/test/data/sample_data_test.dart
+++ b/test/data/sample_data_test.dart
@@ -1,0 +1,110 @@
+import 'package:buylog/data/sample_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SampleData regression', () {
+    test('has enough items and required category coverage', () {
+      expect(SampleData.items.length, greaterThanOrEqualTo(10));
+
+      final categories = SampleData.items.map((item) => item.category).toSet();
+      expect(
+        categories,
+        containsAll({'욕실/위생', '주방/세제', '세탁/청소', '헤어/바디', '가전/필터'}),
+      );
+    });
+
+    test('every item has complete and sorted purchase history', () {
+      for (final item in SampleData.items) {
+        expect(
+          item.name.trim(),
+          isNotEmpty,
+          reason: '${item.id} name is empty',
+        );
+        expect(
+          item.brand.trim(),
+          isNotEmpty,
+          reason: '${item.id} brand is empty',
+        );
+        expect(
+          item.purchaseHistory.length,
+          greaterThanOrEqualTo(2),
+          reason: '${item.name} must have at least 2 purchase records',
+        );
+
+        for (var i = 0; i < item.purchaseHistory.length; i++) {
+          final record = item.purchaseHistory[i];
+          expect(
+            record.price,
+            greaterThan(0),
+            reason: '${item.name} has non-positive price',
+          );
+          expect(
+            record.store.trim(),
+            isNotEmpty,
+            reason: '${item.name} has empty store',
+          );
+
+          if (i < item.purchaseHistory.length - 1) {
+            final next = item.purchaseHistory[i + 1];
+            expect(
+              record.date.isAfter(next.date) ||
+                  record.date.isAtSameMomentAs(next.date),
+              isTrue,
+              reason: '${item.name} purchaseHistory must be newest first',
+            );
+          }
+        }
+      }
+    });
+
+    test('recent six-month window contains at least 8 purchases', () {
+      final now = DateTime.now();
+      final windowStart = DateTime(now.year, now.month - 5, 1);
+
+      final recentPurchaseCount = SampleData.items
+          .expand((item) => item.purchaseHistory)
+          .where(
+            (record) =>
+                !record.date.isBefore(windowStart) && !record.date.isAfter(now),
+          )
+          .length;
+
+      expect(recentPurchaseCount, greaterThanOrEqualTo(8));
+    });
+
+    test('itemsFor regenerates date-relative data from normalized now', () {
+      final may6Items = SampleData.itemsFor(DateTime(2026, 5, 6, 23, 59));
+      final may8Items = SampleData.itemsFor(DateTime(2026, 5, 8, 23, 59));
+
+      final may6First = may6Items.first;
+      final may8First = may8Items.first;
+      final may8FirstPurchase = may8First.purchaseHistory.first;
+
+      expect(
+        may8First.purchaseHistory.first.date.difference(
+          may6First.purchaseHistory.first.date,
+        ),
+        const Duration(days: 2),
+      );
+      expect(may8First.daysRemaining, may6First.daysRemaining);
+      expect(may8FirstPurchase.date, DateTime(2026, 4, 24));
+      expect(may8FirstPurchase.date.hour, 0);
+      expect(may8FirstPurchase.date.minute, 0);
+    });
+
+    test('group members use exact neutral labels', () {
+      const expectedNames = ['사용자', '가족 A', '가족 B', '가족 C'];
+      final memberNames = SampleData.groupMembers
+          .map((member) => member.name)
+          .toList();
+
+      expect(memberNames, expectedNames);
+      expect(
+        memberNames.every(
+          (name) => !name.contains('지민') && !name.contains('김지민'),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/screens/home_screen_recent_purchase_test.dart
+++ b/test/screens/home_screen_recent_purchase_test.dart
@@ -1,0 +1,112 @@
+import 'package:buylog/models/item.dart';
+import 'package:buylog/screens/home_screen.dart';
+import 'package:buylog/services/item_store.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ConsumableItem _buildItem({
+  required String id,
+  required String name,
+  required String brand,
+  required IconData icon,
+  required int daysRemaining,
+  List<PurchaseRecord> purchaseHistory = const [],
+}) {
+  return ConsumableItem(
+    id: id,
+    name: name,
+    brand: brand,
+    category: '생활용품',
+    icon: icon,
+    daysRemaining: daysRemaining,
+    cycleDays: 30,
+    progress: 0.3,
+    purchaseHistory: purchaseHistory,
+  );
+}
+
+Widget _wrapHome() {
+  return const MaterialApp(home: Scaffold(body: HomeScreen()));
+}
+
+void main() {
+  setUp(() {
+    ItemStore.instance.value = [];
+  });
+
+  tearDown(() {
+    ItemStore.instance.value = [];
+  });
+
+  testWidgets('uses neutral user name in the latest home UI', (tester) async {
+    await tester.pumpWidget(_wrapHome());
+
+    expect(find.textContaining('사용자'), findsOneWidget);
+    expect(find.textContaining('지민'), findsNothing);
+  });
+
+  testWidgets('renders recent ledger rows from ItemStore purchase history', (
+    tester,
+  ) async {
+    ItemStore.instance.value = [
+      _buildItem(
+        id: 'filter',
+        name: '샤워기 필터',
+        brand: '바디럽',
+        icon: Icons.water_drop_outlined,
+        daysRemaining: 2,
+        purchaseHistory: [
+          PurchaseRecord(
+            date: DateTime(2026, 5, 5),
+            price: 34900,
+            store: '코웨이몰',
+          ),
+        ],
+      ),
+      _buildItem(
+        id: 'capsule',
+        name: '세탁 캡슐',
+        brand: '퍼실',
+        icon: Icons.local_laundry_service_outlined,
+        daysRemaining: 10,
+        purchaseHistory: [
+          PurchaseRecord(
+            date: DateTime(2026, 4, 27),
+            price: 17900,
+            store: '쿠팡',
+          ),
+        ],
+      ),
+    ];
+
+    await tester.pumpWidget(_wrapHome());
+
+    expect(find.text('최근 기록'), findsOneWidget);
+    expect(find.text('샤워기 필터 구매 기록됨 · 코웨이몰 · 34,900원'), findsOneWidget);
+    expect(find.text('세탁 캡슐 구매 기록됨 · 쿠팡 · 17,900원'), findsOneWidget);
+    expect(find.text('05.05'), findsOneWidget);
+    expect(find.text('04.27'), findsOneWidget);
+    expect(find.text('이마트 영수증 3개 항목 자동 추가'), findsNothing);
+    expect(find.text('세탁세제 주기 45일로 업데이트'), findsNothing);
+  });
+
+  testWidgets('shows an honest empty state when no purchase history exists', (
+    tester,
+  ) async {
+    ItemStore.instance.value = [
+      _buildItem(
+        id: 'tissue',
+        name: '미용 티슈',
+        brand: '크리넥스',
+        icon: Icons.inventory_2_outlined,
+        daysRemaining: 5,
+      ),
+    ];
+
+    await tester.pumpWidget(_wrapHome());
+
+    expect(find.text('최근 기록'), findsOneWidget);
+    expect(find.text('최근 기록이 없습니다.'), findsOneWidget);
+    expect(find.textContaining('영수증'), findsNothing);
+  });
+}

--- a/test/screens/reports_screen_year_view_test.dart
+++ b/test/screens/reports_screen_year_view_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/screens/reports_screen.dart';
+
+Widget _wrap() {
+  return const MaterialApp(home: Scaffold(body: ReportsScreen()));
+}
+
+Future<void> _pumpReportsScreen(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(800, 2200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(_wrap());
+}
+
+void main() {
+  group('ReportsScreen year view', () {
+    testWidgets('shows month/year mode controls', (tester) async {
+      await _pumpReportsScreen(tester);
+
+      expect(find.text('월간'), findsOneWidget);
+      expect(find.text('연간'), findsOneWidget);
+    });
+
+    testWidgets('tapping year mode shows annual summary and yearly trend', (
+      tester,
+    ) async {
+      await _pumpReportsScreen(tester);
+
+      await tester.tap(find.text('연간'));
+      await tester.pump();
+
+      final currentYear = DateTime.now().year;
+      expect(find.text('연간 지출 현황'), findsOneWidget);
+      expect(find.text('$currentYear년'), findsWidgets);
+      expect(find.text('연간 월별 지출'), findsOneWidget);
+      expect(find.text('월별 지출 추이'), findsNothing);
+    });
+  });
+}

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -1,0 +1,22 @@
+import 'package:buylog/screens/settings_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('SettingsScreen shows a neutralized profile card', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: SettingsScreen())),
+    );
+
+    expect(find.text('사용자'), findsOneWidget);
+    expect(find.text('사'), findsOneWidget);
+    expect(find.text('계정 정보 없음'), findsOneWidget);
+
+    expect(find.text('지민'), findsNothing);
+    expect(find.text('김지민'), findsNothing);
+    expect(find.text('김민수'), findsNothing);
+    expect(find.text('minsu@email.com'), findsNothing);
+  });
+}

--- a/test/services/recent_purchase_service_test.dart
+++ b/test/services/recent_purchase_service_test.dart
@@ -1,0 +1,379 @@
+import 'package:buylog/models/item.dart';
+import 'package:buylog/services/recent_purchase_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RecentPurchaseService.fromItems', () {
+    test('returns newest-first purchases, applies limit, and maps fields', () {
+      final items = <ConsumableItem>[
+        ConsumableItem(
+          id: 'item-1',
+          name: '세탁세제',
+          brand: '브랜드A',
+          category: '세탁',
+          icon: Icons.local_laundry_service_outlined,
+          daysRemaining: 4,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 5, 1),
+              price: 8900,
+              store: '쿠팡',
+            ),
+            PurchaseRecord(
+              date: DateTime(2026, 4, 15),
+              price: 7900,
+              store: '홈플러스',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'item-2',
+          name: '주방세제',
+          brand: '브랜드B',
+          category: '주방',
+          icon: Icons.kitchen_outlined,
+          daysRemaining: 8,
+          cycleDays: 40,
+          progress: 0.3,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 5, 5),
+              price: 4900,
+              store: '홈플러스',
+            ),
+            PurchaseRecord(
+              date: DateTime(2026, 4, 30),
+              price: 4500,
+              store: '다이소',
+            ),
+          ],
+        ),
+      ];
+
+      final rows = RecentPurchaseService.fromItems(items);
+
+      expect(rows, hasLength(3));
+      expect(rows[0].itemId, 'item-2');
+      expect(rows[0].itemName, '주방세제');
+      expect(rows[0].brand, '브랜드B');
+      expect(rows[0].icon, Icons.kitchen_outlined);
+      expect(rows[0].date, DateTime(2026, 5, 5));
+      expect(rows[0].price, 4900);
+      expect(rows[0].store, '홈플러스');
+      expect(rows[1].date, DateTime(2026, 5, 1));
+      expect(rows[1].itemId, 'item-1');
+      expect(rows[2].date, DateTime(2026, 4, 30));
+      expect(rows[2].itemId, 'item-2');
+    });
+
+    test('returns empty list when every item has empty purchase history', () {
+      final items = <ConsumableItem>[
+        ConsumableItem(
+          id: 'item-1',
+          name: '휴지',
+          brand: '브랜드A',
+          category: '생활',
+          icon: Icons.category_outlined,
+          daysRemaining: 10,
+          cycleDays: 30,
+          progress: 0.2,
+        ),
+        ConsumableItem(
+          id: 'item-2',
+          name: '물티슈',
+          brand: '브랜드B',
+          category: '생활',
+          icon: Icons.category_outlined,
+          daysRemaining: 5,
+          cycleDays: 20,
+          progress: 0.5,
+        ),
+      ];
+
+      final rows = RecentPurchaseService.fromItems(items);
+
+      expect(rows, isEmpty);
+    });
+
+    test('returns empty list for empty input', () {
+      final rows = RecentPurchaseService.fromItems(const []);
+
+      expect(rows, isEmpty);
+    });
+
+    test('returns empty list when limit is zero', () {
+      final items = <ConsumableItem>[
+        ConsumableItem(
+          id: 'item-1',
+          name: '휴지',
+          brand: '브랜드A',
+          category: '생활',
+          icon: Icons.category_outlined,
+          daysRemaining: 10,
+          cycleDays: 30,
+          progress: 0.2,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 5, 1),
+              price: 1000,
+              store: '마트',
+            ),
+          ],
+        ),
+      ];
+
+      final rows = RecentPurchaseService.fromItems(items, limit: 0);
+
+      expect(rows, isEmpty);
+    });
+  });
+
+  group('RecentPurchaseService.fromPurchaseRows', () {
+    test(
+      'returns purchase-recency rows newest first even when the newest purchase belongs to an older item',
+      () {
+        final rows = [
+          {
+            'id': 'purchase-1',
+            'purchase_date': '2026-05-06',
+            'price': 15900,
+            'store_name': '코스트코',
+            'product_items': {
+              'id': 'older-item',
+              'name': '대용량 세제',
+              'brand': '브랜드A',
+              'categories': {'name': '세탁'},
+            },
+          },
+          {
+            'id': 'purchase-2',
+            'purchase_date': '2026-05-04',
+            'price': 4900,
+            'store_name': '홈플러스',
+            'product_items': {
+              'id': 'newer-item',
+              'name': '주방세제',
+              'brand': '브랜드B',
+              'categories': {'name': '주방'},
+            },
+          },
+        ];
+
+        final parsed = RecentPurchaseService.fromPurchaseRows(rows);
+
+        expect(parsed, hasLength(2));
+        expect(parsed.first.itemId, 'older-item');
+        expect(parsed.first.itemName, '대용량 세제');
+        expect(parsed.first.icon, ConsumableItem.iconForCategory('세탁'));
+        expect(parsed.first.store, '코스트코');
+        expect(parsed.first.date, DateTime(2026, 5, 6));
+        expect(parsed.last.itemId, 'newer-item');
+      },
+    );
+
+    test('applies positive limit after sorting newest first', () {
+      final rows = [
+        {
+          'id': 'purchase-older',
+          'purchase_date': '2026-05-02',
+          'price': 3000,
+          'store_name': '다이소',
+          'product_items': {
+            'id': 'item-1',
+            'name': '휴지',
+            'brand': '브랜드A',
+            'categories': {'name': '생활'},
+          },
+        },
+        {
+          'id': 'purchase-newest',
+          'purchase_date': '2026-05-06',
+          'price': 5000,
+          'store_name': '쿠팡',
+          'product_items': {
+            'id': 'item-2',
+            'name': '물티슈',
+            'brand': '브랜드B',
+            'categories': {'name': '생활'},
+          },
+        },
+        {
+          'id': 'purchase-second',
+          'purchase_date': '2026-05-04',
+          'price': 4200,
+          'store_name': '홈플러스',
+          'product_items': {
+            'id': 'item-3',
+            'name': '주방세제',
+            'brand': '브랜드C',
+            'categories': {'name': '주방'},
+          },
+        },
+      ];
+
+      final parsed = RecentPurchaseService.fromPurchaseRows(rows, limit: 2);
+
+      expect(parsed, hasLength(2));
+      expect(parsed[0].itemId, 'item-2');
+      expect(parsed[0].icon, ConsumableItem.iconForCategory('생활'));
+      expect(parsed[0].date, DateTime(2026, 5, 6));
+      expect(parsed[1].itemId, 'item-3');
+      expect(parsed[1].icon, ConsumableItem.iconForCategory('주방'));
+      expect(parsed[1].date, DateTime(2026, 5, 4));
+    });
+
+    test('uses created_at as a tie breaker when purchase_date is the same', () {
+      final rows = [
+        {
+          'id': 'purchase-early',
+          'purchase_date': '2026-05-06',
+          'created_at': '2026-05-06T08:00:00Z',
+          'price': 4000,
+          'store_name': '마트',
+          'product_items': {
+            'id': 'item-1',
+            'name': '휴지',
+            'brand': '브랜드A',
+            'categories': {'name': '생활'},
+          },
+        },
+        {
+          'id': 'purchase-late',
+          'purchase_date': '2026-05-06',
+          'created_at': '2026-05-06T20:00:00Z',
+          'price': 5000,
+          'store_name': '쿠팡',
+          'product_items': {
+            'id': 'item-2',
+            'name': '물티슈',
+            'brand': '브랜드B',
+            'categories': {'name': '생활'},
+          },
+        },
+      ];
+
+      final parsed = RecentPurchaseService.fromPurchaseRows(rows, limit: 2);
+
+      expect(parsed.map((row) => row.itemId), ['item-2', 'item-1']);
+      expect(parsed.first.store, '쿠팡');
+    });
+
+    test('returns empty list when helper limit is non-positive', () {
+      final validRows = [
+        {
+          'id': 'purchase-1',
+          'purchase_date': '2026-05-06',
+          'created_at': '2026-05-06T20:00:00Z',
+          'price': 5000,
+          'store_name': '쿠팡',
+          'product_items': {
+            'id': 'item-2',
+            'name': '물티슈',
+            'brand': '브랜드B',
+            'categories': {'name': '생활'},
+          },
+        },
+      ];
+
+      expect(
+        RecentPurchaseService.fromPurchaseRows(validRows, limit: 0),
+        isEmpty,
+      );
+      expect(
+        RecentPurchaseService.fromPurchaseRows(validRows, limit: -1),
+        isEmpty,
+      );
+    });
+
+    test('filters out rows for other users when userId is provided', () {
+      final rows = [
+        {
+          'id': 'purchase-1',
+          'purchased_by': 'user-1',
+          'purchase_date': '2026-05-06',
+          'price': 5000,
+          'store_name': '쿠팡',
+          'product_items': {
+            'id': 'item-1',
+            'name': '물티슈',
+            'brand': '브랜드A',
+            'categories': {'name': '생활'},
+          },
+        },
+        {
+          'id': 'purchase-2',
+          'purchased_by': 'user-2',
+          'purchase_date': '2026-05-07',
+          'price': 7000,
+          'store_name': '홈플러스',
+          'product_items': {
+            'id': 'item-2',
+            'name': '주방세제',
+            'brand': '브랜드B',
+            'categories': {'name': '주방'},
+          },
+        },
+      ];
+
+      final parsed = RecentPurchaseService.fromPurchaseRows(
+        rows,
+        userId: 'user-1',
+      );
+
+      expect(parsed, hasLength(1));
+      expect(parsed.single.itemId, 'item-1');
+      expect(parsed.single.store, '쿠팡');
+    });
+
+    test('skips malformed rows and returns empty list for empty input', () {
+      final rows = [
+        <String, dynamic>{},
+        {
+          'id': 'missing-product',
+          'purchase_date': '2026-05-06',
+          'price': 1000,
+          'store_name': '마트',
+          'product_items': null,
+        },
+        {
+          'id': 'bad-date',
+          'purchase_date': 'not-a-date',
+          'price': 1000,
+          'store_name': '마트',
+          'product_items': {
+            'id': 'item-1',
+            'name': '휴지',
+            'brand': '브랜드A',
+            'categories': {'name': '생활'},
+          },
+        },
+        {
+          'id': 'valid',
+          'purchase_date': '2026-05-01',
+          'price': 3200,
+          'store_name': '다이소',
+          'product_items': {
+            'id': 'item-2',
+            'name': '물티슈',
+            'brand': '브랜드B',
+            'categories': null,
+          },
+        },
+      ];
+
+      expect(RecentPurchaseService.fromPurchaseRows(const []), isEmpty);
+
+      final parsed = RecentPurchaseService.fromPurchaseRows(rows);
+
+      expect(parsed, hasLength(1));
+      expect(parsed.single.itemId, 'item-2');
+      expect(parsed.single.itemName, '물티슈');
+      expect(parsed.single.brand, '브랜드B');
+      expect(parsed.single.price, 3200);
+      expect(parsed.single.store, '다이소');
+    });
+  });
+}

--- a/test/services/report_service_test.dart
+++ b/test/services/report_service_test.dart
@@ -196,6 +196,125 @@ void main() {
     });
   });
 
+  group('ReportService annual reports', () {
+    test('aggregateYear returns 12 month buckets and annual total', () {
+      final fixture = <ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '세제',
+          brand: 'x',
+          category: '세탁',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 1, 12),
+              price: 10000,
+              store: 's',
+            ),
+            PurchaseRecord(
+              date: DateTime(2026, 3, 15),
+              price: 15000,
+              store: 's',
+            ),
+            PurchaseRecord(
+              date: DateTime(2025, 12, 30),
+              price: 99999,
+              store: 's',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'b',
+          name: '필터',
+          brand: 'x',
+          category: '필터',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 3, 20),
+              price: 8000,
+              store: 's',
+            ),
+          ],
+        ),
+      ];
+
+      final service = ReportService.fromItems(fixture);
+      final yearly = service.aggregateYear(2026);
+
+      expect(yearly.year, 2026);
+      expect(yearly.months.length, 12);
+      expect(yearly.months.first.month, DateTime(2026, 1, 1));
+      expect(yearly.months.last.month, DateTime(2026, 12, 1));
+      expect(yearly.totalAmount, 33000);
+      expect(yearly.months[0].totalAmount, 10000);
+      expect(yearly.months[2].totalAmount, 23000);
+      expect(yearly.months[11].totalAmount, 0);
+    });
+
+    test('categoryBreakdownForYear aggregates only the selected year', () {
+      final service = ReportService.fromItems(<ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '세제',
+          brand: 'x',
+          category: '세탁',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 2, 1),
+              price: 12000,
+              store: 's',
+            ),
+            PurchaseRecord(
+              date: DateTime(2025, 2, 1),
+              price: 99000,
+              store: 's',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'b',
+          name: '필터',
+          brand: 'x',
+          category: '필터',
+          icon: Icons.circle,
+          daysRemaining: 0,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 2, 5),
+              price: 18000,
+              store: 's',
+            ),
+          ],
+        ),
+      ]);
+
+      final breakdown = service.categoryBreakdownForYear(2026);
+
+      expect(breakdown.length, 2);
+      expect(breakdown[0].category, '필터');
+      expect(breakdown[0].amount, 18000);
+      expect(breakdown[1].category, '세탁');
+      expect(breakdown[1].amount, 12000);
+      expect(
+        breakdown.fold<double>(0, (sum, item) => sum + item.ratio),
+        closeTo(1.0, 0.001),
+      );
+    });
+  });
+
   group('ReportService.latestMonthlyWithSpending', () {
     // 회귀: 현재 월 구매가 없으면 months.last가 0원 버킷이 되어 요약 화면이
     // "0원"으로 무너지는 문제(Codex adversarial review Finding 2). 이 메서드는

--- a/test/services/supabase_service_test.dart
+++ b/test/services/supabase_service_test.dart
@@ -1,0 +1,80 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'package:buylog/services/supabase_service.dart';
+
+class _FailingImageStorageGateway implements ProductImageStorageGateway {
+  @override
+  Future<void> uploadBinary(
+    String path,
+    Uint8List imageBytes,
+    FileOptions fileOptions,
+  ) {
+    throw StateError('upload failed');
+  }
+
+  @override
+  String getPublicUrl(String path) => 'https://example.com/$path';
+}
+
+class _RecordingImageStorageGateway implements ProductImageStorageGateway {
+  String? uploadedPath;
+  Uint8List? uploadedBytes;
+  FileOptions? uploadedOptions;
+
+  @override
+  Future<void> uploadBinary(
+    String path,
+    Uint8List imageBytes,
+    FileOptions fileOptions,
+  ) async {
+    uploadedPath = path;
+    uploadedBytes = imageBytes;
+    uploadedOptions = fileOptions;
+  }
+
+  @override
+  String getPublicUrl(String path) => 'https://cdn.example.com/$path';
+}
+
+void main() {
+  group('SupabaseService.uploadItemImage', () {
+    tearDown(() {
+      SupabaseService.debugImageStorageGateway = null;
+    });
+
+    test('propagates upload failures instead of returning null', () async {
+      SupabaseService.debugImageStorageGateway = _FailingImageStorageGateway();
+
+      await expectLater(
+        SupabaseService.uploadItemImage(
+          imageBytes: Uint8List.fromList([1, 2, 3]),
+          itemId: 'item-1',
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test(
+      'uploads item images under the stable items path and returns public URL',
+      () async {
+        final gateway = _RecordingImageStorageGateway();
+        SupabaseService.debugImageStorageGateway = gateway;
+        final bytes = Uint8List.fromList([255, 216, 255, 217]);
+
+        final url = await SupabaseService.uploadItemImage(
+          imageBytes: bytes,
+          itemId: 'item-1',
+        );
+
+        expect(gateway.uploadedPath, 'items/item-1.jpg');
+        expect(gateway.uploadedBytes, bytes);
+        expect(gateway.uploadedOptions?.upsert, isTrue);
+        expect(gateway.uploadedOptions?.contentType, 'image/jpeg');
+        expect(url, 'https://cdn.example.com/items/item-1.jpg');
+      },
+    );
+  });
+}

--- a/test/widgets/dday_badge_test.dart
+++ b/test/widgets/dday_badge_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/widgets/countdown_ring.dart';
+import 'package:buylog/widgets/dday_badge.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+void main() {
+  group('D-day overdue display', () {
+    testWidgets('DdayBadge shows overdue days as D+N instead of D--N', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(const DdayBadge(daysRemaining: -6)));
+
+      expect(find.text('D+6'), findsOneWidget);
+      expect(find.text('D--6'), findsNothing);
+    });
+
+    testWidgets('DdayBadge keeps today as D-Day', (tester) async {
+      await tester.pumpWidget(_wrap(const DdayBadge(daysRemaining: 0)));
+
+      expect(find.text('D-Day'), findsOneWidget);
+      expect(find.text('D-0'), findsNothing);
+    });
+
+    testWidgets('CountdownRing explains overdue state instead of 교체까지', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(const CountdownRing(daysRemaining: -3, totalDays: 30)),
+      );
+
+      expect(find.text('D+3'), findsOneWidget);
+      expect(find.text('교체 지남'), findsOneWidget);
+      expect(find.text('교체까지'), findsNothing);
+    });
+  });
+}

--- a/test/widgets/reports/monthly_bar_chart_highlight_test.dart
+++ b/test/widgets/reports/monthly_bar_chart_highlight_test.dart
@@ -87,5 +87,22 @@ void main() {
       expect(colors[1], isNot(_highlightColor));
       expect(colors[2], _highlightColor);
     });
+
+    testWidgets('highlightLatest=false → 선택 월만 진한 색', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          MonthlyBarChart(
+            data: _fixture(),
+            selectedMonth: DateTime(2026, 1, 1),
+            highlightLatest: false,
+          ),
+        ),
+      );
+
+      final colors = _readBarColors(tester);
+      expect(colors[0], _highlightColor);
+      expect(colors[1], isNot(_highlightColor));
+      expect(colors[2], isNot(_highlightColor));
+    });
   });
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  file_selector_windows
   url_launcher_windows
 )
 


### PR DESCRIPTION
## 변경 사항
- Supabase/로컬 샘플 데이터를 실제 사용 흐름에 가까운 소모품과 구매 이력으로 정리했습니다.
- 최근 기록 섹션을 고정 문자열 대신 구매 이력 기반으로 표시하고, 사용자명을 `사용자`로 통일했습니다.
- D-day가 지난 항목을 `D+N`/`교체 지남`으로 표시하도록 공통 포맷터를 추가했습니다.
- 리포트 화면에 월간/연간 전환, 연도 이동, 연간 월별 지출과 카테고리 breakdown을 추가했습니다.
- Supabase Storage 이미지 업로드가 service role 없이 동작하도록 앱 로직과 Storage 정책 migration을 수정했습니다.

## 변경 이유
- 테스트성 데이터와 고정 문자열이 실제 사용자 이력처럼 보이는 문제를 줄이고, 교체/구매 기록 화면의 신뢰도를 높이기 위함입니다.
- 이미지 업로드 실패가 `null`로 숨겨져 제품만 저장되는 문제를 방지하기 위함입니다.

## 테스트
- `git diff --cached --check`
- `flutter analyze`
- `flutter test`
- Supabase MCP로 Storage 정책 확인
- anon Storage REST 업로드 smoke test `200 OK`

## 참고 사항
- 이미지 smoke test 과정에서 `product-images/items/codex-smoke-14272e8c04374ba488f50280bf50ad3b.jpg` 테스트 객체가 하나 생성되었습니다. 삭제 권한 정책은 제품 요구 범위를 넓히므로 추가하지 않았고, Supabase가 SQL 직접 삭제를 차단했습니다.
- `.gitignore`, `.claude/`, `.mcp.json`, `docs/superpowers/`는 로컬 도구/설정 산출물로 보고 PR 범위에서 제외했습니다.