### PR TITLE
리포트 페이지 분석 UI와 차트 색상 개선

### DIFF
--- a/docs/superpowers/plans/2026-05-27-report-ui-polish.md
+++ b/docs/superpowers/plans/2026-05-27-report-ui-polish.md
@@ -1,0 +1,996 @@
+# Report UI Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 리포트 페이지의 막대 그래프 색/글자 조화와 리포트 섹션의 시각 일관성을 warm-neutral 디자인에 맞게 개선한다.
+
+**Architecture:** 비즈니스 집계 로직은 `ReportService`에 그대로 두고, 리포트 전용 색상 판단을 `lib/widgets/reports/report_palette.dart`로 분리한다. `MonthlyBarChart`, 카테고리 차트, 인사이트 카드, 관련 리스트 위젯은 같은 팔레트를 소비해 차트와 아이콘의 색상 체계를 맞춘다. `ReportsScreen`은 섹션 순서와 배치만 조정한다.
+
+**Tech Stack:** Flutter, Dart, Material 3, `fl_chart`, `flutter_test`
+
+---
+
+## Current UI Findings
+
+- `lib/widgets/reports/monthly_bar_chart.dart`는 강조 막대에 `AppColors.primary`, 나머지 막대에 `AppColors.primary.withValues(alpha: 0.3)`을 사용한다. 현재 surface 위에서 30% primary 블렌드는 `#EAC9BF`이며 surface 대비가 약 `1.46:1`이라 막대가 배경에 묻힌다.
+- 선택 월과 최신 월이 모두 `AppColors.primary`라서, 사용자가 오래된 월을 선택했을 때 "선택"과 "최신"이 같은 상태처럼 보인다.
+- 막대 차트 하단 월 라벨은 `AppColors.textMuted`를 11px로 사용한다. surface 대비는 약 `3.48:1`이라 작은 글자에서 흐리다.
+- `lib/widgets/reports/category_pie_chart.dart`는 `#0891B2`, `#7C3AED` 같은 cool 계열 색을 하드코딩한다. `docs/REDESIGN_NOTES.md`도 이 파일의 색이 warm 팔레트와 어긋난다고 기록하고 있다.
+- `ReportInsightStrip`은 모든 인사이트를 `primaryLight2` 배경과 `primary` 텍스트로 보여준다. 인사이트 종류별 구분이 약하고, `primary` on `primaryLight2` 대비는 약 `3.31:1`이다.
+- 리포트 화면은 카테고리 도넛 차트가 막대 차트보다 먼저 나온다. 지출 추이를 먼저 확인한 뒤 카테고리 구성으로 내려가는 흐름이 더 자연스럽다.
+
+## File Structure
+
+- Create `lib/widgets/reports/report_palette.dart`
+  - 리포트 전용 막대, 카테고리, 인사이트 색상과 tint 계산을 담당한다.
+- Create `test/widgets/reports/report_palette_test.dart`
+  - 막대 상태별 색, 카테고리 색, 인사이트 색을 고정한다.
+- Modify `lib/widgets/reports/monthly_bar_chart.dart`
+  - 막대 상태별 색, 월 라벨 색, y축 보조 라벨, tooltip을 개선한다.
+- Modify `test/widgets/reports/monthly_bar_chart_highlight_test.dart`
+  - 기존 `isSelected || isLatest` 단색 spec-lock을 선택/최신 분리 spec-lock으로 갱신한다.
+- Modify `lib/widgets/reports/category_pie_chart.dart`
+  - cool 계열 하드코딩 팔레트를 제거하고 `ReportPalette`를 사용한다.
+- Create `test/widgets/reports/category_pie_chart_test.dart`
+  - 도넛 차트 section 색이 warm 리포트 팔레트를 사용하는지 검증한다.
+- Modify `lib/widgets/reports/enhanced_category_breakdown_list.dart`
+- Modify `lib/widgets/reports/refill_forecast_card.dart`
+- Modify `lib/widgets/reports/price_movement_list.dart`
+- Modify `lib/widgets/reports/month_filter_list_view.dart`
+  - 카테고리 색상 의존을 `category_pie_chart.dart`에서 `report_palette.dart`로 옮긴다.
+- Modify `lib/widgets/reports/report_insight_strip.dart`
+  - 인사이트 종류별 색, 배경 tint, viewport 기반 카드 폭을 적용한다.
+- Modify `test/widgets/reports/report_insight_strip_test.dart`
+  - 작은 viewport에서도 카드가 화면 폭 안에 들어오는지 검증한다.
+- Modify `lib/screens/reports_screen.dart`
+  - 막대 그래프 섹션을 카테고리 구성 섹션보다 먼저 보여준다.
+- Modify `test/screens/reports_screen_month_filter_test.dart`
+  - 리포트 화면에서 추이 섹션이 카테고리 구성보다 위에 있는지 검증한다.
+
+---
+
+### Task 1: Report Palette
+
+**Files:**
+- Create: `lib/widgets/reports/report_palette.dart`
+- Create: `test/widgets/reports/report_palette_test.dart`
+
+- [ ] **Step 1: Write the failing palette tests**
+
+Create `test/widgets/reports/report_palette_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:buylog/widgets/reports/report_palette.dart';
+
+void main() {
+  group('ReportPalette', () {
+    test('returns explicit chart colors for selected, latest, idle, and empty bars', () {
+      expect(
+        ReportPalette.barColor(
+          isSelected: true,
+          isLatest: false,
+          hasValue: true,
+        ),
+        AppColors.primaryDark,
+      );
+      expect(
+        ReportPalette.barColor(
+          isSelected: false,
+          isLatest: true,
+          hasValue: true,
+        ),
+        AppColors.primary,
+      );
+      expect(
+        ReportPalette.barColor(
+          isSelected: false,
+          isLatest: false,
+          hasValue: true,
+        ),
+        const Color(0xFFC57868),
+      );
+      expect(
+        ReportPalette.barColor(
+          isSelected: false,
+          isLatest: false,
+          hasValue: false,
+        ),
+        AppColors.surfaceAlt,
+      );
+    });
+
+    test('maps report categories to warm palette colors', () {
+      expect(ReportPalette.categoryColor('욕실/위생'), const Color(0xFF4D8B8C));
+      expect(ReportPalette.categoryColor('가전/필터'), AppColors.success);
+      expect(ReportPalette.categoryColor('세탁/청소'), AppColors.warning);
+      expect(ReportPalette.categoryColor('주방/세제'), const Color(0xFF8B5E83));
+      expect(ReportPalette.categoryColor('헤어/바디'), AppColors.danger);
+      expect(ReportPalette.categoryColor('알 수 없음'), AppColors.textSecondary);
+    });
+
+    test('maps insight kinds to distinct semantic colors', () {
+      expect(
+        ReportPalette.insightColor(ReportInsightKind.refill),
+        AppColors.success,
+      );
+      expect(
+        ReportPalette.insightColor(ReportInsightKind.spending),
+        AppColors.primaryDark,
+      );
+      expect(
+        ReportPalette.insightColor(ReportInsightKind.price),
+        AppColors.warning,
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_palette_test.dart
+```
+
+Expected: FAIL with `Error: Error when reading 'lib/widgets/reports/report_palette.dart'`.
+
+- [ ] **Step 3: Implement the report palette**
+
+Create `lib/widgets/reports/report_palette.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+
+class ReportPalette {
+  static const chartIdle = Color(0xFFC57868);
+  static const chartGrid = Color(0xFFE7DDCC);
+
+  static const hygiene = Color(0xFF4D8B8C);
+  static const kitchen = Color(0xFF8B5E83);
+
+  static const Map<String, Color> categoryColors = <String, Color>{
+    '위생': hygiene,
+    '욕실/위생': hygiene,
+    '필터': AppColors.success,
+    '가전/필터': AppColors.success,
+    '세탁': AppColors.warning,
+    '세탁/청소': AppColors.warning,
+    '주방': kitchen,
+    '주방/세제': kitchen,
+    '헤어/바디': AppColors.danger,
+    '기타': AppColors.textSecondary,
+  };
+
+  static Color barColor({
+    required bool isSelected,
+    required bool isLatest,
+    required bool hasValue,
+  }) {
+    if (!hasValue) return AppColors.surfaceAlt;
+    if (isSelected) return AppColors.primaryDark;
+    if (isLatest) return AppColors.primary;
+    return chartIdle;
+  }
+
+  static Color categoryColor(String name) =>
+      categoryColors[name] ?? AppColors.textSecondary;
+
+  static Color categoryTint(String name, {double alpha = 0.12}) =>
+      categoryColor(name).withValues(alpha: alpha);
+
+  static Color insightColor(ReportInsightKind kind) {
+    return switch (kind) {
+      ReportInsightKind.refill => AppColors.success,
+      ReportInsightKind.spending => AppColors.primaryDark,
+      ReportInsightKind.price => AppColors.warning,
+    };
+  }
+
+  static Color insightSurface(ReportInsightKind kind) {
+    return Color.alphaBlend(
+      insightColor(kind).withValues(alpha: 0.12),
+      AppColors.surface,
+    );
+  }
+}
+
+Color colorForCategory(String name) => ReportPalette.categoryColor(name);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_palette_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/reports/report_palette.dart test/widgets/reports/report_palette_test.dart
+git commit -m "feat: add report palette"
+```
+
+---
+
+### Task 2: Category Color Migration
+
+**Files:**
+- Modify: `lib/widgets/reports/category_pie_chart.dart`
+- Modify: `lib/widgets/reports/enhanced_category_breakdown_list.dart`
+- Modify: `lib/widgets/reports/refill_forecast_card.dart`
+- Modify: `lib/widgets/reports/price_movement_list.dart`
+- Modify: `lib/widgets/reports/month_filter_list_view.dart`
+- Create: `test/widgets/reports/category_pie_chart_test.dart`
+
+- [ ] **Step 1: Write the failing category chart test**
+
+Create `test/widgets/reports/category_pie_chart_test.dart`:
+
+```dart
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:buylog/widgets/reports/category_pie_chart.dart';
+import 'package:buylog/widgets/reports/report_palette.dart';
+
+void main() {
+  testWidgets('CategoryPieChart uses the warm report palette', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CategoryPieChart(
+            data: [
+              CategoryBreakdown(
+                category: '욕실/위생',
+                amount: 15000,
+                ratio: 0.6,
+              ),
+              CategoryBreakdown(
+                category: '주방/세제',
+                amount: 10000,
+                ratio: 0.4,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final chart = tester.widget<PieChart>(find.byType(PieChart));
+
+    expect(chart.data.sections[0].color, ReportPalette.categoryColor('욕실/위생'));
+    expect(chart.data.sections[1].color, ReportPalette.categoryColor('주방/세제'));
+    expect(chart.data.sections[0].color, isNot(const Color(0xFF0891B2)));
+    expect(chart.data.sections[1].color, isNot(const Color(0xFF7C3AED)));
+  });
+
+  testWidgets('CategoryPieChart fallback color is readable textSecondary', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CategoryPieChart(
+            data: [
+              CategoryBreakdown(
+                category: '새 카테고리',
+                amount: 1000,
+                ratio: 1,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final chart = tester.widget<PieChart>(find.byType(PieChart));
+
+    expect(chart.data.sections.single.color, AppColors.textSecondary);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/category_pie_chart_test.dart
+```
+
+Expected: FAIL because `CategoryPieChart` still uses the local cool palette.
+
+- [ ] **Step 3: Update `CategoryPieChart` to use `ReportPalette`**
+
+In `lib/widgets/reports/category_pie_chart.dart`, remove `_categoryPalette` and the local `colorForCategory` implementation. Add this import:
+
+```dart
+import 'report_palette.dart';
+```
+
+Keep the public helper for compatibility:
+
+```dart
+Color colorForCategory(String name) => ReportPalette.categoryColor(name);
+```
+
+The `PieChartSectionData` and legend swatch code should keep calling `colorForCategory(c.category)`.
+
+- [ ] **Step 4: Move list widgets to the palette import**
+
+In each file below, replace:
+
+```dart
+import 'category_pie_chart.dart';
+```
+
+with:
+
+```dart
+import 'report_palette.dart';
+```
+
+Files:
+
+```text
+lib/widgets/reports/enhanced_category_breakdown_list.dart
+lib/widgets/reports/refill_forecast_card.dart
+lib/widgets/reports/price_movement_list.dart
+lib/widgets/reports/month_filter_list_view.dart
+```
+
+No call-site rename is needed because `report_palette.dart` exports the top-level `colorForCategory(String name)` helper.
+
+- [ ] **Step 5: Run category and dependent widget tests**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/category_pie_chart_test.dart test/widgets/reports/enhanced_category_breakdown_list_test.dart test/widgets/reports/refill_forecast_card_test.dart test/widgets/reports/price_movement_list_test.dart test/widgets/reports/month_filter_list_view_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/widgets/reports/category_pie_chart.dart lib/widgets/reports/enhanced_category_breakdown_list.dart lib/widgets/reports/refill_forecast_card.dart lib/widgets/reports/price_movement_list.dart lib/widgets/reports/month_filter_list_view.dart test/widgets/reports/category_pie_chart_test.dart
+git commit -m "refactor: align report category colors"
+```
+
+---
+
+### Task 3: Monthly Bar Chart Visual States
+
+**Files:**
+- Modify: `lib/widgets/reports/monthly_bar_chart.dart`
+- Modify: `test/widgets/reports/monthly_bar_chart_highlight_test.dart`
+
+- [ ] **Step 1: Update the chart state tests**
+
+In `test/widgets/reports/monthly_bar_chart_highlight_test.dart`, replace the color constant and group description with:
+
+```dart
+import 'package:buylog/widgets/reports/report_palette.dart';
+
+const _selectedColor = AppColors.primaryDark;
+const _latestColor = AppColors.primary;
+const _idleColor = ReportPalette.chartIdle;
+const _emptyColor = AppColors.surfaceAlt;
+```
+
+Replace the test group body with:
+
+```dart
+group('MonthlyBarChart highlight states', () {
+  testWidgets('selectedMonth=null → 마지막 막대는 latest, 나머지는 idle', (tester) async {
+    await tester.pumpWidget(_wrap(MonthlyBarChart(data: _fixture())));
+
+    final colors = _readBarColors(tester);
+    expect(colors.length, 3);
+    expect(colors[0], _idleColor);
+    expect(colors[1], _idleColor);
+    expect(colors[2], _latestColor);
+  });
+
+  testWidgets('selectedMonth=2026-01-01 → 선택 막대와 최신 막대가 다른 색', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        MonthlyBarChart(
+          data: _fixture(),
+          selectedMonth: DateTime(2026, 1, 1),
+        ),
+      ),
+    );
+
+    final colors = _readBarColors(tester);
+    expect(colors[0], _selectedColor);
+    expect(colors[1], _idleColor);
+    expect(colors[2], _latestColor);
+  });
+
+  testWidgets('selectedMonth=latest → 선택 색이 latest 색보다 우선한다', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        MonthlyBarChart(
+          data: _fixture(),
+          selectedMonth: DateTime(2026, 3, 1),
+        ),
+      ),
+    );
+
+    final colors = _readBarColors(tester);
+    expect(colors[0], _idleColor);
+    expect(colors[1], _idleColor);
+    expect(colors[2], _selectedColor);
+  });
+
+  testWidgets('highlightLatest=false → 선택 월만 selected 색', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        MonthlyBarChart(
+          data: _fixture(),
+          selectedMonth: DateTime(2026, 1, 1),
+          highlightLatest: false,
+        ),
+      ),
+    );
+
+    final colors = _readBarColors(tester);
+    expect(colors[0], _selectedColor);
+    expect(colors[1], _idleColor);
+    expect(colors[2], _idleColor);
+  });
+
+  testWidgets('0원 막대는 surfaceAlt 색으로 표시한다', (tester) async {
+    final fixture = <MonthlySpending>[
+      MonthlySpending(
+        month: DateTime(2026, 1, 1),
+        totalAmount: 0,
+        byCategory: const {},
+        items: const [],
+      ),
+      MonthlySpending(
+        month: DateTime(2026, 2, 1),
+        totalAmount: 20000,
+        byCategory: const {'주방': 20000},
+        items: const [],
+      ),
+    ];
+
+    await tester.pumpWidget(_wrap(MonthlyBarChart(data: fixture)));
+
+    final colors = _readBarColors(tester);
+    expect(colors[0], _emptyColor);
+    expect(colors[1], _latestColor);
+  });
+});
+```
+
+- [ ] **Step 2: Add chart readability assertions**
+
+Add this test below the highlight group:
+
+```dart
+testWidgets('MonthlyBarChart shows y-axis labels and tooltip formatting', (tester) async {
+  await tester.pumpWidget(_wrap(MonthlyBarChart(data: _fixture())));
+
+  final chart = tester.widget<BarChart>(find.byType(BarChart));
+
+  expect(chart.data.titlesData.leftTitles.sideTitles.showTitles, isTrue);
+  expect(chart.data.titlesData.leftTitles.sideTitles.reservedSize, 40);
+  expect(chart.data.gridData.getDrawingHorizontalLine(50000).color, ReportPalette.chartGrid);
+
+  final tooltip = chart.data.barTouchData.touchTooltipData.getTooltipItem(
+    chart.data.barGroups[1],
+    1,
+    chart.data.barGroups[1].barRods.first,
+    0,
+  );
+
+  expect(tooltip?.text, contains('2월'));
+  expect(tooltip?.text, contains('20,000원'));
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/monthly_bar_chart_highlight_test.dart
+```
+
+Expected: FAIL because `MonthlyBarChart` still uses `primary.withValues(alpha: 0.3)`, hides left titles, and does not format custom tooltip text.
+
+- [ ] **Step 4: Update `MonthlyBarChart` imports and helpers**
+
+Add imports to `lib/widgets/reports/monthly_bar_chart.dart`:
+
+```dart
+import '../../utils/price_format.dart';
+import 'report_palette.dart';
+```
+
+Add helper methods inside `MonthlyBarChart`:
+
+```dart
+double _barWidthFor(int count) => count > 8 ? 18 : 24;
+
+String _axisPriceLabel(double value) {
+  if (value <= 0) return '';
+  if (value >= 10000) return '${(value / 10000).round()}만';
+  return value.round().toString();
+}
+```
+
+- [ ] **Step 5: Update chart data options**
+
+Inside `BarChartData`, replace the grid and title configuration with:
+
+```dart
+gridData: FlGridData(
+  show: true,
+  drawVerticalLine: false,
+  horizontalInterval: computedMaxY / 4,
+  getDrawingHorizontalLine: (value) =>
+      const FlLine(color: ReportPalette.chartGrid, strokeWidth: 0.5),
+),
+titlesData: FlTitlesData(
+  topTitles: const AxisTitles(
+    sideTitles: SideTitles(showTitles: false),
+  ),
+  rightTitles: const AxisTitles(
+    sideTitles: SideTitles(showTitles: false),
+  ),
+  leftTitles: AxisTitles(
+    sideTitles: SideTitles(
+      showTitles: true,
+      reservedSize: 40,
+      interval: computedMaxY / 2,
+      getTitlesWidget: (value, meta) {
+        final label = _axisPriceLabel(value);
+        if (label.isEmpty) return const SizedBox.shrink();
+        return Text(
+          label,
+          style: const TextStyle(
+            fontSize: 10,
+            fontWeight: FontWeight.w600,
+            color: AppColors.textSecondary,
+          ),
+        );
+      },
+    ),
+  ),
+  bottomTitles: AxisTitles(
+    sideTitles: SideTitles(
+      showTitles: true,
+      reservedSize: 30,
+      getTitlesWidget: (value, meta) {
+        final index = value.toInt();
+        if (index >= 0 && index < data.length) {
+          final isLatest = index == data.length - 1;
+          final isSelected =
+              selectedMonth != null && data[index].month == selectedMonth;
+          final highlighted = isSelected || (highlightLatest && isLatest);
+          return Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              '${data[index].month.month}월',
+              style: TextStyle(
+                fontSize: 11,
+                fontWeight: highlighted ? FontWeight.w800 : FontWeight.w600,
+                color: highlighted
+                    ? AppColors.primaryDark
+                    : AppColors.textSecondary,
+              ),
+            ),
+          );
+        }
+        return const SizedBox.shrink();
+      },
+    ),
+  ),
+),
+```
+
+- [ ] **Step 6: Add custom tooltip formatting**
+
+Inside `barTouchData`, keep the existing `touchCallback` and add `touchTooltipData`:
+
+```dart
+touchTooltipData: BarTouchTooltipData(
+  getTooltipColor: (_) => AppColors.text,
+  tooltipBorderRadius: BorderRadius.circular(8),
+  tooltipPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+  fitInsideHorizontally: true,
+  getTooltipItem: (group, groupIndex, rod, rodIndex) {
+    final month = data[group.x.toInt()].month;
+    final amount = data[group.x.toInt()].totalAmount;
+    return BarTooltipItem(
+      '${month.month}월\n${formatPrice(amount)}',
+      const TextStyle(
+        color: Colors.white,
+        fontSize: 12,
+        fontWeight: FontWeight.w700,
+        height: 1.25,
+      ),
+    );
+  },
+),
+```
+
+- [ ] **Step 7: Replace bar color and width logic**
+
+Inside `barGroups`, replace the `BarChartRodData` color and width with:
+
+```dart
+width: _barWidthFor(data.length),
+color: ReportPalette.barColor(
+  isSelected: isSelected,
+  isLatest: highlightLatest && isLatest,
+  hasValue: entry.value.totalAmount > 0,
+),
+```
+
+Keep the existing rounded top corners.
+
+- [ ] **Step 8: Run chart tests**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/monthly_bar_chart_highlight_test.dart test/widgets/reports/monthly_bar_chart_tap_test.dart
+```
+
+Expected: PASS. The tap tests must continue to pass because the `FlTapUpEvent` gate is preserved.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add lib/widgets/reports/monthly_bar_chart.dart test/widgets/reports/monthly_bar_chart_highlight_test.dart
+git commit -m "feat: refine report bar chart colors"
+```
+
+---
+
+### Task 4: Insight Strip Color and Width
+
+**Files:**
+- Modify: `lib/widgets/reports/report_insight_strip.dart`
+- Modify: `test/widgets/reports/report_insight_strip_test.dart`
+
+- [ ] **Step 1: Add responsive width test**
+
+Add this test to `test/widgets/reports/report_insight_strip_test.dart`:
+
+```dart
+testWidgets('ReportInsightStrip constrains cards to the available width', (tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 220,
+          child: ReportInsightStrip(
+            insights: [
+              ReportInsight(
+                kind: ReportInsightKind.refill,
+                title: '다가오는 재구매',
+                body: '30일 안에 2개 품목이 필요해요.',
+                priority: 30,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+
+  final fixedWidths = tester
+      .widgetList<SizedBox>(find.byType(SizedBox))
+      .map((box) => box.width)
+      .whereType<double>()
+      .toList();
+
+  expect(fixedWidths, contains(220));
+  expect(fixedWidths.where((width) => width > 220), isEmpty);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails or exposes the current fixed width**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_insight_strip_test.dart
+```
+
+Expected: FAIL because the strip currently creates an inner `SizedBox(width: 250)` even when the available width is 220.
+
+- [ ] **Step 3: Update `ReportInsightStrip` to use `ReportPalette` and `LayoutBuilder`**
+
+In `lib/widgets/reports/report_insight_strip.dart`, add:
+
+```dart
+import 'report_palette.dart';
+```
+
+Replace the `SingleChildScrollView` return with:
+
+```dart
+return LayoutBuilder(
+  builder: (context, constraints) {
+    final availableWidth = constraints.maxWidth.isFinite
+        ? constraints.maxWidth
+        : MediaQuery.sizeOf(context).width - 40;
+    final cardWidth = availableWidth < 250 ? availableWidth : 250.0;
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      clipBehavior: Clip.none,
+      child: Row(
+        children: [
+          for (var i = 0; i < insights.length; i++) ...[
+            SizedBox(
+              width: cardWidth,
+              child: _InsightCard(insight: insights[i]),
+            ),
+            if (i != insights.length - 1) const SizedBox(width: 10),
+          ],
+        ],
+      ),
+    );
+  },
+);
+```
+
+- [ ] **Step 4: Update `_InsightCard` colors**
+
+Inside `_InsightCard.build`, add:
+
+```dart
+final accent = ReportPalette.insightColor(insight.kind);
+final surface = ReportPalette.insightSurface(insight.kind);
+```
+
+Replace the decoration and icon/title colors with:
+
+```dart
+decoration: BoxDecoration(
+  color: surface,
+  borderRadius: BorderRadius.circular(14),
+  border: Border.all(
+    color: accent.withValues(alpha: 0.22),
+    width: 0.5,
+  ),
+),
+```
+
+```dart
+color: accent.withValues(alpha: 0.14),
+```
+
+```dart
+color: accent,
+```
+
+For the title text style, use readable ink instead of the accent color:
+
+```dart
+style: const TextStyle(
+  fontSize: 12,
+  fontWeight: FontWeight.w800,
+  color: AppColors.text,
+),
+```
+
+Keep the body text as `AppColors.text`.
+
+- [ ] **Step 5: Run insight tests**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_insight_strip_test.dart test/widgets/reports/report_palette_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/widgets/reports/report_insight_strip.dart test/widgets/reports/report_insight_strip_test.dart
+git commit -m "feat: refine report insight cards"
+```
+
+---
+
+### Task 5: Report Section Order
+
+**Files:**
+- Modify: `lib/screens/reports_screen.dart`
+- Modify: `test/screens/reports_screen_month_filter_test.dart`
+
+- [ ] **Step 1: Add a screen order test**
+
+Add this test to `test/screens/reports_screen_month_filter_test.dart`:
+
+```dart
+testWidgets('지출 추이 섹션이 카테고리 구성보다 먼저 보인다', (tester) async {
+  await _pumpReportsScreen(tester);
+
+  final trendTop = tester.getTopLeft(find.text('월별 지출 추이')).dy;
+  final categoryTop = tester
+      .getTopLeft(find.textContaining('월 카테고리 구성'))
+      .dy;
+
+  expect(trendTop, lessThan(categoryTop));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+flutter test test/screens/reports_screen_month_filter_test.dart
+```
+
+Expected: FAIL because `ReportsScreen` currently places the category pie section before the monthly bar chart section.
+
+- [ ] **Step 3: Move the chart section above the category pie section**
+
+In `lib/screens/reports_screen.dart`, move the `SliverToBoxAdapter` whose title is `chartTitle` so it appears before the `SliverToBoxAdapter` whose title is `pieTitle`.
+
+The new order after `RefillForecastCard` should be:
+
+```dart
+SliverToBoxAdapter(
+  child: Padding(
+    padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+    child: _ReportSectionCard(
+      title: chartTitle,
+      child: MonthlyBarChart(
+        data: chartData,
+        selectedMonth: effectiveSelectedMonth,
+        onMonthTap: _onMonthTap,
+        highlightLatest: !isYearly,
+      ),
+    ),
+  ),
+),
+SliverToBoxAdapter(
+  child: Padding(
+    padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+    child: _ReportSectionCard(
+      title: pieTitle,
+      child: CategoryPieChart(data: breakdown),
+    ),
+  ),
+),
+```
+
+Do not change the `MonthFilterListView` state logic in this task.
+
+- [ ] **Step 4: Run screen tests**
+
+Run:
+
+```bash
+flutter test test/screens/reports_screen_month_filter_test.dart test/screens/reports_screen_year_view_test.dart
+```
+
+Expected: PASS. Existing month selection, stale month, and yearly view tests must still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/screens/reports_screen.dart test/screens/reports_screen_month_filter_test.dart
+git commit -m "feat: reorder report chart sections"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- No source edits are planned in this task.
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+dart format lib test
+```
+
+Expected: formatting completes without errors.
+
+- [ ] **Step 2: Analyze**
+
+Run:
+
+```bash
+flutter analyze
+```
+
+Expected: no new errors or warnings.
+
+- [ ] **Step 3: Run targeted report tests**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_palette_test.dart test/widgets/reports/category_pie_chart_test.dart test/widgets/reports/monthly_bar_chart_highlight_test.dart test/widgets/reports/monthly_bar_chart_tap_test.dart test/widgets/reports/report_insight_strip_test.dart test/screens/reports_screen_month_filter_test.dart test/screens/reports_screen_year_view_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run:
+
+```bash
+flutter test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual visual pass**
+
+Run:
+
+```bash
+flutter run -d chrome
+```
+
+Check these points on the report tab:
+
+- 막대 차트에서 선택 월은 진한 terracotta, 최신 월은 기존 primary, 일반 월은 muted clay, 0원 월은 surfaceAlt로 구분된다.
+- 막대 하단 월 라벨이 배경에 묻히지 않고, 선택/최신 월 라벨은 더 굵게 보인다.
+- y축 보조 라벨과 grid line이 차트를 설명하지만 시선을 빼앗지 않는다.
+- 카테고리 도넛, 카테고리 상세, 가격 변동, 재구매 아이콘 색이 같은 warm 계열로 이어진다.
+- 인사이트 카드가 refill/spending/price 종류별 accent를 갖지만 제목과 본문은 readable ink 색으로 읽힌다.
+- 월간/연간 전환 후에도 추이 섹션이 카테고리 구성보다 먼저 보인다.
+- 360px 폭에서도 인사이트 카드 텍스트가 부모 영역 밖으로 튀어나가지 않는다.
+
+- [ ] **Step 6: Commit plan document**
+
+```bash
+git add docs/superpowers/plans/2026-05-27-report-ui-polish.md
+git commit -m "docs: plan report ui polish"
+```
+
+---
+
+## Rollout Notes
+
+- 새 패키지를 추가하지 않는다.
+- `ReportService`와 집계 모델은 수정하지 않는다.
+- `MonthlyBarChart`의 tap dedup 로직은 유지한다. `test/widgets/reports/monthly_bar_chart_tap_test.dart`가 회귀 방지 역할을 한다.
+- 기존 `colorForCategory(String name)` helper는 `report_palette.dart`로 옮기되 같은 이름을 유지한다.
+- 시각 대비 기준은 작은 텍스트에 `AppColors.textSecondary` 이상을 쓰는 방향으로 맞춘다. accent 색은 아이콘, 막대, swatch, border에 주로 사용한다.
+
+## Self-Review
+
+- Spec coverage: 사용자가 지적한 막대 색/글자 조화는 Task 1과 Task 3에서 해결한다. 추가 UI 보완 지점인 카테고리 cool palette, 인사이트 카드 단색감, 섹션 순서는 Task 2, Task 4, Task 5에서 다룬다.
+- Placeholder scan: 모든 파일 경로, 테스트 명령, 코드 변경 예시가 구체적이다. 미정 상태의 항목은 없다.
+- Type consistency: `ReportPalette`, `barColor`, `categoryColor`, `categoryTint`, `insightColor`, `insightSurface` 이름은 전 태스크에서 동일하게 사용한다.
+- Scope check: 비즈니스 로직, Supabase 연동, 데이터 모델 변경은 제외했다. 이번 계획은 리포트 화면의 시각 품질 개선에만 집중한다.

--- a/docs/superpowers/plans/2026-05-27-rich-reports-page.md
+++ b/docs/superpowers/plans/2026-05-27-rich-reports-page.md
@@ -1,0 +1,1178 @@
+# Rich Reports Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 리포트 페이지를 단순 지출 차트에서 buylog만의 강점인 소모품 교체 주기, 재구매 예측, 가격 변동, 카테고리 소비 패턴을 한눈에 보여주는 분석 화면으로 강화한다.
+
+**Architecture:** 집계/판단 로직은 `ReportService`와 전용 값 객체에 둔다. `ReportsScreen`은 상태와 섹션 배치만 담당하고, UI는 `lib/widgets/reports/`의 작은 위젯으로 분리한다. 기존 `fl_chart`, `AppColors`, `SampleData` 기반을 유지하고 신규 패키지는 추가하지 않는다.
+
+**Tech Stack:** Flutter, Dart, Material 3, `fl_chart`, `flutter_test`
+
+---
+
+## Product Direction
+
+현재 리포트는 월간/연간 합계, 카테고리 도넛, 막대 차트, 선택 월 상세 내역이 중심이다. 차별화 방향은 "얼마를 썼는가"보다 "앞으로 어떤 소모품 비용이 다가오고, 어떤 품목/카테고리가 소비 패턴을 바꾸고 있는가"를 보여주는 것이다.
+
+이번 계획의 핵심 섹션은 다음 5개다.
+
+1. **Report Hero**: 선택 기간 총액, 전월/전년 대비 증감, 구매 건수, 최상위 카테고리를 한 화면 상단에서 보여준다.
+2. **Smart Insight Strip**: 규칙 기반 인사이트 2~3개를 카드로 표시한다. 예: "이번 달 필터 지출이 전월보다 34,900원 증가", "30일 안에 4개 품목 재구매 예상".
+3. **Upcoming Refill Forecast**: `daysRemaining`과 최근 구매가로 30/60/90일 예상 지출을 계산해 buylog의 소모품 관리 강점을 드러낸다.
+4. **Price Movement Watch**: 같은 품목의 최근 구매가와 직전 구매가를 비교해 가격 상승/하락 품목을 보여준다.
+5. **Enhanced Category Breakdown**: 기존 카테고리 목록에 전월 대비 증감, 품목 수, 구매 건수를 추가한다.
+
+## File Structure
+
+- Modify `lib/services/report_service.dart`
+  - 리포트 전용 값 객체와 집계 메서드 추가.
+  - 기간 비교, 인사이트, 교체 예정 비용, 가격 변동 계산을 담당.
+- Modify `test/services/report_service_test.dart`
+  - 새 비즈니스 로직의 고정 fixture 기반 단위 테스트 추가.
+- Modify `lib/screens/reports_screen.dart`
+  - 섹션 위젯 조립과 월/연 상태 전달만 담당하도록 정리.
+  - `_formatPrice` 중복은 새 유틸로 제거한다.
+- Create `lib/utils/price_format.dart`
+  - `formatPrice(int price)` 공용화.
+- Modify `lib/widgets/reports/month_filter_list_view.dart`
+  - 새 가격 포맷 유틸 사용.
+- Create `lib/widgets/reports/report_hero_card.dart`
+  - 기간 총액, 증감, 구매 건수, top category KPI 표시.
+- Create `lib/widgets/reports/report_insight_strip.dart`
+  - 규칙 기반 인사이트 카드 가로 스크롤/랩 표시.
+- Create `lib/widgets/reports/refill_forecast_card.dart`
+  - 30/60/90일 예상 교체 비용과 예정 품목 표시.
+- Create `lib/widgets/reports/price_movement_list.dart`
+  - 최근 가격 변동 품목 리스트 표시.
+- Create `lib/widgets/reports/enhanced_category_breakdown_list.dart`
+  - 기존 카테고리 목록을 별도 위젯으로 분리하고 증감/건수 표시.
+- Modify `test/screens/reports_screen_year_view_test.dart`
+  - 새 섹션이 월간/연간 모드에서 적절히 보이는지 검증.
+- Modify `test/screens/reports_screen_month_filter_test.dart`
+  - 기존 월 선택 상세 내역 회귀 테스트 유지.
+- Create `test/widgets/reports/report_hero_card_test.dart`
+- Create `test/widgets/reports/report_insight_strip_test.dart`
+- Create `test/widgets/reports/refill_forecast_card_test.dart`
+- Create `test/widgets/reports/price_movement_list_test.dart`
+
+---
+
+### Task 1: Shared Price Formatter
+
+**Files:**
+- Create: `lib/utils/price_format.dart`
+- Modify: `lib/screens/reports_screen.dart`
+- Modify: `lib/widgets/reports/month_filter_list_view.dart`
+- Test: existing screen/widget tests
+
+- [ ] **Step 1: Create the formatter**
+
+```dart
+String formatPrice(int price) {
+  final sign = price < 0 ? '-' : '';
+  final digits = price.abs().toString();
+  final buffer = StringBuffer();
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return '$sign${buffer}원';
+}
+```
+
+- [ ] **Step 2: Replace local `_formatPrice`**
+
+In `reports_screen.dart` and `month_filter_list_view.dart`, import:
+
+```dart
+import '../utils/price_format.dart';
+```
+
+or, from widgets:
+
+```dart
+import '../../utils/price_format.dart';
+```
+
+Then replace `_formatPrice(value)` with `formatPrice(value)` and delete the local methods.
+
+- [ ] **Step 3: Run regression tests**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/month_filter_list_view_test.dart test/screens/reports_screen_month_filter_test.dart
+```
+
+Expected: PASS. The `"12,500원"` assertion must still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/utils/price_format.dart lib/screens/reports_screen.dart lib/widgets/reports/month_filter_list_view.dart
+git commit -m "refactor: share report price formatter"
+```
+
+---
+
+### Task 2: Report Summary Metrics
+
+**Files:**
+- Modify: `lib/services/report_service.dart`
+- Modify: `test/services/report_service_test.dart`
+
+- [ ] **Step 1: Add failing tests**
+
+Add tests that cover monthly comparison, yearly comparison, purchase count, top category, and empty data:
+
+```dart
+group('ReportService period summaries', () {
+  test('monthlySummary compares selected month with previous month', () {
+    final service = ReportService.fromItems(<ConsumableItem>[
+      ConsumableItem(
+        id: 'a',
+        name: '필터',
+        brand: 'x',
+        category: '가전/필터',
+        icon: Icons.circle,
+        daysRemaining: 10,
+        cycleDays: 30,
+        progress: 0.5,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 4, 2), price: 30000, store: '쿠팡'),
+          PurchaseRecord(date: DateTime(2026, 3, 2), price: 20000, store: '쿠팡'),
+        ],
+      ),
+      ConsumableItem(
+        id: 'b',
+        name: '세제',
+        brand: 'x',
+        category: '주방/세제',
+        icon: Icons.circle,
+        daysRemaining: 20,
+        cycleDays: 30,
+        progress: 0.4,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 4, 8), price: 5000, store: '이마트'),
+        ],
+      ),
+    ]);
+
+    final summary = service.monthlySummary(DateTime(2026, 4, 1));
+
+    expect(summary.totalAmount, 35000);
+    expect(summary.previousAmount, 20000);
+    expect(summary.deltaAmount, 15000);
+    expect(summary.purchaseCount, 2);
+    expect(summary.topCategory, '가전/필터');
+    expect(summary.topCategoryAmount, 30000);
+  });
+
+  test('yearlySummary compares selected year with previous year', () {
+    final service = ReportService.fromItems(<ConsumableItem>[
+      ConsumableItem(
+        id: 'a',
+        name: '필터',
+        brand: 'x',
+        category: '가전/필터',
+        icon: Icons.circle,
+        daysRemaining: 10,
+        cycleDays: 30,
+        progress: 0.5,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 2, 2), price: 30000, store: '쿠팡'),
+          PurchaseRecord(date: DateTime(2025, 2, 2), price: 12000, store: '쿠팡'),
+        ],
+      ),
+    ]);
+
+    final summary = service.yearlySummary(2026);
+
+    expect(summary.totalAmount, 30000);
+    expect(summary.previousAmount, 12000);
+    expect(summary.deltaAmount, 18000);
+    expect(summary.purchaseCount, 1);
+    expect(summary.topCategory, '가전/필터');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: FAIL with missing `monthlySummary`, `yearlySummary`, and `ReportPeriodSummary`.
+
+- [ ] **Step 3: Implement values and methods**
+
+Add to `report_service.dart`:
+
+```dart
+class ReportPeriodSummary {
+  final int totalAmount;
+  final int previousAmount;
+  final int deltaAmount;
+  final int purchaseCount;
+  final String? topCategory;
+  final int topCategoryAmount;
+
+  const ReportPeriodSummary({
+    required this.totalAmount,
+    required this.previousAmount,
+    required this.deltaAmount,
+    required this.purchaseCount,
+    required this.topCategory,
+    required this.topCategoryAmount,
+  });
+
+  bool get hasPrevious => previousAmount > 0;
+
+  double? get deltaRatio {
+    if (previousAmount == 0) return null;
+    return deltaAmount / previousAmount;
+  }
+}
+```
+
+Add methods to `ReportService`:
+
+```dart
+ReportPeriodSummary monthlySummary(DateTime month) {
+  final current = _aggregateMonth(_monthKey(month));
+  final previous = _aggregateMonth(DateTime(month.year, month.month - 1, 1));
+  return _summaryFrom(
+    totalAmount: current.totalAmount,
+    previousAmount: previous.totalAmount,
+    byCategory: current.byCategory,
+    purchaseCount: _purchaseCountForMonth(month),
+  );
+}
+
+ReportPeriodSummary yearlySummary(int year) {
+  final current = aggregateYear(year);
+  final previous = aggregateYear(year - 1);
+  final byCategory = <String, int>{};
+  var purchaseCount = 0;
+
+  for (final item in source) {
+    for (final purchase in item.purchaseHistory) {
+      if (purchase.date.year != year) continue;
+      purchaseCount++;
+      byCategory[item.category] =
+          (byCategory[item.category] ?? 0) + purchase.price;
+    }
+  }
+
+  return _summaryFrom(
+    totalAmount: current.totalAmount,
+    previousAmount: previous.totalAmount,
+    byCategory: byCategory,
+    purchaseCount: purchaseCount,
+  );
+}
+
+ReportPeriodSummary _summaryFrom({
+  required int totalAmount,
+  required int previousAmount,
+  required Map<String, int> byCategory,
+  required int purchaseCount,
+}) {
+  final top = byCategory.entries.toList()
+    ..sort((a, b) => b.value.compareTo(a.value));
+
+  return ReportPeriodSummary(
+    totalAmount: totalAmount,
+    previousAmount: previousAmount,
+    deltaAmount: totalAmount - previousAmount,
+    purchaseCount: purchaseCount,
+    topCategory: top.isEmpty ? null : top.first.key,
+    topCategoryAmount: top.isEmpty ? 0 : top.first.value,
+  );
+}
+
+int _purchaseCountForMonth(DateTime month) {
+  final key = _monthKey(month);
+  var count = 0;
+  for (final item in source) {
+    for (final purchase in item.purchaseHistory) {
+      if (_monthKey(purchase.date) == key) count++;
+    }
+  }
+  return count;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/report_service.dart test/services/report_service_test.dart
+git commit -m "feat: add report period summaries"
+```
+
+---
+
+### Task 3: Refill Forecast Logic
+
+**Files:**
+- Modify: `lib/services/report_service.dart`
+- Modify: `test/services/report_service_test.dart`
+
+- [ ] **Step 1: Add failing tests**
+
+```dart
+group('ReportService refillForecast', () {
+  test('groups upcoming items into 30, 60, and 90 day forecast windows', () {
+    final service = ReportService.fromItems(<ConsumableItem>[
+      ConsumableItem(
+        id: 'soon',
+        name: '화장지',
+        brand: '코디',
+        category: '욕실/위생',
+        icon: Icons.circle,
+        daysRemaining: 12,
+        cycleDays: 30,
+        progress: 0.6,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 4, 1), price: 15000, store: '쿠팡'),
+        ],
+      ),
+      ConsumableItem(
+        id: 'later',
+        name: '필터',
+        brand: '코웨이',
+        category: '가전/필터',
+        icon: Icons.circle,
+        daysRemaining: 44,
+        cycleDays: 90,
+        progress: 0.5,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 2, 1), price: 35000, store: '코웨이몰'),
+        ],
+      ),
+      ConsumableItem(
+        id: 'far',
+        name: '샴푸',
+        brand: '케라시스',
+        category: '헤어/바디',
+        icon: Icons.circle,
+        daysRemaining: 110,
+        cycleDays: 120,
+        progress: 0.1,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 1, 1), price: 9000, store: '올리브영'),
+        ],
+      ),
+    ]);
+
+    final forecast = service.refillForecast();
+
+    expect(forecast.next30DaysAmount, 15000);
+    expect(forecast.next60DaysAmount, 50000);
+    expect(forecast.next90DaysAmount, 50000);
+    expect(forecast.items.map((e) => e.item.id), ['soon', 'later']);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: FAIL with missing `refillForecast`.
+
+- [ ] **Step 3: Implement forecast values**
+
+Add:
+
+```dart
+class RefillForecast {
+  final int next30DaysAmount;
+  final int next60DaysAmount;
+  final int next90DaysAmount;
+  final List<RefillForecastItem> items;
+
+  const RefillForecast({
+    required this.next30DaysAmount,
+    required this.next60DaysAmount,
+    required this.next90DaysAmount,
+    required this.items,
+  });
+}
+
+class RefillForecastItem {
+  final ConsumableItem item;
+  final int expectedPrice;
+  final int daysUntilRefill;
+
+  const RefillForecastItem({
+    required this.item,
+    required this.expectedPrice,
+    required this.daysUntilRefill,
+  });
+}
+```
+
+Add to `ReportService`:
+
+```dart
+RefillForecast refillForecast() {
+  final items = source
+      .where((item) => item.purchaseHistory.isNotEmpty)
+      .map(
+        (item) => RefillForecastItem(
+          item: item,
+          expectedPrice: item.purchaseHistory.first.price,
+          daysUntilRefill: item.daysRemaining < 0 ? 0 : item.daysRemaining,
+        ),
+      )
+      .where((entry) => entry.daysUntilRefill <= 90)
+      .toList()
+    ..sort((a, b) => a.daysUntilRefill.compareTo(b.daysUntilRefill));
+
+  int sumUntil(int days) => items
+      .where((entry) => entry.daysUntilRefill <= days)
+      .fold<int>(0, (sum, entry) => sum + entry.expectedPrice);
+
+  return RefillForecast(
+    next30DaysAmount: sumUntil(30),
+    next60DaysAmount: sumUntil(60),
+    next90DaysAmount: sumUntil(90),
+    items: items,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/report_service.dart test/services/report_service_test.dart
+git commit -m "feat: add refill forecast metrics"
+```
+
+---
+
+### Task 4: Price Movement Logic
+
+**Files:**
+- Modify: `lib/services/report_service.dart`
+- Modify: `test/services/report_service_test.dart`
+
+- [ ] **Step 1: Add failing tests**
+
+```dart
+group('ReportService priceMovements', () {
+  test('returns items with recent price changes sorted by absolute delta', () {
+    final service = ReportService.fromItems(<ConsumableItem>[
+      ConsumableItem(
+        id: 'up',
+        name: '주방 세제',
+        brand: '자연퐁',
+        category: '주방/세제',
+        icon: Icons.circle,
+        daysRemaining: 10,
+        cycleDays: 30,
+        progress: 0.6,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 4, 1), price: 6000, store: '쿠팡'),
+          PurchaseRecord(date: DateTime(2026, 3, 1), price: 4500, store: '이마트'),
+        ],
+      ),
+      ConsumableItem(
+        id: 'same',
+        name: '샴푸',
+        brand: '케라시스',
+        category: '헤어/바디',
+        icon: Icons.circle,
+        daysRemaining: 20,
+        cycleDays: 60,
+        progress: 0.4,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 4, 1), price: 9000, store: '올리브영'),
+          PurchaseRecord(date: DateTime(2026, 3, 1), price: 9000, store: '쿠팡'),
+        ],
+      ),
+    ]);
+
+    final movements = service.priceMovements(limit: 3);
+
+    expect(movements.length, 1);
+    expect(movements.first.item.id, 'up');
+    expect(movements.first.currentPrice, 6000);
+    expect(movements.first.previousPrice, 4500);
+    expect(movements.first.deltaAmount, 1500);
+    expect(movements.first.deltaRatio, closeTo(0.333, 0.001));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: FAIL with missing `priceMovements`.
+
+- [ ] **Step 3: Implement movement values**
+
+Add:
+
+```dart
+class PriceMovement {
+  final ConsumableItem item;
+  final int currentPrice;
+  final int previousPrice;
+  final String currentStore;
+  final String previousStore;
+
+  const PriceMovement({
+    required this.item,
+    required this.currentPrice,
+    required this.previousPrice,
+    required this.currentStore,
+    required this.previousStore,
+  });
+
+  int get deltaAmount => currentPrice - previousPrice;
+
+  double get deltaRatio => previousPrice == 0 ? 0 : deltaAmount / previousPrice;
+}
+```
+
+Add to `ReportService`:
+
+```dart
+List<PriceMovement> priceMovements({int limit = 5}) {
+  final movements = <PriceMovement>[];
+
+  for (final item in source) {
+    if (item.purchaseHistory.length < 2) continue;
+    final sorted = List<PurchaseRecord>.from(item.purchaseHistory)
+      ..sort((a, b) => b.date.compareTo(a.date));
+    final current = sorted[0];
+    final previous = sorted[1];
+    if (current.price == previous.price) continue;
+
+    movements.add(
+      PriceMovement(
+        item: item,
+        currentPrice: current.price,
+        previousPrice: previous.price,
+        currentStore: current.store,
+        previousStore: previous.store,
+      ),
+    );
+  }
+
+  movements.sort(
+    (a, b) => b.deltaAmount.abs().compareTo(a.deltaAmount.abs()),
+  );
+  return movements.take(limit).toList();
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/report_service.dart test/services/report_service_test.dart
+git commit -m "feat: add report price movement metrics"
+```
+
+---
+
+### Task 5: Insight Rules
+
+**Files:**
+- Modify: `lib/services/report_service.dart`
+- Modify: `test/services/report_service_test.dart`
+
+- [ ] **Step 1: Add failing tests**
+
+```dart
+group('ReportService smartInsights', () {
+  test('creates deterministic insights from summary, forecast, and price movement', () {
+    final service = ReportService.fromItems(<ConsumableItem>[
+      ConsumableItem(
+        id: 'filter',
+        name: '정수기 필터',
+        brand: '코웨이',
+        category: '가전/필터',
+        icon: Icons.circle,
+        daysRemaining: 7,
+        cycleDays: 90,
+        progress: 0.9,
+        purchaseHistory: [
+          PurchaseRecord(date: DateTime(2026, 4, 1), price: 35000, store: '코웨이몰'),
+          PurchaseRecord(date: DateTime(2026, 3, 1), price: 30000, store: '쿠팡'),
+        ],
+      ),
+    ]);
+
+    final insights = service.smartInsights(month: DateTime(2026, 4, 1));
+
+    expect(insights, isNotEmpty);
+    expect(insights.first.title, isNotEmpty);
+    expect(insights.map((e) => e.kind), contains(ReportInsightKind.refill));
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: FAIL with missing `smartInsights`.
+
+- [ ] **Step 3: Implement insights**
+
+Add:
+
+```dart
+enum ReportInsightKind { spending, refill, price }
+
+class ReportInsight {
+  final ReportInsightKind kind;
+  final String title;
+  final String body;
+  final int priority;
+
+  const ReportInsight({
+    required this.kind,
+    required this.title,
+    required this.body,
+    required this.priority,
+  });
+}
+```
+
+Add to `ReportService`:
+
+```dart
+List<ReportInsight> smartInsights({required DateTime month}) {
+  final summary = monthlySummary(month);
+  final forecast = refillForecast();
+  final movements = priceMovements(limit: 1);
+  final insights = <ReportInsight>[];
+
+  if (summary.deltaAmount != 0 && summary.hasPrevious) {
+    final direction = summary.deltaAmount > 0 ? '증가' : '감소';
+    insights.add(
+      ReportInsight(
+        kind: ReportInsightKind.spending,
+        title: '지출 흐름 변화',
+        body: '전월보다 ${summary.deltaAmount.abs()}원 $direction했어요.',
+        priority: 20,
+      ),
+    );
+  }
+
+  if (forecast.items.isNotEmpty) {
+    insights.add(
+      ReportInsight(
+        kind: ReportInsightKind.refill,
+        title: '다가오는 재구매',
+        body:
+            '30일 안에 ${forecast.items.where((e) => e.daysUntilRefill <= 30).length}개 품목, 예상 ${forecast.next30DaysAmount}원이 필요해요.',
+        priority: 30,
+      ),
+    );
+  }
+
+  if (movements.isNotEmpty) {
+    final movement = movements.first;
+    final direction = movement.deltaAmount > 0 ? '올랐어요' : '내렸어요';
+    insights.add(
+      ReportInsight(
+        kind: ReportInsightKind.price,
+        title: '가격 변동 감지',
+        body: '${movement.item.name} 가격이 직전 구매보다 ${movement.deltaAmount.abs()}원 $direction.',
+        priority: 10,
+      ),
+    );
+  }
+
+  insights.sort((a, b) => b.priority.compareTo(a.priority));
+  return insights.take(3).toList();
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/report_service.dart test/services/report_service_test.dart
+git commit -m "feat: add smart report insights"
+```
+
+---
+
+### Task 6: Report Hero UI
+
+**Files:**
+- Create: `lib/widgets/reports/report_hero_card.dart`
+- Create: `test/widgets/reports/report_hero_card_test.dart`
+
+- [ ] **Step 1: Add widget tests**
+
+```dart
+testWidgets('ReportHeroCard renders amount, delta, purchase count, and top category', (tester) async {
+  await tester.pumpWidget(
+    const MaterialApp(
+      home: Scaffold(
+        body: ReportHeroCard(
+          title: '4월 리포트',
+          summary: ReportPeriodSummary(
+            totalAmount: 35000,
+            previousAmount: 20000,
+            deltaAmount: 15000,
+            purchaseCount: 2,
+            topCategory: '가전/필터',
+            topCategoryAmount: 30000,
+          ),
+        ),
+      ),
+    ),
+  );
+
+  expect(find.text('4월 리포트'), findsOneWidget);
+  expect(find.text('35,000원'), findsOneWidget);
+  expect(find.textContaining('15,000원'), findsOneWidget);
+  expect(find.text('구매 2건'), findsOneWidget);
+  expect(find.text('가전/필터'), findsOneWidget);
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_hero_card_test.dart
+```
+
+Expected: FAIL because widget does not exist.
+
+- [ ] **Step 3: Implement widget**
+
+Use `Card`-like `Container`, 16 px radius to match current reports cards. Include:
+
+```dart
+class ReportHeroCard extends StatelessWidget {
+  const ReportHeroCard({
+    super.key,
+    required this.title,
+    required this.summary,
+  });
+
+  final String title;
+  final ReportPeriodSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final deltaLabel = summary.deltaAmount == 0
+        ? '전 기간과 동일'
+        : '전 기간 대비 ${formatPrice(summary.deltaAmount.abs())} ${summary.deltaAmount > 0 ? '증가' : '감소'}';
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            formatPrice(summary.totalAmount),
+            style: const TextStyle(
+              fontSize: 30,
+              fontWeight: FontWeight.w800,
+              color: AppColors.text,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _MetricChip(icon: Icons.trending_up_outlined, label: deltaLabel),
+              _MetricChip(icon: Icons.receipt_long_outlined, label: '구매 ${summary.purchaseCount}건'),
+              _MetricChip(icon: Icons.category_outlined, label: summary.topCategory ?? '카테고리 없음'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_hero_card_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/widgets/reports/report_hero_card.dart test/widgets/reports/report_hero_card_test.dart
+git commit -m "feat: add report hero card"
+```
+
+---
+
+### Task 7: Insight, Forecast, and Price Movement Widgets
+
+**Files:**
+- Create: `lib/widgets/reports/report_insight_strip.dart`
+- Create: `lib/widgets/reports/refill_forecast_card.dart`
+- Create: `lib/widgets/reports/price_movement_list.dart`
+- Create: matching widget tests
+
+- [ ] **Step 1: Write widget tests**
+
+Assert visible labels:
+
+```dart
+expect(find.text('다가오는 재구매'), findsOneWidget);
+expect(find.text('30일'), findsOneWidget);
+expect(find.text('가격 변동'), findsOneWidget);
+```
+
+Use fixed `ReportInsight`, `RefillForecast`, and `PriceMovement` fixtures.
+
+- [ ] **Step 2: Implement `ReportInsightStrip`**
+
+Render up to three compact cards with icon by `ReportInsightKind`:
+
+```dart
+IconData _iconFor(ReportInsightKind kind) {
+  return switch (kind) {
+    ReportInsightKind.spending => Icons.insights_outlined,
+    ReportInsightKind.refill => Icons.event_repeat_outlined,
+    ReportInsightKind.price => Icons.price_change_outlined,
+  };
+}
+```
+
+Use `SingleChildScrollView(scrollDirection: Axis.horizontal)` for narrow screens.
+
+- [ ] **Step 3: Implement `RefillForecastCard`**
+
+Show 30/60/90 day amounts as three columns and the earliest three forecast items below:
+
+```dart
+Text('30일');
+Text(formatPrice(forecast.next30DaysAmount));
+Text('${entry.daysUntilRefill}일 후');
+Text(entry.item.name);
+```
+
+- [ ] **Step 4: Implement `PriceMovementList`**
+
+Show item name, current/previous store, current price, and delta. Use `AppColors.danger` for increases and `AppColors.success` for decreases.
+
+- [ ] **Step 5: Run widget tests**
+
+Run:
+
+```bash
+flutter test test/widgets/reports/report_insight_strip_test.dart test/widgets/reports/refill_forecast_card_test.dart test/widgets/reports/price_movement_list_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/widgets/reports/report_insight_strip.dart lib/widgets/reports/refill_forecast_card.dart lib/widgets/reports/price_movement_list.dart test/widgets/reports/report_insight_strip_test.dart test/widgets/reports/refill_forecast_card_test.dart test/widgets/reports/price_movement_list_test.dart
+git commit -m "feat: add rich report insight widgets"
+```
+
+---
+
+### Task 8: Enhanced Category Breakdown
+
+**Files:**
+- Create: `lib/widgets/reports/enhanced_category_breakdown_list.dart`
+- Modify: `lib/services/report_service.dart`
+- Modify: `test/services/report_service_test.dart`
+- Modify: `lib/screens/reports_screen.dart`
+
+- [ ] **Step 1: Add category comparison model**
+
+Add service tests for `categoryComparisonForMonth(DateTime month)`:
+
+```dart
+expect(rows.first.category, '가전/필터');
+expect(rows.first.amount, 30000);
+expect(rows.first.previousAmount, 10000);
+expect(rows.first.deltaAmount, 20000);
+expect(rows.first.purchaseCount, 1);
+```
+
+- [ ] **Step 2: Implement `CategoryComparison`**
+
+```dart
+class CategoryComparison {
+  final String category;
+  final int amount;
+  final int previousAmount;
+  final int purchaseCount;
+  final double ratio;
+
+  const CategoryComparison({
+    required this.category,
+    required this.amount,
+    required this.previousAmount,
+    required this.purchaseCount,
+    required this.ratio,
+  });
+
+  int get deltaAmount => amount - previousAmount;
+}
+```
+
+- [ ] **Step 3: Implement comparison methods**
+
+Add monthly and yearly methods in `ReportService`. Monthly compares selected month to previous month. Yearly compares selected year to previous year.
+
+- [ ] **Step 4: Implement widget**
+
+Render each category row with:
+
+```dart
+Text(row.category);
+Text(formatPrice(row.amount));
+Text('구매 ${row.purchaseCount}건');
+Text(row.deltaAmount == 0 ? '변동 없음' : '${formatPrice(row.deltaAmount.abs())} ${row.deltaAmount > 0 ? '증가' : '감소'}');
+LinearProgressIndicator(value: row.ratio);
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+flutter test test/services/report_service_test.dart test/screens/reports_screen_year_view_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/services/report_service.dart lib/widgets/reports/enhanced_category_breakdown_list.dart lib/screens/reports_screen.dart test/services/report_service_test.dart
+git commit -m "feat: enrich category report breakdown"
+```
+
+---
+
+### Task 9: Wire Rich Sections Into ReportsScreen
+
+**Files:**
+- Modify: `lib/screens/reports_screen.dart`
+- Modify: `test/screens/reports_screen_year_view_test.dart`
+- Modify: `test/screens/reports_screen_month_filter_test.dart`
+
+- [ ] **Step 1: Add screen assertions**
+
+Monthly mode should show:
+
+```dart
+expect(find.textContaining('리포트'), findsWidgets);
+expect(find.text('다가오는 재구매'), findsOneWidget);
+expect(find.text('가격 변동'), findsOneWidget);
+```
+
+Yearly mode should still show:
+
+```dart
+expect(find.text('연간 지출 현황'), findsOneWidget);
+expect(find.text('연간 월별 지출'), findsOneWidget);
+```
+
+- [ ] **Step 2: Compute screen data**
+
+In `ReportsScreen.build`, after existing `service` creation:
+
+```dart
+final activeMonth = latest?.month ?? DateTime(DateTime.now().year, DateTime.now().month, 1);
+final summary = isYearly
+    ? service.yearlySummary(_selectedYear)
+    : service.monthlySummary(activeMonth);
+final insights = service.smartInsights(month: activeMonth);
+final forecast = service.refillForecast();
+final priceMovements = service.priceMovements(limit: 4);
+final categoryRows = isYearly
+    ? service.categoryComparisonForYear(_selectedYear)
+    : service.categoryComparisonForMonth(activeMonth);
+```
+
+- [ ] **Step 3: Replace old summary and hardcoded AI card**
+
+Use:
+
+```dart
+ReportHeroCard(title: isYearly ? '$_selectedYear년 리포트' : '${activeMonth.month}월 리포트', summary: summary)
+ReportInsightStrip(insights: insights)
+```
+
+Delete the hardcoded `AI 인사이트` text because it currently claims a static savings value unrelated to data.
+
+- [ ] **Step 4: Insert buylog-specific sections**
+
+Place `RefillForecastCard` after insights in monthly mode. Place `PriceMovementList` after the trend chart in both modes. Replace inline category list with `EnhancedCategoryBreakdownList`.
+
+- [ ] **Step 5: Run screen tests**
+
+Run:
+
+```bash
+flutter test test/screens/reports_screen_month_filter_test.dart test/screens/reports_screen_year_view_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/screens/reports_screen.dart test/screens/reports_screen_month_filter_test.dart test/screens/reports_screen_year_view_test.dart
+git commit -m "feat: wire rich report sections"
+```
+
+---
+
+### Task 10: Visual and Quality Verification
+
+**Files:**
+- No required source edits unless verification finds layout/test failures.
+
+- [ ] **Step 1: Format**
+
+Run:
+
+```bash
+dart format lib test
+```
+
+Expected: files formatted without errors.
+
+- [ ] **Step 2: Analyze**
+
+Run:
+
+```bash
+flutter analyze
+```
+
+Expected: no new warnings or errors.
+
+- [ ] **Step 3: Full tests**
+
+Run:
+
+```bash
+flutter test
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Manual visual pass**
+
+Run:
+
+```bash
+flutter run -d chrome
+```
+
+Check:
+
+- 리포트 첫 화면에서 총액, 인사이트, 교체 예산, 차트 일부가 과밀하지 않게 보인다.
+- 작은 모바일 폭에서 KPI 칩과 인사이트 카드 텍스트가 넘치지 않는다.
+- 월간/연간 전환 시 기존 테스트 기대 문구가 유지된다.
+- 막대 차트 월 탭 상세 내역이 기존처럼 토글된다.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add lib test docs/superpowers/plans/2026-05-27-rich-reports-page.md
+git commit -m "docs: plan rich reports page"
+```
+
+---
+
+## Rollout Notes
+
+- 신규 패키지 추가는 하지 않는다. `fl_chart`와 기존 Material 위젯으로 충분하다.
+- `ReportService`가 커질 수 있으므로, 구현 중 300~350라인을 넘으면 `lib/services/report_models.dart` 또는 `lib/models/report_metrics.dart`로 값 객체만 분리한다.
+- 화면의 한국어 문구는 짧게 유지한다. 예: `다가오는 재구매`, `가격 변동`, `전월 대비`, `구매 n건`.
+- 현재 `ReportsScreen`은 `SampleData.items`를 직접 사용한다. 실제 Supabase/ItemStore 연결은 별도 계획으로 분리한다.
+
+## Self-Review
+
+- Spec coverage: 사용자의 "차별점 또는 강점 느낌" 요구는 소모품 재구매 예측, 가격 변동, 스마트 인사이트, 강화된 카테고리 분석으로 반영했다.
+- Placeholder scan: 구현을 미루는 placeholder 없이 각 작업의 파일, 테스트, 코드 형태, 실행 명령을 명시했다.
+- Type consistency: `ReportPeriodSummary`, `RefillForecast`, `PriceMovement`, `ReportInsight`, `CategoryComparison` 이름을 전 작업에서 일관되게 사용했다.
+- Scope check: Supabase 실데이터 연결, 그룹 리포트, 공유 기능 실구현은 별도 PR 범위로 남겼다.

--- a/lib/screens/reports_screen.dart
+++ b/lib/screens/reports_screen.dart
@@ -192,15 +192,6 @@ class _ReportsScreenState extends State<ReportsScreen> {
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
               child: _ReportSectionCard(
-                title: pieTitle,
-                child: CategoryPieChart(data: breakdown),
-              ),
-            ),
-          ),
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-              child: _ReportSectionCard(
                 title: chartTitle,
                 child: MonthlyBarChart(
                   data: chartData,
@@ -208,6 +199,15 @@ class _ReportsScreenState extends State<ReportsScreen> {
                   onMonthTap: _onMonthTap,
                   highlightLatest: !isYearly,
                 ),
+              ),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+              child: _ReportSectionCard(
+                title: pieTitle,
+                child: CategoryPieChart(data: breakdown),
               ),
             ),
           ),

--- a/lib/screens/reports_screen.dart
+++ b/lib/screens/reports_screen.dart
@@ -4,8 +4,13 @@ import '../data/sample_data.dart';
 import '../services/report_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/reports/category_pie_chart.dart';
+import '../widgets/reports/enhanced_category_breakdown_list.dart';
 import '../widgets/reports/month_filter_list_view.dart';
 import '../widgets/reports/monthly_bar_chart.dart';
+import '../widgets/reports/price_movement_list.dart';
+import '../widgets/reports/refill_forecast_card.dart';
+import '../widgets/reports/report_hero_card.dart';
+import '../widgets/reports/report_insight_strip.dart';
 import '../widgets/reports/share_action_button.dart';
 
 enum _ReportPeriod { monthly, yearly }
@@ -21,15 +26,10 @@ class _ReportsScreenState extends State<ReportsScreen> {
   // _selectedMonth 만 state 로 보유한다. ReportService/집계는 build 마다
   // 재계산한다.
   //
-  // 이유: ReportsScreen 은 main.dart:63 의 IndexedStack 에 상주해 앱 수명
-  // 동안 마운트 유지된다. initState + late final 캐싱을 쓰면 월 경계 교차 시
-  // 구 월 윈도우가, 향후 Supabase write 시 stale 데이터가 화면에 박혀
-  // ReportsScreen 이 destroy 되기 전에는 갱신되지 않는 회귀가 발생한다
-  // (Codex adversarial review Finding 2).
-  //
-  // 비용: SampleData 규모 (~6 items × ~2 purchases × 6 buckets ≈ 100 ops)
-  // 는 16ms 프레임 예산 대비 무시 가능. async ReportService 도입 시
-  // 캐싱은 repository 레이어로 이전한다.
+  // 이유: ReportsScreen 은 main.dart 의 IndexedStack 에 상주해 앱 수명 동안
+  // 마운트 유지된다. initState + late final 캐싱을 쓰면 월 경계 교차 시 구 월
+  // 윈도우가, 향후 Supabase write 시 stale 데이터가 화면에 박혀 ReportsScreen 이
+  // destroy 되기 전에는 갱신되지 않는 회귀가 발생한다.
   DateTime? _selectedMonth;
   _ReportPeriod _period = _ReportPeriod.monthly;
   int _selectedYear = DateTime.now().year;
@@ -55,60 +55,52 @@ class _ReportsScreenState extends State<ReportsScreen> {
     });
   }
 
-  String _formatPrice(int price) {
-    final str = price.toString();
-    final buffer = StringBuffer();
-    for (var i = 0; i < str.length; i++) {
-      if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
-      buffer.write(str[i]);
-    }
-    return '$buffer원';
-  }
-
   @override
   Widget build(BuildContext context) {
     final service = ReportService.fromItems(SampleData.items);
+    final now = DateTime.now();
     final months = service.aggregateRecentMonths();
     final yearly = service.aggregateYear(_selectedYear);
+    final isYearly = _period == _ReportPeriod.yearly;
+
     // 요약/파이/상세는 지출이 있는 최신 월을 우선 사용해 "빈 현재 월 → 0원"
-    // UX 회귀를 피한다. 전부 0원이면 months.last로 fallback.
+    // UX 회귀를 피한다. 전부 0원이면 현재 월로 fallback.
     final latest =
         service.latestMonthlyWithSpending() ??
         (months.isEmpty ? null : months.last);
+    final activeMonth = latest?.month ?? DateTime(now.year, now.month, 1);
+
     final monthlyBreakdown = latest == null
         ? const <CategoryBreakdown>[]
-        : service.categoryBreakdownFor(latest.month);
+        : service.categoryBreakdownFor(activeMonth);
     final yearlyBreakdown = service.categoryBreakdownForYear(_selectedYear);
-    final isYearly = _period == _ReportPeriod.yearly;
     final chartData = isYearly ? yearly.months : months;
     final breakdown = isYearly ? yearlyBreakdown : monthlyBreakdown;
+    final summary = isYearly
+        ? service.yearlySummary(_selectedYear)
+        : service.monthlySummary(activeMonth);
+    final insights = service.smartInsights(month: activeMonth);
+    final forecast = service.refillForecast();
+    final priceMovements = service.priceMovements(limit: 4);
+    final categoryRows = isYearly
+        ? service.categoryComparisonForYear(_selectedYear)
+        : service.categoryComparisonForMonth(activeMonth);
 
     // `_selectedMonth`는 순수 widget state 로 보관되므로 IndexedStack 하에서
     // 앱 수명만큼 유지된다. 월 경계 교차 또는 데이터 동기화로 aggregateRecentMonths
     // 결과가 바뀌면 선택 월이 현재 window 밖으로 밀려 "헤더만 떠 있고 바 차트에는
-    // 해당 월이 없는" 모순 상태가 발생할 수 있다 (Codex review v3.2 HIGH finding).
-    // 매 build 에서 months 와 교차 검증하여 유효 월만 하위 위젯으로 내려보낸다.
+    // 해당 월이 없는" 모순 상태가 발생할 수 있다. 매 build 에서 months 와 교차
+    // 검증하여 유효 월만 하위 위젯으로 내려보낸다.
     final effectiveSelectedMonth =
         _selectedMonth != null &&
             chartData.any((m) => m.month == _selectedMonth)
         ? _selectedMonth
         : null;
 
-    final latestTitle = isYearly
-        ? '연간 지출 현황'
-        : latest == null
-        ? '지출 현황'
-        : '${latest.month.month}월 지출 현황';
-    final latestYear = isYearly
-        ? '$_selectedYear년'
-        : latest == null
-        ? '-'
-        : '${latest.month.year}';
-    final latestTotal = isYearly
-        ? yearly.totalAmount
-        : latest?.totalAmount ?? 0;
+    final heroTitle = isYearly ? '연간 지출 현황' : '${activeMonth.month}월 리포트';
     final chartTitle = isYearly ? '연간 월별 지출' : '월별 지출 추이';
     final detailTitle = isYearly ? '연간 카테고리 상세' : '카테고리별 상세';
+    final pieTitle = isYearly ? '연간 카테고리 구성' : '${activeMonth.month}월 카테고리 구성';
 
     return SafeArea(
       child: CustomScrollView(
@@ -128,7 +120,6 @@ class _ReportsScreenState extends State<ReportsScreen> {
               ),
             ),
           ),
-
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
@@ -154,18 +145,14 @@ class _ReportsScreenState extends State<ReportsScreen> {
                       style: ButtonStyle(
                         visualDensity: VisualDensity.compact,
                         foregroundColor: WidgetStateProperty.resolveWith<Color>(
-                          (states) {
-                            return states.contains(WidgetState.selected)
-                                ? Colors.white
-                                : AppColors.textSecondary;
-                          },
+                          (states) => states.contains(WidgetState.selected)
+                              ? Colors.white
+                              : AppColors.textSecondary,
                         ),
                         backgroundColor: WidgetStateProperty.resolveWith<Color>(
-                          (states) {
-                            return states.contains(WidgetState.selected)
-                                ? AppColors.primary
-                                : AppColors.surface;
-                          },
+                          (states) => states.contains(WidgetState.selected)
+                              ? AppColors.primary
+                              : AppColors.surface,
                         ),
                       ),
                     ),
@@ -182,261 +169,61 @@ class _ReportsScreenState extends State<ReportsScreen> {
               ),
             ),
           ),
-
-          // Monthly summary
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-              child: Container(
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: AppColors.surface,
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: AppColors.border, width: 0.5),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          latestTitle,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.w600,
-                            color: AppColors.text,
-                          ),
-                        ),
-                        Text(
-                          latestYear,
-                          style: const TextStyle(
-                            fontSize: 13,
-                            color: AppColors.textMuted,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      _formatPrice(latestTotal),
-                      style: const TextStyle(
-                        fontSize: 28,
-                        fontWeight: FontWeight.w700,
-                        color: AppColors.text,
-                      ),
-                    ),
-                    const SizedBox(height: 24),
-
-                    // Donut chart
-                    CategoryPieChart(data: breakdown),
-                  ],
-                ),
-              ),
+              child: ReportHeroCard(title: heroTitle, summary: summary),
             ),
           ),
-
-          // Insight card
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
-              child: Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: AppColors.primaryLight2,
-                  borderRadius: BorderRadius.circular(14),
-                  border: Border.all(
-                    color: AppColors.primary.withValues(alpha: 0.2),
-                    width: 0.5,
-                  ),
-                ),
-                child: Row(
-                  children: [
-                    Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: AppColors.primary.withValues(alpha: 0.15),
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                      child: const Icon(
-                        Icons.auto_awesome_outlined,
-                        color: AppColors.primary,
-                        size: 20,
-                      ),
-                    ),
-                    const SizedBox(width: 14),
-                    const Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'AI 인사이트',
-                            style: TextStyle(
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                              color: AppColors.primary,
-                            ),
-                          ),
-                          SizedBox(height: 2),
-                          Text(
-                            '필터류 지출이 전년 대비 15% 절약되었어요!',
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w500,
-                              color: AppColors.text,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ),
+              child: ReportInsightStrip(insights: insights),
             ),
           ),
-
-          // Spending trend bar chart
+          if (!isYearly)
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+                child: RefillForecastCard(forecast: forecast),
+              ),
+            ),
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-              child: Container(
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: AppColors.surface,
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: AppColors.border, width: 0.5),
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      chartTitle,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w600,
-                        color: AppColors.text,
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-                    MonthlyBarChart(
-                      data: chartData,
-                      selectedMonth: effectiveSelectedMonth,
-                      onMonthTap: _onMonthTap,
-                      highlightLatest: !isYearly,
-                    ),
-                  ],
-                ),
+              child: _ReportSectionCard(
+                title: pieTitle,
+                child: CategoryPieChart(data: breakdown),
               ),
             ),
           ),
-
-          // Category breakdown list
           SliverToBoxAdapter(
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 10),
-              child: Text(
-                detailTitle,
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.text,
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+              child: _ReportSectionCard(
+                title: chartTitle,
+                child: MonthlyBarChart(
+                  data: chartData,
+                  selectedMonth: effectiveSelectedMonth,
+                  onMonthTap: _onMonthTap,
+                  highlightLatest: !isYearly,
                 ),
               ),
             ),
           ),
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            sliver: SliverList.separated(
-              itemCount: breakdown.length,
-              separatorBuilder: (context, index) => const SizedBox(height: 8),
-              itemBuilder: (context, index) {
-                final c = breakdown[index];
-                final color = colorForCategory(c.category);
-                final percent = (c.ratio * 100).round();
-                return Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 14,
-                  ),
-                  decoration: BoxDecoration(
-                    color: AppColors.surface,
-                    borderRadius: BorderRadius.circular(14),
-                    border: Border.all(color: AppColors.border, width: 0.5),
-                  ),
-                  child: Row(
-                    children: [
-                      Container(
-                        width: 38,
-                        height: 38,
-                        decoration: BoxDecoration(
-                          color: color.withValues(alpha: 0.12),
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                        child: Center(
-                          child: Container(
-                            width: 12,
-                            height: 12,
-                            decoration: BoxDecoration(
-                              color: color,
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 14),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              c.category,
-                              style: const TextStyle(
-                                fontSize: 14,
-                                fontWeight: FontWeight.w500,
-                                color: AppColors.text,
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            ClipRRect(
-                              borderRadius: BorderRadius.circular(3),
-                              child: LinearProgressIndicator(
-                                value: c.ratio,
-                                minHeight: 4,
-                                backgroundColor: AppColors.border,
-                                valueColor: AlwaysStoppedAnimation<Color>(
-                                  color,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(width: 14),
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.end,
-                        children: [
-                          Text(
-                            _formatPrice(c.amount),
-                            style: const TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: AppColors.text,
-                            ),
-                          ),
-                          Text(
-                            '$percent%',
-                            style: const TextStyle(
-                              fontSize: 12,
-                              color: AppColors.textMuted,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                );
-              },
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+              child: PriceMovementList(movements: priceMovements),
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+              child: EnhancedCategoryBreakdownList(
+                title: detailTitle,
+                rows: categoryRows,
+              ),
             ),
           ),
           SliverToBoxAdapter(
@@ -446,6 +233,40 @@ class _ReportsScreenState extends State<ReportsScreen> {
             ),
           ),
           const SliverToBoxAdapter(child: SizedBox(height: 24)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReportSectionCard extends StatelessWidget {
+  const _ReportSectionCard({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+              color: AppColors.text,
+            ),
+          ),
+          const SizedBox(height: 20),
+          child,
         ],
       ),
     );

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -150,6 +150,165 @@ class ReportService {
         .toList();
   }
 
+  ReportPeriodSummary monthlySummary(DateTime month) {
+    final current = _aggregateMonth(_monthKey(month));
+    final previous = _aggregateMonth(DateTime(month.year, month.month - 1, 1));
+
+    return _summaryFrom(
+      totalAmount: current.totalAmount,
+      previousAmount: previous.totalAmount,
+      byCategory: current.byCategory,
+      purchaseCount: _purchaseCountForMonth(month),
+    );
+  }
+
+  ReportPeriodSummary yearlySummary(int year) {
+    final current = aggregateYear(year);
+    final previous = aggregateYear(year - 1);
+    final byCategory = <String, int>{};
+    var purchaseCount = 0;
+
+    for (final item in source) {
+      for (final purchase in item.purchaseHistory) {
+        if (purchase.date.year != year) continue;
+        purchaseCount++;
+        byCategory[item.category] =
+            (byCategory[item.category] ?? 0) + purchase.price;
+      }
+    }
+
+    return _summaryFrom(
+      totalAmount: current.totalAmount,
+      previousAmount: previous.totalAmount,
+      byCategory: byCategory,
+      purchaseCount: purchaseCount,
+    );
+  }
+
+  RefillForecast refillForecast() {
+    final items =
+        source
+            .where((item) => item.purchaseHistory.isNotEmpty)
+            .map(
+              (item) => RefillForecastItem(
+                item: item,
+                expectedPrice: item.purchaseHistory.first.price,
+                daysUntilRefill: item.daysRemaining < 0
+                    ? 0
+                    : item.daysRemaining,
+              ),
+            )
+            .where((entry) => entry.daysUntilRefill <= 90)
+            .toList()
+          ..sort((a, b) => a.daysUntilRefill.compareTo(b.daysUntilRefill));
+
+    int sumUntil(int days) => items
+        .where((entry) => entry.daysUntilRefill <= days)
+        .fold<int>(0, (sum, entry) => sum + entry.expectedPrice);
+
+    return RefillForecast(
+      next30DaysAmount: sumUntil(30),
+      next60DaysAmount: sumUntil(60),
+      next90DaysAmount: sumUntil(90),
+      items: items,
+    );
+  }
+
+  List<PriceMovement> priceMovements({int limit = 5}) {
+    final movements = <PriceMovement>[];
+
+    for (final item in source) {
+      if (item.purchaseHistory.length < 2) continue;
+      final sorted = List<PurchaseRecord>.from(item.purchaseHistory)
+        ..sort((a, b) => b.date.compareTo(a.date));
+      final current = sorted[0];
+      final previous = sorted[1];
+      if (current.price == previous.price) continue;
+
+      movements.add(
+        PriceMovement(
+          item: item,
+          currentPrice: current.price,
+          previousPrice: previous.price,
+          currentStore: current.store,
+          previousStore: previous.store,
+        ),
+      );
+    }
+
+    movements.sort(
+      (a, b) => b.deltaAmount.abs().compareTo(a.deltaAmount.abs()),
+    );
+    return movements.take(limit).toList();
+  }
+
+  List<ReportInsight> smartInsights({required DateTime month}) {
+    final summary = monthlySummary(month);
+    final forecast = refillForecast();
+    final movements = priceMovements(limit: 1);
+    final insights = <ReportInsight>[];
+
+    if (summary.deltaAmount != 0 && summary.hasPrevious) {
+      final direction = summary.deltaAmount > 0 ? '증가' : '감소';
+      insights.add(
+        ReportInsight(
+          kind: ReportInsightKind.spending,
+          title: '지출 흐름 변화',
+          body: '전월보다 ${summary.deltaAmount.abs()}원 $direction했어요.',
+          priority: 20,
+        ),
+      );
+    }
+
+    if (forecast.items.isNotEmpty) {
+      final next30Count = forecast.items
+          .where((entry) => entry.daysUntilRefill <= 30)
+          .length;
+      insights.add(
+        ReportInsight(
+          kind: ReportInsightKind.refill,
+          title: '다가오는 재구매',
+          body:
+              '30일 안에 $next30Count개 품목, 예상 ${forecast.next30DaysAmount}원이 필요해요.',
+          priority: 30,
+        ),
+      );
+    }
+
+    if (movements.isNotEmpty) {
+      final movement = movements.first;
+      final direction = movement.deltaAmount > 0 ? '올랐어요' : '내렸어요';
+      insights.add(
+        ReportInsight(
+          kind: ReportInsightKind.price,
+          title: '가격 변동 감지',
+          body:
+              '${movement.item.name} 가격이 직전 구매보다 ${movement.deltaAmount.abs()}원 $direction.',
+          priority: 10,
+        ),
+      );
+    }
+
+    insights.sort((a, b) => b.priority.compareTo(a.priority));
+    return insights.take(3).toList();
+  }
+
+  List<CategoryComparison> categoryComparisonForMonth(DateTime month) {
+    final currentKey = _monthKey(month);
+    final previousKey = DateTime(month.year, month.month - 1, 1);
+    return _categoryComparison(
+      includeCurrent: (date) => _monthKey(date) == currentKey,
+      includePrevious: (date) => _monthKey(date) == previousKey,
+    );
+  }
+
+  List<CategoryComparison> categoryComparisonForYear(int year) {
+    return _categoryComparison(
+      includeCurrent: (date) => date.year == year,
+      includePrevious: (date) => date.year == year - 1,
+    );
+  }
+
   MonthlySpending _aggregateMonth(DateTime bucket) {
     var total = 0;
     final byCategory = <String, int>{};
@@ -174,6 +333,77 @@ class ReportService {
       byCategory: byCategory,
       items: itemsInBucket,
     );
+  }
+
+  ReportPeriodSummary _summaryFrom({
+    required int totalAmount,
+    required int previousAmount,
+    required Map<String, int> byCategory,
+    required int purchaseCount,
+  }) {
+    final top = byCategory.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return ReportPeriodSummary(
+      totalAmount: totalAmount,
+      previousAmount: previousAmount,
+      deltaAmount: totalAmount - previousAmount,
+      purchaseCount: purchaseCount,
+      topCategory: top.isEmpty ? null : top.first.key,
+      topCategoryAmount: top.isEmpty ? 0 : top.first.value,
+    );
+  }
+
+  int _purchaseCountForMonth(DateTime month) {
+    final key = _monthKey(month);
+    var count = 0;
+    for (final item in source) {
+      for (final purchase in item.purchaseHistory) {
+        if (_monthKey(purchase.date) == key) count++;
+      }
+    }
+    return count;
+  }
+
+  List<CategoryComparison> _categoryComparison({
+    required bool Function(DateTime date) includeCurrent,
+    required bool Function(DateTime date) includePrevious,
+  }) {
+    var total = 0;
+    final current = <String, int>{};
+    final previous = <String, int>{};
+    final purchaseCounts = <String, int>{};
+
+    for (final item in source) {
+      for (final purchase in item.purchaseHistory) {
+        if (includeCurrent(purchase.date)) {
+          total += purchase.price;
+          current[item.category] =
+              (current[item.category] ?? 0) + purchase.price;
+          purchaseCounts[item.category] =
+              (purchaseCounts[item.category] ?? 0) + 1;
+        }
+        if (includePrevious(purchase.date)) {
+          previous[item.category] =
+              (previous[item.category] ?? 0) + purchase.price;
+        }
+      }
+    }
+
+    if (total == 0) return const <CategoryComparison>[];
+
+    return current.entries
+        .map(
+          (entry) => CategoryComparison(
+            category: entry.key,
+            amount: entry.value,
+            previousAmount: previous[entry.key] ?? 0,
+            purchaseCount: purchaseCounts[entry.key] ?? 0,
+            ratio: entry.value / total,
+          ),
+        )
+        .toList()
+      ..sort((a, b) => b.amount.compareTo(a.amount));
   }
 }
 
@@ -211,4 +441,109 @@ class CategoryBreakdown {
     required this.amount,
     required this.ratio,
   });
+}
+
+class ReportPeriodSummary {
+  final int totalAmount;
+  final int previousAmount;
+  final int deltaAmount;
+  final int purchaseCount;
+  final String? topCategory;
+  final int topCategoryAmount;
+
+  const ReportPeriodSummary({
+    required this.totalAmount,
+    required this.previousAmount,
+    required this.deltaAmount,
+    required this.purchaseCount,
+    required this.topCategory,
+    required this.topCategoryAmount,
+  });
+
+  bool get hasPrevious => previousAmount > 0;
+
+  double? get deltaRatio {
+    if (previousAmount == 0) return null;
+    return deltaAmount / previousAmount;
+  }
+}
+
+class RefillForecast {
+  final int next30DaysAmount;
+  final int next60DaysAmount;
+  final int next90DaysAmount;
+  final List<RefillForecastItem> items;
+
+  const RefillForecast({
+    required this.next30DaysAmount,
+    required this.next60DaysAmount,
+    required this.next90DaysAmount,
+    required this.items,
+  });
+}
+
+class RefillForecastItem {
+  final ConsumableItem item;
+  final int expectedPrice;
+  final int daysUntilRefill;
+
+  const RefillForecastItem({
+    required this.item,
+    required this.expectedPrice,
+    required this.daysUntilRefill,
+  });
+}
+
+class PriceMovement {
+  final ConsumableItem item;
+  final int currentPrice;
+  final int previousPrice;
+  final String currentStore;
+  final String previousStore;
+
+  const PriceMovement({
+    required this.item,
+    required this.currentPrice,
+    required this.previousPrice,
+    required this.currentStore,
+    required this.previousStore,
+  });
+
+  int get deltaAmount => currentPrice - previousPrice;
+
+  double get deltaRatio => previousPrice == 0 ? 0 : deltaAmount / previousPrice;
+}
+
+enum ReportInsightKind { spending, refill, price }
+
+class ReportInsight {
+  final ReportInsightKind kind;
+  final String title;
+  final String body;
+  final int priority;
+
+  const ReportInsight({
+    required this.kind,
+    required this.title,
+    required this.body,
+    required this.priority,
+  });
+}
+
+class CategoryComparison {
+  final String category;
+  final int amount;
+  final int previousAmount;
+  final int purchaseCount;
+  final double ratio;
+
+  const CategoryComparison({
+    required this.category,
+    required this.amount,
+    required this.previousAmount,
+    required this.purchaseCount,
+    required this.ratio,
+  });
+
+  int get deltaAmount => amount - previousAmount;
 }

--- a/lib/utils/price_format.dart
+++ b/lib/utils/price_format.dart
@@ -1,0 +1,12 @@
+String formatPrice(int price) {
+  final sign = price < 0 ? '-' : '';
+  final digits = price.abs().toString();
+  final buffer = StringBuffer();
+
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+
+  return '$sign$buffer원';
+}

--- a/lib/widgets/reports/category_pie_chart.dart
+++ b/lib/widgets/reports/category_pie_chart.dart
@@ -3,23 +3,11 @@ import 'package:flutter/material.dart';
 
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
-
-const Map<String, Color> _categoryPalette = <String, Color>{
-  '위생': Color(0xFF0891B2),
-  '욕실/위생': Color(0xFF0891B2),
-  '필터': Color(0xFF059669),
-  '가전/필터': Color(0xFF059669),
-  '세탁': Color(0xFFD97706),
-  '세탁/청소': Color(0xFFD97706),
-  '주방': Color(0xFF7C3AED),
-  '주방/세제': Color(0xFF7C3AED),
-  '헤어/바디': Color(0xFFDB2777),
-  '기타': Color(0xFFEC4899),
-};
+import 'report_palette.dart';
 
 /// 카테고리명 → 표시 색상. 매핑이 없으면 muted 색상으로 폴백.
 Color colorForCategory(String name) =>
-    _categoryPalette[name] ?? AppColors.textMuted;
+    ReportPalette.categoryColor(name);
 
 /// 카테고리별 지출 도넛 차트 + 범례.
 class CategoryPieChart extends StatelessWidget {

--- a/lib/widgets/reports/category_pie_chart.dart
+++ b/lib/widgets/reports/category_pie_chart.dart
@@ -6,8 +6,7 @@ import '../../theme/app_theme.dart';
 import 'report_palette.dart';
 
 /// 카테고리명 → 표시 색상. 매핑이 없으면 muted 색상으로 폴백.
-Color colorForCategory(String name) =>
-    ReportPalette.categoryColor(name);
+Color colorForCategory(String name) => ReportPalette.categoryColor(name);
 
 /// 카테고리별 지출 도넛 차트 + 범례.
 class CategoryPieChart extends StatelessWidget {

--- a/lib/widgets/reports/enhanced_category_breakdown_list.dart
+++ b/lib/widgets/reports/enhanced_category_breakdown_list.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
 import '../../utils/price_format.dart';
-import 'category_pie_chart.dart';
+import 'report_palette.dart';
 
 class EnhancedCategoryBreakdownList extends StatelessWidget {
   const EnhancedCategoryBreakdownList({

--- a/lib/widgets/reports/enhanced_category_breakdown_list.dart
+++ b/lib/widgets/reports/enhanced_category_breakdown_list.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+import '../../utils/price_format.dart';
+import 'category_pie_chart.dart';
+
+class EnhancedCategoryBreakdownList extends StatelessWidget {
+  const EnhancedCategoryBreakdownList({
+    super.key,
+    required this.title,
+    required this.rows,
+  });
+
+  final String title;
+  final List<CategoryComparison> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 10),
+        if (rows.isEmpty)
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            decoration: BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: BorderRadius.circular(14),
+              border: Border.all(color: AppColors.border, width: 0.5),
+            ),
+            child: const Text(
+              '표시할 카테고리 지출이 없어요',
+              style: TextStyle(fontSize: 13, color: AppColors.textMuted),
+            ),
+          )
+        else
+          ...rows.map(
+            (row) => Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: _CategoryRow(row: row),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _CategoryRow extends StatelessWidget {
+  const _CategoryRow({required this.row});
+
+  final CategoryComparison row;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = colorForCategory(row.category);
+    final percent = (row.ratio * 100).round();
+    final deltaLabel = row.deltaAmount == 0
+        ? '변동 없음'
+        : '${formatPrice(row.deltaAmount.abs())} ${row.deltaAmount > 0 ? '증가' : '감소'}';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 38,
+            height: 38,
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Center(
+              child: Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: color,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        row.category,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.text,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      '구매 ${row.purchaseCount}건',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(3),
+                  child: LinearProgressIndicator(
+                    value: row.ratio,
+                    minHeight: 4,
+                    backgroundColor: AppColors.border,
+                    valueColor: AlwaysStoppedAnimation<Color>(color),
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  deltaLabel,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 14),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                formatPrice(row.amount),
+                style: const TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.text,
+                ),
+              ),
+              Text(
+                '$percent%',
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: AppColors.textMuted,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/reports/month_filter_list_view.dart
+++ b/lib/widgets/reports/month_filter_list_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../models/item.dart';
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
+import '../../utils/price_format.dart';
 import 'category_pie_chart.dart';
 
 class MonthFilterListView extends StatelessWidget {
@@ -14,18 +15,6 @@ class MonthFilterListView extends StatelessWidget {
 
   final DateTime? selectedMonth;
   final ReportService service;
-
-  // TODO: 4번째 중복. 후속 이슈에서 lib/utils/price_format.dart 등으로 통합.
-  //   기존: reports_screen.dart:14, item_detail_screen.dart:12, item_card.dart:92.
-  String _formatPrice(int price) {
-    final str = price.toString();
-    final buffer = StringBuffer();
-    for (var i = 0; i < str.length; i++) {
-      if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
-      buffer.write(str[i]);
-    }
-    return '$buffer원';
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -139,7 +128,7 @@ class MonthFilterListView extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Text(
-                _formatPrice(totalForMonth),
+                formatPrice(totalForMonth),
                 style: const TextStyle(
                   fontSize: 14,
                   fontWeight: FontWeight.w600,

--- a/lib/widgets/reports/month_filter_list_view.dart
+++ b/lib/widgets/reports/month_filter_list_view.dart
@@ -4,7 +4,7 @@ import '../../models/item.dart';
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
 import '../../utils/price_format.dart';
-import 'category_pie_chart.dart';
+import 'report_palette.dart';
 
 class MonthFilterListView extends StatelessWidget {
   const MonthFilterListView({

--- a/lib/widgets/reports/monthly_bar_chart.dart
+++ b/lib/widgets/reports/monthly_bar_chart.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
+import '../../utils/price_format.dart';
+import 'report_palette.dart';
 
 /// 월별 지출 막대 차트.
 class MonthlyBarChart extends StatelessWidget {
@@ -18,6 +20,14 @@ class MonthlyBarChart extends StatelessWidget {
   final void Function(DateTime month)? onMonthTap;
   final DateTime? selectedMonth;
   final bool highlightLatest;
+
+  double _barWidthFor(int count) => count > 8 ? 18 : 24;
+
+  String _axisPriceLabel(double value) {
+    if (value <= 0) return '';
+    if (value >= 10000) return '${(value / 10000).round()}만';
+    return value.round().toString();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -36,9 +46,9 @@ class MonthlyBarChart extends StatelessWidget {
           gridData: FlGridData(
             show: true,
             drawVerticalLine: false,
-            horizontalInterval: 50000,
+            horizontalInterval: computedMaxY / 4,
             getDrawingHorizontalLine: (value) =>
-                FlLine(color: AppColors.border, strokeWidth: 0.5),
+                const FlLine(color: ReportPalette.chartGrid, strokeWidth: 0.5),
           ),
           borderData: FlBorderData(show: false),
           titlesData: FlTitlesData(
@@ -48,22 +58,50 @@ class MonthlyBarChart extends StatelessWidget {
             rightTitles: const AxisTitles(
               sideTitles: SideTitles(showTitles: false),
             ),
-            leftTitles: const AxisTitles(
-              sideTitles: SideTitles(showTitles: false),
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                reservedSize: 40,
+                interval: computedMaxY / 2,
+                getTitlesWidget: (value, meta) {
+                  final label = _axisPriceLabel(value);
+                  if (label.isEmpty) return const SizedBox.shrink();
+                  return Text(
+                    label,
+                    style: const TextStyle(
+                      fontSize: 10,
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.textSecondary,
+                    ),
+                  );
+                },
+              ),
             ),
             bottomTitles: AxisTitles(
               sideTitles: SideTitles(
                 showTitles: true,
+                reservedSize: 30,
                 getTitlesWidget: (value, meta) {
                   final index = value.toInt();
                   if (index >= 0 && index < data.length) {
+                    final isLatest = index == data.length - 1;
+                    final isSelected =
+                        selectedMonth != null &&
+                        data[index].month == selectedMonth;
+                    final highlighted =
+                        isSelected || (highlightLatest && isLatest);
                     return Padding(
                       padding: const EdgeInsets.only(top: 8),
                       child: Text(
                         '${data[index].month.month}월',
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 11,
-                          color: AppColors.textMuted,
+                          fontWeight: highlighted
+                              ? FontWeight.w800
+                              : FontWeight.w600,
+                          color: highlighted
+                              ? AppColors.primaryDark
+                              : AppColors.textSecondary,
                         ),
                       ),
                     );
@@ -75,6 +113,28 @@ class MonthlyBarChart extends StatelessWidget {
           ),
           barTouchData: BarTouchData(
             enabled: true,
+            touchTooltipData: BarTouchTooltipData(
+              getTooltipColor: (_) => AppColors.text,
+              tooltipBorderRadius: BorderRadius.circular(8),
+              tooltipPadding: const EdgeInsets.symmetric(
+                horizontal: 10,
+                vertical: 8,
+              ),
+              fitInsideHorizontally: true,
+              getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                final month = data[group.x.toInt()].month;
+                final amount = data[group.x.toInt()].totalAmount;
+                return BarTooltipItem(
+                  '${month.month}월\n${formatPrice(amount)}',
+                  const TextStyle(
+                    color: Colors.white,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    height: 1.25,
+                  ),
+                );
+              },
+            ),
             touchCallback: (event, response) {
               // fl_chart 1.2.0 은 desktop/web 에서 한 번의 탭에 FlTapDownEvent +
               // FlTapUpEvent 둘 다 emit 한다. 본 차트는 CustomScrollView 안에
@@ -98,16 +158,17 @@ class MonthlyBarChart extends StatelessWidget {
             final isLatest = entry.key == data.length - 1;
             final isSelected =
                 selectedMonth != null && entry.value.month == selectedMonth;
-            final highlighted = isSelected || (highlightLatest && isLatest);
             return BarChartGroupData(
               x: entry.key,
               barRods: [
                 BarChartRodData(
                   toY: entry.value.totalAmount.toDouble(),
-                  width: 28,
-                  color: highlighted
-                      ? AppColors.primary
-                      : AppColors.primary.withValues(alpha: 0.3),
+                  width: _barWidthFor(data.length),
+                  color: ReportPalette.barColor(
+                    isSelected: isSelected,
+                    isLatest: highlightLatest && isLatest,
+                    hasValue: entry.value.totalAmount > 0,
+                  ),
                   borderRadius: const BorderRadius.only(
                     topLeft: Radius.circular(6),
                     topRight: Radius.circular(6),

--- a/lib/widgets/reports/price_movement_list.dart
+++ b/lib/widgets/reports/price_movement_list.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+import '../../utils/price_format.dart';
+import 'category_pie_chart.dart';
+
+class PriceMovementList extends StatelessWidget {
+  const PriceMovementList({super.key, required this.movements});
+
+  final List<PriceMovement> movements;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('가격 변동', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 12),
+          if (movements.isEmpty)
+            const Text(
+              '비교할 최근 가격 변동이 없어요',
+              style: TextStyle(fontSize: 13, color: AppColors.textMuted),
+            )
+          else
+            ...movements.map((movement) => _MovementRow(movement: movement)),
+        ],
+      ),
+    );
+  }
+}
+
+class _MovementRow extends StatelessWidget {
+  const _MovementRow({required this.movement});
+
+  final PriceMovement movement;
+
+  @override
+  Widget build(BuildContext context) {
+    final deltaColor = movement.deltaAmount > 0
+        ? AppColors.danger
+        : AppColors.success;
+    final deltaLabel = movement.deltaAmount > 0 ? '상승' : '하락';
+    final categoryColor = colorForCategory(movement.item.category);
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              color: categoryColor.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(movement.item.icon, size: 18, color: categoryColor),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  movement.item.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.text,
+                  ),
+                ),
+                Text(
+                  '${movement.previousStore} → ${movement.currentStore}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 10),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                formatPrice(movement.currentPrice),
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w800,
+                  color: AppColors.text,
+                ),
+              ),
+              Text(
+                '${formatPrice(movement.deltaAmount.abs())} $deltaLabel',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: deltaColor,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/reports/price_movement_list.dart
+++ b/lib/widgets/reports/price_movement_list.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
 import '../../utils/price_format.dart';
-import 'category_pie_chart.dart';
+import 'report_palette.dart';
 
 class PriceMovementList extends StatelessWidget {
   const PriceMovementList({super.key, required this.movements});

--- a/lib/widgets/reports/refill_forecast_card.dart
+++ b/lib/widgets/reports/refill_forecast_card.dart
@@ -1,0 +1,171 @@
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+import '../../utils/price_format.dart';
+import 'category_pie_chart.dart';
+
+class RefillForecastCard extends StatelessWidget {
+  const RefillForecastCard({super.key, required this.forecast});
+
+  final RefillForecast forecast;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('다가오는 재구매', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: _WindowAmount(
+                  label: '30일',
+                  amount: forecast.next30DaysAmount,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _WindowAmount(
+                  label: '60일',
+                  amount: forecast.next60DaysAmount,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _WindowAmount(
+                  label: '90일',
+                  amount: forecast.next90DaysAmount,
+                ),
+              ),
+            ],
+          ),
+          if (forecast.items.isEmpty) ...[
+            const SizedBox(height: 14),
+            const Text(
+              '90일 안에 예정된 재구매가 없어요',
+              style: TextStyle(fontSize: 13, color: AppColors.textMuted),
+            ),
+          ] else ...[
+            const SizedBox(height: 14),
+            ...forecast.items
+                .take(3)
+                .map((entry) => _ForecastRow(entry: entry)),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _WindowAmount extends StatelessWidget {
+  const _WindowAmount({required this.label, required this.amount});
+
+  final String label;
+  final int amount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceAlt.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              color: AppColors.textMuted,
+            ),
+          ),
+          const SizedBox(height: 4),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: Text(
+              formatPrice(amount),
+              style: const TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w800,
+                color: AppColors.text,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ForecastRow extends StatelessWidget {
+  const _ForecastRow({required this.entry});
+
+  final RefillForecastItem entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = colorForCategory(entry.item.category);
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        children: [
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.12),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(entry.item.icon, size: 17, color: color),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  entry.item.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.text,
+                  ),
+                ),
+                Text(
+                  '${entry.daysUntilRefill}일 후',
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: AppColors.textMuted,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Text(
+            formatPrice(entry.expectedPrice),
+            style: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w700,
+              color: AppColors.text,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/reports/refill_forecast_card.dart
+++ b/lib/widgets/reports/refill_forecast_card.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
 import '../../utils/price_format.dart';
-import 'category_pie_chart.dart';
+import 'report_palette.dart';
 
 class RefillForecastCard extends StatelessWidget {
   const RefillForecastCard({super.key, required this.forecast});

--- a/lib/widgets/reports/report_hero_card.dart
+++ b/lib/widgets/reports/report_hero_card.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+import '../../utils/price_format.dart';
+
+class ReportHeroCard extends StatelessWidget {
+  const ReportHeroCard({super.key, required this.title, required this.summary});
+
+  final String title;
+  final ReportPeriodSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final deltaLabel = summary.deltaAmount == 0
+        ? '전 기간과 동일'
+        : '전 기간 대비 ${formatPrice(summary.deltaAmount.abs())} ${summary.deltaAmount > 0 ? '증가' : '감소'}';
+    final topCategoryLabel = summary.topCategory == null
+        ? '카테고리 없음'
+        : '${summary.topCategory} ${formatPrice(summary.topCategoryAmount)}';
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            formatPrice(summary.totalAmount),
+            style: const TextStyle(
+              fontSize: 30,
+              fontWeight: FontWeight.w800,
+              color: AppColors.text,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _MetricChip(
+                icon: summary.deltaAmount > 0
+                    ? Icons.trending_up_outlined
+                    : Icons.trending_down_outlined,
+                label: deltaLabel,
+              ),
+              _MetricChip(
+                icon: Icons.receipt_long_outlined,
+                label: '구매 ${summary.purchaseCount}건',
+              ),
+              _MetricChip(
+                icon: Icons.category_outlined,
+                label: topCategoryLabel,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricChip extends StatelessWidget {
+  const _MetricChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceAlt.withValues(alpha: 0.7),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 15, color: AppColors.primary),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/reports/report_insight_strip.dart
+++ b/lib/widgets/reports/report_insight_strip.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../services/report_service.dart';
 import '../../theme/app_theme.dart';
+import 'report_palette.dart';
 
 class ReportInsightStrip extends StatelessWidget {
   const ReportInsightStrip({super.key, required this.insights});
@@ -14,17 +15,29 @@ class ReportInsightStrip extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      clipBehavior: Clip.none,
-      child: Row(
-        children: [
-          for (var i = 0; i < insights.length; i++) ...[
-            SizedBox(width: 250, child: _InsightCard(insight: insights[i])),
-            if (i != insights.length - 1) const SizedBox(width: 10),
-          ],
-        ],
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final availableWidth = constraints.maxWidth.isFinite
+            ? constraints.maxWidth
+            : MediaQuery.sizeOf(context).width - 40;
+        final cardWidth = availableWidth < 250 ? availableWidth : 250.0;
+
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          clipBehavior: Clip.none,
+          child: Row(
+            children: [
+              for (var i = 0; i < insights.length; i++) ...[
+                SizedBox(
+                  width: cardWidth,
+                  child: _InsightCard(insight: insights[i]),
+                ),
+                if (i != insights.length - 1) const SizedBox(width: 10),
+              ],
+            ],
+          ),
+        );
+      },
     );
   }
 }
@@ -36,13 +49,16 @@ class _InsightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final accent = ReportPalette.insightColor(insight.kind);
+    final surface = ReportPalette.insightSurface(insight.kind);
+
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: AppColors.primaryLight2,
+        color: surface,
         borderRadius: BorderRadius.circular(14),
         border: Border.all(
-          color: AppColors.primary.withValues(alpha: 0.18),
+          color: accent.withValues(alpha: 0.22),
           width: 0.5,
         ),
       ),
@@ -53,14 +69,10 @@ class _InsightCard extends StatelessWidget {
             width: 34,
             height: 34,
             decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.14),
+              color: accent.withValues(alpha: 0.14),
               borderRadius: BorderRadius.circular(10),
             ),
-            child: Icon(
-              _iconFor(insight.kind),
-              size: 18,
-              color: AppColors.primary,
-            ),
+            child: Icon(_iconFor(insight.kind), size: 18, color: accent),
           ),
           const SizedBox(width: 12),
           Expanded(
@@ -73,8 +85,8 @@ class _InsightCard extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                   style: const TextStyle(
                     fontSize: 12,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.primary,
+                    fontWeight: FontWeight.w800,
+                    color: AppColors.text,
                   ),
                 ),
                 const SizedBox(height: 3),

--- a/lib/widgets/reports/report_insight_strip.dart
+++ b/lib/widgets/reports/report_insight_strip.dart
@@ -57,10 +57,7 @@ class _InsightCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: surface,
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(
-          color: accent.withValues(alpha: 0.22),
-          width: 0.5,
-        ),
+        border: Border.all(color: accent.withValues(alpha: 0.22), width: 0.5),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/widgets/reports/report_insight_strip.dart
+++ b/lib/widgets/reports/report_insight_strip.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+
+class ReportInsightStrip extends StatelessWidget {
+  const ReportInsightStrip({super.key, required this.insights});
+
+  final List<ReportInsight> insights;
+
+  @override
+  Widget build(BuildContext context) {
+    if (insights.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      clipBehavior: Clip.none,
+      child: Row(
+        children: [
+          for (var i = 0; i < insights.length; i++) ...[
+            SizedBox(width: 250, child: _InsightCard(insight: insights[i])),
+            if (i != insights.length - 1) const SizedBox(width: 10),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _InsightCard extends StatelessWidget {
+  const _InsightCard({required this.insight});
+
+  final ReportInsight insight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.primaryLight2,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(
+          color: AppColors.primary.withValues(alpha: 0.18),
+          width: 0.5,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.14),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(
+              _iconFor(insight.kind),
+              size: 18,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  insight.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.primary,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  insight.body,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    height: 1.3,
+                    fontWeight: FontWeight.w500,
+                    color: AppColors.text,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+IconData _iconFor(ReportInsightKind kind) {
+  return switch (kind) {
+    ReportInsightKind.spending => Icons.insights_outlined,
+    ReportInsightKind.refill => Icons.event_repeat_outlined,
+    ReportInsightKind.price => Icons.price_change_outlined,
+  };
+}

--- a/lib/widgets/reports/report_palette.dart
+++ b/lib/widgets/reports/report_palette.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../../services/report_service.dart';
+import '../../theme/app_theme.dart';
+
+class ReportPalette {
+  static const chartIdle = Color(0xFFC57868);
+  static const chartGrid = Color(0xFFE7DDCC);
+
+  static const hygiene = Color(0xFF4D8B8C);
+  static const kitchen = Color(0xFF8B5E83);
+
+  static const Map<String, Color> categoryColors = <String, Color>{
+    '위생': hygiene,
+    '욕실/위생': hygiene,
+    '필터': AppColors.success,
+    '가전/필터': AppColors.success,
+    '세탁': AppColors.warning,
+    '세탁/청소': AppColors.warning,
+    '주방': kitchen,
+    '주방/세제': kitchen,
+    '헤어/바디': AppColors.danger,
+    '기타': AppColors.textSecondary,
+  };
+
+  static Color barColor({
+    required bool isSelected,
+    required bool isLatest,
+    required bool hasValue,
+  }) {
+    if (!hasValue) return AppColors.surfaceAlt;
+    if (isSelected) return AppColors.primaryDark;
+    if (isLatest) return AppColors.primary;
+    return chartIdle;
+  }
+
+  static Color categoryColor(String name) =>
+      categoryColors[name] ?? AppColors.textSecondary;
+
+  static Color categoryTint(String name, {double alpha = 0.12}) =>
+      categoryColor(name).withValues(alpha: alpha);
+
+  static Color insightColor(ReportInsightKind kind) {
+    return switch (kind) {
+      ReportInsightKind.refill => AppColors.success,
+      ReportInsightKind.spending => AppColors.primaryDark,
+      ReportInsightKind.price => AppColors.warning,
+    };
+  }
+
+  static Color insightSurface(ReportInsightKind kind) {
+    return Color.alphaBlend(
+      insightColor(kind).withValues(alpha: 0.12),
+      AppColors.surface,
+    );
+  }
+}
+
+Color colorForCategory(String name) => ReportPalette.categoryColor(name);

--- a/test/screens/reports_screen_month_filter_test.dart
+++ b/test/screens/reports_screen_month_filter_test.dart
@@ -12,7 +12,7 @@ Future<void> _pumpReportsScreen(WidgetTester tester) async {
   // ReportsScreen 은 sliver 스택이 길어 기본 800x600 viewport 밖으로 밀리는
   // sliver 가 생긴다. SliverToBoxAdapter 의 lazy build 를 피하기 위해
   // viewport 를 충분히 키운다.
-  await tester.binding.setSurfaceSize(const Size(800, 2000));
+  await tester.binding.setSurfaceSize(const Size(800, 3200));
   addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(_wrap());
 }
@@ -47,6 +47,8 @@ void main() {
   group('ReportsScreen month filter toggle', () {
     testWidgets('초기 상태: 상세 헤더 없음', (tester) async {
       await _pumpReportsScreen(tester);
+      expect(find.text('다가오는 재구매'), findsWidgets);
+      expect(find.text('가격 변동'), findsOneWidget);
       expect(find.textContaining('상세 내역'), findsNothing);
     });
 

--- a/test/screens/reports_screen_month_filter_test.dart
+++ b/test/screens/reports_screen_month_filter_test.dart
@@ -52,6 +52,17 @@ void main() {
       expect(find.textContaining('상세 내역'), findsNothing);
     });
 
+    testWidgets('지출 추이 섹션이 카테고리 구성보다 먼저 보인다', (tester) async {
+      await _pumpReportsScreen(tester);
+
+      final trendTop = tester.getTopLeft(find.text('월별 지출 추이')).dy;
+      final categoryTop = tester
+          .getTopLeft(find.textContaining('월 카테고리 구성'))
+          .dy;
+
+      expect(trendTop, lessThan(categoryTop));
+    });
+
     testWidgets('첫 탭 → 해당 월 헤더 표시', (tester) async {
       await _pumpReportsScreen(tester);
       final target = _firstNonZeroMonth(tester);

--- a/test/screens/reports_screen_year_view_test.dart
+++ b/test/screens/reports_screen_year_view_test.dart
@@ -8,7 +8,7 @@ Widget _wrap() {
 }
 
 Future<void> _pumpReportsScreen(WidgetTester tester) async {
-  await tester.binding.setSurfaceSize(const Size(800, 2200));
+  await tester.binding.setSurfaceSize(const Size(800, 3000));
   addTearDown(() => tester.binding.setSurfaceSize(null));
   await tester.pumpWidget(_wrap());
 }
@@ -34,6 +34,8 @@ void main() {
       expect(find.text('연간 지출 현황'), findsOneWidget);
       expect(find.text('$currentYear년'), findsWidgets);
       expect(find.text('연간 월별 지출'), findsOneWidget);
+      expect(find.text('가격 변동'), findsOneWidget);
+      expect(find.text('연간 카테고리 상세'), findsOneWidget);
       expect(find.text('월별 지출 추이'), findsNothing);
     });
   });

--- a/test/services/report_service_test.dart
+++ b/test/services/report_service_test.dart
@@ -429,4 +429,338 @@ void main() {
       expect(mar.first.amount, 2000);
     });
   });
+
+  group('ReportService period summaries', () {
+    test('monthlySummary compares selected month with previous month', () {
+      final service = ReportService.fromItems(<ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '필터',
+          brand: 'x',
+          category: '가전/필터',
+          icon: Icons.circle,
+          daysRemaining: 10,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 4, 2),
+              price: 30000,
+              store: '쿠팡',
+            ),
+            PurchaseRecord(
+              date: DateTime(2026, 3, 2),
+              price: 20000,
+              store: '쿠팡',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'b',
+          name: '세제',
+          brand: 'x',
+          category: '주방/세제',
+          icon: Icons.circle,
+          daysRemaining: 20,
+          cycleDays: 30,
+          progress: 0.4,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 4, 8),
+              price: 5000,
+              store: '이마트',
+            ),
+          ],
+        ),
+      ]);
+
+      final summary = service.monthlySummary(DateTime(2026, 4, 1));
+
+      expect(summary.totalAmount, 35000);
+      expect(summary.previousAmount, 20000);
+      expect(summary.deltaAmount, 15000);
+      expect(summary.purchaseCount, 2);
+      expect(summary.topCategory, '가전/필터');
+      expect(summary.topCategoryAmount, 30000);
+    });
+
+    test('yearlySummary compares selected year with previous year', () {
+      final service = ReportService.fromItems(<ConsumableItem>[
+        ConsumableItem(
+          id: 'a',
+          name: '필터',
+          brand: 'x',
+          category: '가전/필터',
+          icon: Icons.circle,
+          daysRemaining: 10,
+          cycleDays: 30,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 2, 2),
+              price: 30000,
+              store: '쿠팡',
+            ),
+            PurchaseRecord(
+              date: DateTime(2025, 2, 2),
+              price: 12000,
+              store: '쿠팡',
+            ),
+          ],
+        ),
+      ]);
+
+      final summary = service.yearlySummary(2026);
+
+      expect(summary.totalAmount, 30000);
+      expect(summary.previousAmount, 12000);
+      expect(summary.deltaAmount, 18000);
+      expect(summary.purchaseCount, 1);
+      expect(summary.topCategory, '가전/필터');
+    });
+  });
+
+  group('ReportService refillForecast', () {
+    test('groups upcoming items into 30, 60, and 90 day forecast windows', () {
+      final service = ReportService.fromItems(<ConsumableItem>[
+        ConsumableItem(
+          id: 'soon',
+          name: '화장지',
+          brand: '코디',
+          category: '욕실/위생',
+          icon: Icons.circle,
+          daysRemaining: 12,
+          cycleDays: 30,
+          progress: 0.6,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 4, 1),
+              price: 15000,
+              store: '쿠팡',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'later',
+          name: '필터',
+          brand: '코웨이',
+          category: '가전/필터',
+          icon: Icons.circle,
+          daysRemaining: 44,
+          cycleDays: 90,
+          progress: 0.5,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 2, 1),
+              price: 35000,
+              store: '코웨이몰',
+            ),
+          ],
+        ),
+        ConsumableItem(
+          id: 'far',
+          name: '샴푸',
+          brand: '케라시스',
+          category: '헤어/바디',
+          icon: Icons.circle,
+          daysRemaining: 110,
+          cycleDays: 120,
+          progress: 0.1,
+          purchaseHistory: [
+            PurchaseRecord(
+              date: DateTime(2026, 1, 1),
+              price: 9000,
+              store: '올리브영',
+            ),
+          ],
+        ),
+      ]);
+
+      final forecast = service.refillForecast();
+
+      expect(forecast.next30DaysAmount, 15000);
+      expect(forecast.next60DaysAmount, 50000);
+      expect(forecast.next90DaysAmount, 50000);
+      expect(forecast.items.map((e) => e.item.id), ['soon', 'later']);
+    });
+  });
+
+  group('ReportService priceMovements', () {
+    test(
+      'returns items with recent price changes sorted by absolute delta',
+      () {
+        final service = ReportService.fromItems(<ConsumableItem>[
+          ConsumableItem(
+            id: 'up',
+            name: '주방 세제',
+            brand: '자연퐁',
+            category: '주방/세제',
+            icon: Icons.circle,
+            daysRemaining: 10,
+            cycleDays: 30,
+            progress: 0.6,
+            purchaseHistory: [
+              PurchaseRecord(
+                date: DateTime(2026, 4, 1),
+                price: 6000,
+                store: '쿠팡',
+              ),
+              PurchaseRecord(
+                date: DateTime(2026, 3, 1),
+                price: 4500,
+                store: '이마트',
+              ),
+            ],
+          ),
+          ConsumableItem(
+            id: 'same',
+            name: '샴푸',
+            brand: '케라시스',
+            category: '헤어/바디',
+            icon: Icons.circle,
+            daysRemaining: 20,
+            cycleDays: 60,
+            progress: 0.4,
+            purchaseHistory: [
+              PurchaseRecord(
+                date: DateTime(2026, 4, 1),
+                price: 9000,
+                store: '올리브영',
+              ),
+              PurchaseRecord(
+                date: DateTime(2026, 3, 1),
+                price: 9000,
+                store: '쿠팡',
+              ),
+            ],
+          ),
+        ]);
+
+        final movements = service.priceMovements(limit: 3);
+
+        expect(movements.length, 1);
+        expect(movements.first.item.id, 'up');
+        expect(movements.first.currentPrice, 6000);
+        expect(movements.first.previousPrice, 4500);
+        expect(movements.first.deltaAmount, 1500);
+        expect(movements.first.deltaRatio, closeTo(0.333, 0.001));
+      },
+    );
+  });
+
+  group('ReportService smartInsights', () {
+    test(
+      'creates deterministic insights from summary, forecast, and price movement',
+      () {
+        final service = ReportService.fromItems(<ConsumableItem>[
+          ConsumableItem(
+            id: 'filter',
+            name: '정수기 필터',
+            brand: '코웨이',
+            category: '가전/필터',
+            icon: Icons.circle,
+            daysRemaining: 7,
+            cycleDays: 90,
+            progress: 0.9,
+            purchaseHistory: [
+              PurchaseRecord(
+                date: DateTime(2026, 4, 1),
+                price: 35000,
+                store: '코웨이몰',
+              ),
+              PurchaseRecord(
+                date: DateTime(2026, 3, 1),
+                price: 30000,
+                store: '쿠팡',
+              ),
+            ],
+          ),
+        ]);
+
+        final insights = service.smartInsights(month: DateTime(2026, 4, 1));
+
+        expect(insights, isNotEmpty);
+        expect(insights.first.title, isNotEmpty);
+        expect(insights.map((e) => e.kind), contains(ReportInsightKind.refill));
+      },
+    );
+  });
+
+  group('ReportService category comparisons', () {
+    test(
+      'categoryComparisonForMonth compares selected month to previous month',
+      () {
+        final service = ReportService.fromItems(<ConsumableItem>[
+          ConsumableItem(
+            id: 'filter',
+            name: '정수기 필터',
+            brand: '코웨이',
+            category: '가전/필터',
+            icon: Icons.circle,
+            daysRemaining: 7,
+            cycleDays: 90,
+            progress: 0.9,
+            purchaseHistory: [
+              PurchaseRecord(
+                date: DateTime(2026, 4, 1),
+                price: 30000,
+                store: '코웨이몰',
+              ),
+              PurchaseRecord(
+                date: DateTime(2026, 3, 1),
+                price: 10000,
+                store: '쿠팡',
+              ),
+            ],
+          ),
+        ]);
+
+        final rows = service.categoryComparisonForMonth(DateTime(2026, 4, 1));
+
+        expect(rows.first.category, '가전/필터');
+        expect(rows.first.amount, 30000);
+        expect(rows.first.previousAmount, 10000);
+        expect(rows.first.deltaAmount, 20000);
+        expect(rows.first.purchaseCount, 1);
+      },
+    );
+
+    test(
+      'categoryComparisonForYear compares selected year to previous year',
+      () {
+        final service = ReportService.fromItems(<ConsumableItem>[
+          ConsumableItem(
+            id: 'filter',
+            name: '정수기 필터',
+            brand: '코웨이',
+            category: '가전/필터',
+            icon: Icons.circle,
+            daysRemaining: 7,
+            cycleDays: 90,
+            progress: 0.9,
+            purchaseHistory: [
+              PurchaseRecord(
+                date: DateTime(2026, 4, 1),
+                price: 30000,
+                store: '코웨이몰',
+              ),
+              PurchaseRecord(
+                date: DateTime(2025, 4, 1),
+                price: 12000,
+                store: '쿠팡',
+              ),
+            ],
+          ),
+        ]);
+
+        final rows = service.categoryComparisonForYear(2026);
+
+        expect(rows.first.category, '가전/필터');
+        expect(rows.first.amount, 30000);
+        expect(rows.first.previousAmount, 12000);
+        expect(rows.first.deltaAmount, 18000);
+        expect(rows.first.purchaseCount, 1);
+      },
+    );
+  });
 }

--- a/test/widgets/reports/category_pie_chart_test.dart
+++ b/test/widgets/reports/category_pie_chart_test.dart
@@ -1,0 +1,64 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:buylog/widgets/reports/category_pie_chart.dart';
+import 'package:buylog/widgets/reports/report_palette.dart';
+
+void main() {
+  testWidgets('CategoryPieChart uses the warm report palette', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CategoryPieChart(
+            data: [
+              CategoryBreakdown(
+                category: '욕실/위생',
+                amount: 15000,
+                ratio: 0.6,
+              ),
+              CategoryBreakdown(
+                category: '주방/세제',
+                amount: 10000,
+                ratio: 0.4,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final chart = tester.widget<PieChart>(find.byType(PieChart));
+
+    expect(chart.data.sections[0].color, ReportPalette.categoryColor('욕실/위생'));
+    expect(chart.data.sections[1].color, ReportPalette.categoryColor('주방/세제'));
+    expect(chart.data.sections[0].color, isNot(const Color(0xFF0891B2)));
+    expect(chart.data.sections[1].color, isNot(const Color(0xFF7C3AED)));
+  });
+
+  testWidgets('CategoryPieChart fallback color is readable textSecondary', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CategoryPieChart(
+            data: [
+              CategoryBreakdown(
+                category: '새 카테고리',
+                amount: 1000,
+                ratio: 1,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final chart = tester.widget<PieChart>(find.byType(PieChart));
+
+    expect(chart.data.sections.single.color, AppColors.textSecondary);
+  });
+}

--- a/test/widgets/reports/category_pie_chart_test.dart
+++ b/test/widgets/reports/category_pie_chart_test.dart
@@ -14,16 +14,8 @@ void main() {
         home: Scaffold(
           body: CategoryPieChart(
             data: [
-              CategoryBreakdown(
-                category: '욕실/위생',
-                amount: 15000,
-                ratio: 0.6,
-              ),
-              CategoryBreakdown(
-                category: '주방/세제',
-                amount: 10000,
-                ratio: 0.4,
-              ),
+              CategoryBreakdown(category: '욕실/위생', amount: 15000, ratio: 0.6),
+              CategoryBreakdown(category: '주방/세제', amount: 10000, ratio: 0.4),
             ],
           ),
         ),
@@ -46,11 +38,7 @@ void main() {
         home: Scaffold(
           body: CategoryPieChart(
             data: [
-              CategoryBreakdown(
-                category: '새 카테고리',
-                amount: 1000,
-                ratio: 1,
-              ),
+              CategoryBreakdown(category: '새 카테고리', amount: 1000, ratio: 1),
             ],
           ),
         ),

--- a/test/widgets/reports/enhanced_category_breakdown_list_test.dart
+++ b/test/widgets/reports/enhanced_category_breakdown_list_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/widgets/reports/enhanced_category_breakdown_list.dart';
+
+void main() {
+  testWidgets('EnhancedCategoryBreakdownList renders category metrics', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: EnhancedCategoryBreakdownList(
+            title: '카테고리별 상세',
+            rows: [
+              CategoryComparison(
+                category: '가전/필터',
+                amount: 30000,
+                previousAmount: 10000,
+                purchaseCount: 1,
+                ratio: 1,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('카테고리별 상세'), findsOneWidget);
+    expect(find.text('가전/필터'), findsOneWidget);
+    expect(find.text('30,000원'), findsOneWidget);
+    expect(find.text('구매 1건'), findsOneWidget);
+    expect(find.text('20,000원 증가'), findsOneWidget);
+  });
+}

--- a/test/widgets/reports/monthly_bar_chart_highlight_test.dart
+++ b/test/widgets/reports/monthly_bar_chart_highlight_test.dart
@@ -5,8 +5,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:buylog/services/report_service.dart';
 import 'package:buylog/theme/app_theme.dart';
 import 'package:buylog/widgets/reports/monthly_bar_chart.dart';
+import 'package:buylog/widgets/reports/report_palette.dart';
 
-const _highlightColor = AppColors.primary;
+const _selectedColor = AppColors.primaryDark;
+const _latestColor = AppColors.primary;
+const _idleColor = ReportPalette.chartIdle;
+const _emptyColor = AppColors.surfaceAlt;
 
 List<MonthlySpending> _fixture() {
   return <MonthlySpending>[
@@ -41,20 +45,20 @@ List<Color?> _readBarColors(WidgetTester tester) {
 }
 
 void main() {
-  // monthly_bar_chart.dart:88 의 `final highlighted = isSelected || isLatest;`
-  // OR 동작을 spec-lock. PR2 는 monthly_bar_chart.dart 를 수정하지 않는다.
-  group('MonthlyBarChart highlight (isSelected || isLatest spec-lock)', () {
-    testWidgets('selectedMonth=null → 마지막 막대만 진한 색', (tester) async {
+  group('MonthlyBarChart highlight states', () {
+    testWidgets('selectedMonth=null → 마지막 막대는 latest, 나머지는 idle', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(MonthlyBarChart(data: _fixture())));
 
       final colors = _readBarColors(tester);
       expect(colors.length, 3);
-      expect(colors[0], isNot(_highlightColor));
-      expect(colors[1], isNot(_highlightColor));
-      expect(colors[2], _highlightColor);
+      expect(colors[0], _idleColor);
+      expect(colors[1], _idleColor);
+      expect(colors[2], _latestColor);
     });
 
-    testWidgets('selectedMonth=2026-01-01 (non-latest) → 1월과 3월 둘 다 진한 색', (
+    testWidgets('selectedMonth=2026-01-01 → 선택 막대와 최신 막대가 다른 색', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -67,12 +71,14 @@ void main() {
       );
 
       final colors = _readBarColors(tester);
-      expect(colors[0], _highlightColor);
-      expect(colors[1], isNot(_highlightColor));
-      expect(colors[2], _highlightColor);
+      expect(colors[0], _selectedColor);
+      expect(colors[1], _idleColor);
+      expect(colors[2], _latestColor);
     });
 
-    testWidgets('selectedMonth=2026-03-01 (latest) → 3월만 진한 색', (tester) async {
+    testWidgets('selectedMonth=latest → 선택 색이 latest 색보다 우선한다', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _wrap(
           MonthlyBarChart(
@@ -83,12 +89,12 @@ void main() {
       );
 
       final colors = _readBarColors(tester);
-      expect(colors[0], isNot(_highlightColor));
-      expect(colors[1], isNot(_highlightColor));
-      expect(colors[2], _highlightColor);
+      expect(colors[0], _idleColor);
+      expect(colors[1], _idleColor);
+      expect(colors[2], _selectedColor);
     });
 
-    testWidgets('highlightLatest=false → 선택 월만 진한 색', (tester) async {
+    testWidgets('highlightLatest=false → 선택 월만 selected 색', (tester) async {
       await tester.pumpWidget(
         _wrap(
           MonthlyBarChart(
@@ -100,9 +106,57 @@ void main() {
       );
 
       final colors = _readBarColors(tester);
-      expect(colors[0], _highlightColor);
-      expect(colors[1], isNot(_highlightColor));
-      expect(colors[2], isNot(_highlightColor));
+      expect(colors[0], _selectedColor);
+      expect(colors[1], _idleColor);
+      expect(colors[2], _idleColor);
     });
+
+    testWidgets('0원 막대는 surfaceAlt 색으로 표시한다', (tester) async {
+      final fixture = <MonthlySpending>[
+        MonthlySpending(
+          month: DateTime(2026, 1, 1),
+          totalAmount: 0,
+          byCategory: const {},
+          items: const [],
+        ),
+        MonthlySpending(
+          month: DateTime(2026, 2, 1),
+          totalAmount: 20000,
+          byCategory: const {'주방': 20000},
+          items: const [],
+        ),
+      ];
+
+      await tester.pumpWidget(_wrap(MonthlyBarChart(data: fixture)));
+
+      final colors = _readBarColors(tester);
+      expect(colors[0], _emptyColor);
+      expect(colors[1], _latestColor);
+    });
+  });
+
+  testWidgets('MonthlyBarChart shows y-axis labels and tooltip formatting', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(MonthlyBarChart(data: _fixture())));
+
+    final chart = tester.widget<BarChart>(find.byType(BarChart));
+
+    expect(chart.data.titlesData.leftTitles.sideTitles.showTitles, isTrue);
+    expect(chart.data.titlesData.leftTitles.sideTitles.reservedSize, 40);
+    expect(
+      chart.data.gridData.getDrawingHorizontalLine(50000).color,
+      ReportPalette.chartGrid,
+    );
+
+    final tooltip = chart.data.barTouchData.touchTooltipData.getTooltipItem(
+      chart.data.barGroups[1],
+      1,
+      chart.data.barGroups[1].barRods.first,
+      0,
+    );
+
+    expect(tooltip?.text, contains('2월'));
+    expect(tooltip?.text, contains('20,000원'));
   });
 }

--- a/test/widgets/reports/monthly_bar_chart_highlight_test.dart
+++ b/test/widgets/reports/monthly_bar_chart_highlight_test.dart
@@ -76,9 +76,7 @@ void main() {
       expect(colors[2], _latestColor);
     });
 
-    testWidgets('selectedMonth=latest → 선택 색이 latest 색보다 우선한다', (
-      tester,
-    ) async {
+    testWidgets('selectedMonth=latest → 선택 색이 latest 색보다 우선한다', (tester) async {
       await tester.pumpWidget(
         _wrap(
           MonthlyBarChart(

--- a/test/widgets/reports/price_movement_list_test.dart
+++ b/test/widgets/reports/price_movement_list_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/models/item.dart';
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/widgets/reports/price_movement_list.dart';
+
+void main() {
+  testWidgets('PriceMovementList renders changed item and delta', (
+    tester,
+  ) async {
+    final item = ConsumableItem(
+      id: 'dish',
+      name: '주방 세제',
+      brand: '자연퐁',
+      category: '주방/세제',
+      icon: Icons.kitchen_outlined,
+      daysRemaining: 10,
+      cycleDays: 30,
+      progress: 0.6,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PriceMovementList(
+            movements: [
+              PriceMovement(
+                item: item,
+                currentPrice: 6000,
+                previousPrice: 4500,
+                currentStore: '쿠팡',
+                previousStore: '이마트',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('가격 변동'), findsOneWidget);
+    expect(find.text('주방 세제'), findsOneWidget);
+    expect(find.text('6,000원'), findsOneWidget);
+    expect(find.text('1,500원 상승'), findsOneWidget);
+  });
+}

--- a/test/widgets/reports/refill_forecast_card_test.dart
+++ b/test/widgets/reports/refill_forecast_card_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/models/item.dart';
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/widgets/reports/refill_forecast_card.dart';
+
+void main() {
+  testWidgets('RefillForecastCard renders windows and upcoming items', (
+    tester,
+  ) async {
+    final item = ConsumableItem(
+      id: 'paper',
+      name: '화장지',
+      brand: '코디',
+      category: '욕실/위생',
+      icon: Icons.bathroom_outlined,
+      daysRemaining: 12,
+      cycleDays: 30,
+      progress: 0.6,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: RefillForecastCard(
+            forecast: RefillForecast(
+              next30DaysAmount: 15000,
+              next60DaysAmount: 50000,
+              next90DaysAmount: 50000,
+              items: [
+                RefillForecastItem(
+                  item: item,
+                  expectedPrice: 15000,
+                  daysUntilRefill: 12,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('다가오는 재구매'), findsOneWidget);
+    expect(find.text('30일'), findsOneWidget);
+    expect(find.text('60일'), findsOneWidget);
+    expect(find.text('90일'), findsOneWidget);
+    expect(find.text('화장지'), findsOneWidget);
+    expect(find.text('12일 후'), findsOneWidget);
+  });
+}

--- a/test/widgets/reports/report_hero_card_test.dart
+++ b/test/widgets/reports/report_hero_card_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/widgets/reports/report_hero_card.dart';
+
+void main() {
+  testWidgets(
+    'ReportHeroCard renders amount, delta, purchase count, and top category',
+    (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ReportHeroCard(
+              title: '4월 리포트',
+              summary: ReportPeriodSummary(
+                totalAmount: 35000,
+                previousAmount: 20000,
+                deltaAmount: 15000,
+                purchaseCount: 2,
+                topCategory: '가전/필터',
+                topCategoryAmount: 30000,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('4월 리포트'), findsOneWidget);
+      expect(find.text('35,000원'), findsOneWidget);
+      expect(find.textContaining('15,000원'), findsOneWidget);
+      expect(find.text('구매 2건'), findsOneWidget);
+      expect(find.textContaining('가전/필터'), findsOneWidget);
+    },
+  );
+}

--- a/test/widgets/reports/report_insight_strip_test.dart
+++ b/test/widgets/reports/report_insight_strip_test.dart
@@ -26,4 +26,37 @@ void main() {
     expect(find.text('다가오는 재구매'), findsOneWidget);
     expect(find.textContaining('30일'), findsOneWidget);
   });
+
+  testWidgets('ReportInsightStrip constrains cards to the available width', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 220,
+            child: ReportInsightStrip(
+              insights: [
+                ReportInsight(
+                  kind: ReportInsightKind.refill,
+                  title: '다가오는 재구매',
+                  body: '30일 안에 2개 품목이 필요해요.',
+                  priority: 30,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final fixedWidths = tester
+        .widgetList<SizedBox>(find.byType(SizedBox))
+        .map((box) => box.width)
+        .whereType<double>()
+        .toList();
+
+    expect(fixedWidths, contains(220));
+    expect(fixedWidths.where((width) => width > 220), isEmpty);
+  });
 }

--- a/test/widgets/reports/report_insight_strip_test.dart
+++ b/test/widgets/reports/report_insight_strip_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/widgets/reports/report_insight_strip.dart';
+
+void main() {
+  testWidgets('ReportInsightStrip renders insight cards', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ReportInsightStrip(
+            insights: [
+              ReportInsight(
+                kind: ReportInsightKind.refill,
+                title: '다가오는 재구매',
+                body: '30일 안에 2개 품목이 필요해요.',
+                priority: 30,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('다가오는 재구매'), findsOneWidget);
+    expect(find.textContaining('30일'), findsOneWidget);
+  });
+}

--- a/test/widgets/reports/report_palette_test.dart
+++ b/test/widgets/reports/report_palette_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:buylog/services/report_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:buylog/widgets/reports/report_palette.dart';
+
+void main() {
+  group('ReportPalette', () {
+    test(
+      'returns explicit chart colors for selected, latest, idle, and empty bars',
+      () {
+        expect(
+          ReportPalette.barColor(
+            isSelected: true,
+            isLatest: false,
+            hasValue: true,
+          ),
+          AppColors.primaryDark,
+        );
+        expect(
+          ReportPalette.barColor(
+            isSelected: false,
+            isLatest: true,
+            hasValue: true,
+          ),
+          AppColors.primary,
+        );
+        expect(
+          ReportPalette.barColor(
+            isSelected: false,
+            isLatest: false,
+            hasValue: true,
+          ),
+          const Color(0xFFC57868),
+        );
+        expect(
+          ReportPalette.barColor(
+            isSelected: false,
+            isLatest: false,
+            hasValue: false,
+          ),
+          AppColors.surfaceAlt,
+        );
+      },
+    );
+
+    test('maps report categories to warm palette colors', () {
+      expect(ReportPalette.categoryColor('욕실/위생'), const Color(0xFF4D8B8C));
+      expect(ReportPalette.categoryColor('가전/필터'), AppColors.success);
+      expect(ReportPalette.categoryColor('세탁/청소'), AppColors.warning);
+      expect(ReportPalette.categoryColor('주방/세제'), const Color(0xFF8B5E83));
+      expect(ReportPalette.categoryColor('헤어/바디'), AppColors.danger);
+      expect(ReportPalette.categoryColor('알 수 없음'), AppColors.textSecondary);
+    });
+
+    test('maps insight kinds to distinct semantic colors', () {
+      expect(
+        ReportPalette.insightColor(ReportInsightKind.refill),
+        AppColors.success,
+      );
+      expect(
+        ReportPalette.insightColor(ReportInsightKind.spending),
+        AppColors.primaryDark,
+      );
+      expect(
+        ReportPalette.insightColor(ReportInsightKind.price),
+        AppColors.warning,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 변경 사항
- 리포트 화면을 월간/연간 요약, 인사이트, 재구매 예측, 가격 변동, 카테고리 상세 중심으로 확장했습니다.
- 리포트 전용 팔레트를 추가하고 막대 차트의 선택/최신/일반/0원 상태 색상, y축 라벨, tooltip을 개선했습니다.
- 카테고리 차트와 관련 리스트의 색상을 warm-neutral 톤으로 통일하고, 인사이트 카드의 좁은 화면 폭 대응을 보강했습니다.
- 리포트 섹션 순서를 지출 추이 후 카테고리 구성으로 조정했습니다.

## 변경 이유
- 기존 막대 그래프는 비활성 막대와 하단 라벨 대비가 낮아 지출 추이를 읽기 어려웠습니다.
- 카테고리 색상이 앱의 warm-neutral 팔레트와 맞지 않아 리포트 화면만 시각적으로 분리되어 보였습니다.
- 리포트 페이지가 단순 지출 차트보다 재구매/가격 변동/카테고리 변화까지 보여주는 분석 화면으로 동작하도록 보강했습니다.

## 테스트
- `flutter analyze`
- `flutter test`

## 리뷰 포인트
- 막대 차트의 선택/최신 상태 구분이 실제 사용 흐름에서 충분히 명확한지 확인 부탁드립니다.
- 인사이트 카드와 카테고리 색상이 전체 앱 팔레트와 잘 맞는지 확인 부탁드립니다.