### PR TITLE
그룹 추가 흐름과 AI 가격 비교 프록시 개선

### DIFF
--- a/docs/superpowers/plans/2026-05-27-group-page-add-actions.md
+++ b/docs/superpowers/plans/2026-05-27-group-page-add-actions.md
@@ -1,0 +1,841 @@
+# Group Page Add Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 그룹 페이지에서 선택된 그룹에 물품을 바로 추가하고, 이미 그룹이 있는 상태에서도 새 그룹을 만들 수 있는 명확한 진입점을 제공한다.
+
+**Architecture:** 그룹 생성과 물품 저장의 비즈니스 로직은 기존 `GroupStore`, `ItemStore`, `SupabaseService`에 그대로 둔다. `GroupScreen`은 선택된 `ItemScope`를 화면 액션에 연결하고, 새 `GroupQuickActions` 위젯은 콜백만 받는 순수 UI로 만든다. 등록/스캔 화면에는 현재 그룹 대상 배너를 표시해서 사용자가 어느 그룹에 추가하는지 확인할 수 있게 한다.
+
+**Tech Stack:** Flutter, Dart, `ValueNotifier`, `flutter_test`, existing Supabase gateway test seams.
+
+---
+
+## Current Repo Context
+
+- `lib/screens/group_screen.dart` already has `_openScopedAdd(ItemScope scope)` but it is only connected to the empty item list CTA.
+- `_CreateGroupDialog` already exists in `lib/screens/group_screen.dart`, but the visible create entry point is only `_EmptyGroupState`, so users with an existing group cannot discover adding another group.
+- `lib/main.dart` keeps a global FAB for adding items, including on the group tab when a group is selected. This can stay as a fallback, but the group page needs explicit in-page actions.
+- `lib/screens/add_item_screen.dart` and `lib/screens/scan_screen.dart` already accept `targetScope`, so wiring should pass the selected group scope rather than adding storage logic to widgets.
+- `AGENTS.md` treats business logic inside Flutter widgets as a P1 issue. This plan keeps persistence, ownership, and selected group behavior in services/stores and adds only UI callbacks to widgets.
+
+## File Structure
+
+- Create: `lib/widgets/group/group_quick_actions.dart`
+  - Renders the in-page action controls: manual item add, receipt scan, and group add.
+  - Takes callbacks only; no store reads and no persistence.
+- Create: `test/widgets/group/group_quick_actions_test.dart`
+  - Verifies labels render and each callback is invoked.
+- Modify: `lib/screens/group_screen.dart`
+  - Adds scan navigation helper.
+  - Adds create-group dialog helper for non-empty group states.
+  - Renders `GroupQuickActions` when `selectedGroupScope` exists.
+- Modify: `test/screens/group_screen_test.dart`
+  - Verifies the group page exposes the new actions.
+  - Verifies manual add saves using the selected group id.
+  - Verifies scan action opens `ScanScreen`.
+  - Verifies additional group creation is reachable when a group already exists.
+- Modify: `test/services/group_store_test.dart`
+  - Adds a regression test for appending a new group and selecting it.
+- Modify: `lib/screens/add_item_screen.dart`
+  - Shows a compact target-group banner for group scoped registration.
+- Modify: `test/screens/add_item_screen_test.dart`
+  - Verifies the banner appears for group scope.
+- Modify: `lib/screens/scan_screen.dart`
+  - Shows a compact target-group banner on scan entry.
+- Create: `test/screens/scan_screen_test.dart`
+  - Verifies the scan banner appears for group scope.
+- Modify: `test/widget_test.dart`
+  - Keep existing global FAB expectations unchanged unless product review decides to remove the group-tab FAB later.
+
+---
+
+### Task 1: Protect Additional Group Creation State
+
+**Files:**
+- Modify: `test/services/group_store_test.dart`
+
+- [ ] **Step 1: Add the failing regression test**
+
+Add this test inside the existing `group('GroupStore', () { ... })` block, after the current `creates a group and exposes it through state` test:
+
+```dart
+test('createGroup appends a new group and selects it when groups already exist', () async {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_groupWithMembers()],
+    selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+  gateway.nextCreatedGroupId = 'group-2';
+
+  await GroupStore.instance.createGroup('사무실');
+
+  expect(GroupStore.instance.value.groups.map((group) => group.name), [
+    '우리 가족',
+    '사무실',
+  ]);
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+  expect(
+    GroupStore.instance.value.selectedGroupScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart
+```
+
+Expected: FAIL because `_RecordingGroupDatabaseGateway.nextCreatedGroupId` does not exist.
+
+- [ ] **Step 3: Extend the group gateway fake**
+
+In `test/services/group_store_test.dart`, add this field to `_RecordingGroupDatabaseGateway`:
+
+```dart
+String nextCreatedGroupId = 'group-1';
+```
+
+Then change `createGroupWithOwner` to use it:
+
+```dart
+@override
+Future<Map<String, dynamic>> createGroupWithOwner({
+  required String name,
+  required String inviteCode,
+}) async {
+  if (createGroupWithOwnerError != null) {
+    throw createGroupWithOwnerError!;
+  }
+
+  createdGroupValues = <String, dynamic>{
+    'name': name,
+    'invite_code': inviteCode,
+  };
+  return <String, dynamic>{
+    'id': nextCreatedGroupId,
+    'name': name,
+    'invite_code': inviteCode,
+    'created_by': SupabaseService.currentUserId,
+    'created_at': '2026-05-26T00:00:00.000Z',
+    'group_members': <Map<String, dynamic>>[],
+  };
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add test/services/group_store_test.dart
+git commit -m "test: cover adding another group"
+```
+
+---
+
+### Task 2: Add a Pure Group Quick Actions Widget
+
+**Files:**
+- Create: `lib/widgets/group/group_quick_actions.dart`
+- Create: `test/widgets/group/group_quick_actions_test.dart`
+
+- [ ] **Step 1: Write the widget tests**
+
+Create `test/widgets/group/group_quick_actions_test.dart`:
+
+```dart
+import 'package:buylog/theme/app_theme.dart';
+import 'package:buylog/widgets/group/group_quick_actions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders group page quick actions', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: GroupQuickActions(
+            onAddItem: () {},
+            onScanReceipt: () {},
+            onCreateGroup: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('물품 추가'), findsOneWidget);
+    expect(find.text('영수증 스캔'), findsOneWidget);
+    expect(find.text('그룹 추가'), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsWidgets);
+    expect(find.byIcon(Icons.document_scanner_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.group_add_outlined), findsOneWidget);
+  });
+
+  testWidgets('invokes each quick action callback', (tester) async {
+    var addItemCalls = 0;
+    var scanCalls = 0;
+    var createGroupCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: GroupQuickActions(
+            onAddItem: () => addItemCalls += 1,
+            onScanReceipt: () => scanCalls += 1,
+            onCreateGroup: () => createGroupCalls += 1,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('물품 추가'));
+    await tester.tap(find.text('영수증 스캔'));
+    await tester.tap(find.text('그룹 추가'));
+
+    expect(addItemCalls, 1);
+    expect(scanCalls, 1);
+    expect(createGroupCalls, 1);
+  });
+
+  testWidgets('disables group creation while the store is saving', (tester) async {
+    var createGroupCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: GroupQuickActions(
+            onAddItem: () {},
+            onScanReceipt: () {},
+            onCreateGroup: () => createGroupCalls += 1,
+            isCreateGroupDisabled: true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('그룹 추가'));
+
+    expect(createGroupCalls, 0);
+  });
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```powershell
+flutter test test/widgets/group/group_quick_actions_test.dart
+```
+
+Expected: FAIL because `GroupQuickActions` does not exist.
+
+- [ ] **Step 3: Implement the widget**
+
+Create `lib/widgets/group/group_quick_actions.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import '../../theme/app_theme.dart';
+
+class GroupQuickActions extends StatelessWidget {
+  const GroupQuickActions({
+    super.key,
+    required this.onAddItem,
+    required this.onScanReceipt,
+    required this.onCreateGroup,
+    this.isCreateGroupDisabled = false,
+  });
+
+  final VoidCallback onAddItem;
+  final VoidCallback onScanReceipt;
+  final VoidCallback onCreateGroup;
+  final bool isCreateGroupDisabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: FilledButton.icon(
+                onPressed: onAddItem,
+                icon: const Icon(Icons.add, size: 18),
+                label: const Text('물품 추가'),
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 13),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: onScanReceipt,
+                icon: const Icon(Icons.document_scanner_outlined, size: 18),
+                label: const Text('영수증 스캔'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.primary,
+                  side: const BorderSide(color: AppColors.primary),
+                  padding: const EdgeInsets.symmetric(vertical: 13),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton.icon(
+            onPressed: isCreateGroupDisabled ? null : onCreateGroup,
+            icon: const Icon(Icons.group_add_outlined, size: 18),
+            label: const Text('그룹 추가'),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.textSecondary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run:
+
+```powershell
+flutter test test/widgets/group/group_quick_actions_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add lib/widgets/group/group_quick_actions.dart test/widgets/group/group_quick_actions_test.dart
+git commit -m "feat: add group quick actions"
+```
+
+---
+
+### Task 3: Wire Quick Actions Into GroupScreen
+
+**Files:**
+- Modify: `lib/screens/group_screen.dart`
+- Modify: `test/screens/group_screen_test.dart`
+
+- [ ] **Step 1: Add GroupScreen action tests and test support**
+
+In `test/screens/group_screen_test.dart`, add these imports:
+
+```dart
+import 'package:buylog/screens/add_item_screen.dart';
+import 'package:buylog/screens/scan_screen.dart';
+```
+
+Extend `_RecordingItemDatabaseGateway` with save recording:
+
+```dart
+Map<String, dynamic>? upsertedItemPayload;
+
+@override
+Future<void> upsertItem(Map<String, dynamic> payload) async {
+  upsertedItemPayload = Map<String, dynamic>.from(payload);
+}
+```
+
+Extend `_FakeGroupDatabaseGateway` with a deterministic next group id:
+
+```dart
+String nextCreatedGroupId = 'group-1';
+```
+
+Then change `_FakeGroupDatabaseGateway.createGroupWithOwner` so it passes that id:
+
+```dart
+final group = _groupRow(
+  id: nextCreatedGroupId,
+  name: name,
+  inviteCode: inviteCode,
+);
+```
+
+Add these tests before the final `empty group item list shows add CTA` test:
+
+```dart
+testWidgets('existing group page exposes in-page add actions', (tester) async {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group()],
+    selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+
+  expect(find.text('물품 추가'), findsOneWidget);
+  expect(find.text('영수증 스캔'), findsOneWidget);
+  expect(find.text('그룹 추가'), findsOneWidget);
+});
+
+testWidgets('manual group page add saves with the selected group id', (
+  tester,
+) async {
+  final itemGateway = _RecordingItemDatabaseGateway();
+  SupabaseService.debugItemDatabaseGateway = itemGateway;
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group()],
+    selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+  await tester.tap(find.text('물품 추가'));
+  await tester.pumpAndSettle();
+
+  expect(find.byType(AddItemScreen), findsOneWidget);
+
+  await tester.enterText(find.byType(TextFormField).at(0), '세제');
+  await tester.enterText(find.byType(TextFormField).at(1), '브랜드');
+  await tester.enterText(find.byType(TextFormField).at(2), '30');
+  await tester.enterText(find.byType(TextFormField).at(3), '8900');
+  await tester.enterText(find.byType(TextFormField).at(4), '마트');
+  await tester.tap(find.text('등록 완료'));
+  await tester.pumpAndSettle();
+
+  expect(itemGateway.upsertedItemPayload?['group_id'], 'group-1');
+  expect(itemGateway.upsertedItemPayload?['user_id'], isNull);
+});
+
+testWidgets('scan group page action opens ScanScreen', (tester) async {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group()],
+    selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+  await tester.tap(find.text('영수증 스캔'));
+  await tester.pumpAndSettle();
+
+  expect(find.byType(ScanScreen), findsOneWidget);
+});
+
+testWidgets('group add action creates another group from non-empty state', (
+  tester,
+) async {
+  final gateway = _FakeGroupDatabaseGateway()
+    ..nextCreatedGroupId = 'group-2';
+  SupabaseService.debugGroupDatabaseGateway = gateway;
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group(id: 'group-1', name: '우리 가족')],
+    selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+  await tester.tap(find.text('그룹 추가'));
+  await tester.pumpAndSettle();
+
+  await tester.enterText(find.byType(TextFormField), '사무실');
+  await tester.tap(find.text('만들기'));
+  await tester.pump();
+  await tester.pumpAndSettle();
+
+  expect(gateway.createGroupWithOwnerCalls, 1);
+  expect(gateway.createdGroupValues?['name'], '사무실');
+  expect(GroupStore.instance.value.groups.map((group) => group.name), [
+    '우리 가족',
+    '사무실',
+  ]);
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```powershell
+flutter test test/screens/group_screen_test.dart
+```
+
+Expected: FAIL because `GroupScreen` does not render `물품 추가`, `영수증 스캔`, or `그룹 추가` for an existing group.
+
+- [ ] **Step 3: Add navigation helpers to GroupScreen**
+
+In `lib/screens/group_screen.dart`, add imports:
+
+```dart
+import '../widgets/group/group_quick_actions.dart';
+import 'scan_screen.dart';
+```
+
+Add these methods inside `_GroupScreenState`, after `_openScopedAdd`:
+
+```dart
+void _openScopedScan(ItemScope scope) {
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      builder: (scanContext) => Scaffold(
+        backgroundColor: AppColors.background,
+        body: Stack(
+          children: [
+            ScanScreen(targetScope: scope),
+            Positioned(
+              top: MediaQuery.of(scanContext).padding.top + 8,
+              right: 12,
+              child: Material(
+                color: AppColors.surface,
+                shape: const CircleBorder(),
+                elevation: 1,
+                child: IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  color: AppColors.text,
+                  onPressed: () => Navigator.of(scanContext).pop(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void _openCreateGroupDialog() {
+  showDialog<void>(
+    context: context,
+    builder: (_) => const _CreateGroupDialog(),
+  );
+}
+```
+
+- [ ] **Step 4: Render GroupQuickActions for selected groups**
+
+In `lib/screens/group_screen.dart`, insert this block immediately after the `ItemScopeTabs` and its following `SizedBox(height: 16)`:
+
+```dart
+Padding(
+  padding: const EdgeInsets.symmetric(horizontal: 20),
+  child: GroupQuickActions(
+    onAddItem: () => _openScopedAdd(selectedGroupScope),
+    onScanReceipt: () => _openScopedScan(selectedGroupScope),
+    onCreateGroup: _openCreateGroupDialog,
+    isCreateGroupDisabled: state.isSaving,
+  ),
+),
+const SizedBox(height: 16),
+```
+
+The surrounding section should remain inside the `else ...[` branch where `selectedGroupScope!` has already been established.
+
+- [ ] **Step 5: Run the focused screen tests**
+
+Run:
+
+```powershell
+flutter test test/screens/group_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```powershell
+git add lib/screens/group_screen.dart test/screens/group_screen_test.dart
+git commit -m "feat: expose group page add actions"
+```
+
+---
+
+### Task 4: Show the Target Group on Add and Scan Screens
+
+**Files:**
+- Modify: `lib/screens/add_item_screen.dart`
+- Modify: `test/screens/add_item_screen_test.dart`
+- Modify: `lib/screens/scan_screen.dart`
+- Create: `test/screens/scan_screen_test.dart`
+
+- [ ] **Step 1: Add AddItemScreen banner test**
+
+In `test/screens/add_item_screen_test.dart`, add this test after the existing group registration test:
+
+```dart
+testWidgets('shows the target group while adding a group item', (tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppTheme.lightTheme,
+      home: const AddItemScreen(
+        targetScope: ItemScope.group(id: 'group-1', label: '우리 가족'),
+      ),
+    ),
+  );
+
+  expect(find.text('우리 가족에 추가 중'), findsOneWidget);
+});
+```
+
+- [ ] **Step 2: Add ScanScreen banner test**
+
+Create `test/screens/scan_screen_test.dart`:
+
+```dart
+import 'package:buylog/models/item_scope.dart';
+import 'package:buylog/screens/scan_screen.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows the target group while scanning for a group', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: const Scaffold(
+          body: ScanScreen(
+            targetScope: ItemScope.group(id: 'group-1', label: '우리 가족'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('우리 가족에 스캔 추가'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 3: Run the focused tests and confirm they fail**
+
+Run:
+
+```powershell
+flutter test test/screens/add_item_screen_test.dart test/screens/scan_screen_test.dart
+```
+
+Expected: FAIL because neither screen renders the target group banner yet.
+
+- [ ] **Step 4: Implement AddItemScreen banner**
+
+In `lib/screens/add_item_screen.dart`, add this helper inside `_AddItemScreenState`, near `_buildOcrBanner`:
+
+```dart
+Widget _buildScopeBanner() {
+  final scope = _effectiveScope;
+  if (!scope.isGroup) {
+    return const SizedBox.shrink();
+  }
+
+  return Container(
+    width: double.infinity,
+    padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+    decoration: BoxDecoration(
+      color: AppColors.primaryLight2,
+      borderRadius: BorderRadius.circular(10),
+      border: Border.all(color: AppColors.primaryLight, width: 0.5),
+    ),
+    child: Row(
+      children: [
+        const Icon(Icons.group_outlined, size: 18, color: AppColors.primary),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            '${scope.label}에 추가 중',
+            style: const TextStyle(
+              fontSize: 13,
+              color: AppColors.primaryDark,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+```
+
+Then insert this block at the top of the `SingleChildScrollView` column, before the OCR banner:
+
+```dart
+if (_effectiveScope.isGroup) ...[
+  _buildScopeBanner(),
+  const SizedBox(height: 20),
+],
+```
+
+- [ ] **Step 5: Implement ScanScreen banner**
+
+In `lib/screens/scan_screen.dart`, add this helper inside `_ScanScreenState`:
+
+```dart
+Widget _buildScopeBanner() {
+  if (!widget.targetScope.isGroup) {
+    return const SizedBox.shrink();
+  }
+
+  return Padding(
+    padding: const EdgeInsets.fromLTRB(20, 10, 20, 0),
+    child: Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.primaryLight2,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.primaryLight, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.group_outlined, size: 18, color: AppColors.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${widget.targetScope.label}에 스캔 추가',
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.primaryDark,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+```
+
+In `_buildIdle`, insert the banner after the subtitle text and before `const SizedBox(height: 32)`:
+
+```dart
+_buildScopeBanner(),
+```
+
+- [ ] **Step 6: Run the focused tests**
+
+Run:
+
+```powershell
+flutter test test/screens/add_item_screen_test.dart test/screens/scan_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add lib/screens/add_item_screen.dart lib/screens/scan_screen.dart test/screens/add_item_screen_test.dart test/screens/scan_screen_test.dart
+git commit -m "feat: show group target during item entry"
+```
+
+---
+
+### Task 5: Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Format changed Dart files**
+
+Run:
+
+```powershell
+dart format lib/widgets/group/group_quick_actions.dart lib/screens/group_screen.dart lib/screens/add_item_screen.dart lib/screens/scan_screen.dart test/widgets/group/group_quick_actions_test.dart test/screens/group_screen_test.dart test/screens/add_item_screen_test.dart test/screens/scan_screen_test.dart test/services/group_store_test.dart
+```
+
+Expected: command exits `0`.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart test/widgets/group/group_quick_actions_test.dart test/screens/group_screen_test.dart test/screens/add_item_screen_test.dart test/screens/scan_screen_test.dart test/widget_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run analyzer**
+
+Run:
+
+```powershell
+flutter analyze --no-fatal-infos
+```
+
+Expected: no analyzer errors.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```powershell
+flutter test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run:
+
+```powershell
+flutter run -d windows
+```
+
+Manual checks:
+
+1. 그룹 탭에서 기존 그룹이 선택된 상태로 `물품 추가`, `영수증 스캔`, `그룹 추가`가 보인다.
+2. `물품 추가`를 누르면 등록 화면에 `선택 그룹명에 추가 중` 배너가 보이고 저장된 row의 `group_id`가 선택 그룹 id로 들어간다.
+3. `영수증 스캔`을 누르면 스캔 화면에 `선택 그룹명에 스캔 추가` 배너가 보인다.
+4. `그룹 추가`를 누르면 생성 다이얼로그가 뜨고, 생성 성공 후 새 그룹 탭이 선택된다.
+5. 그룹이 하나도 없는 상태에서는 기존 빈 상태의 `그룹 만들기` 흐름이 계속 동작한다.
+
+- [ ] **Step 6: Final commit if task commits were not created**
+
+```powershell
+git add lib/widgets/group/group_quick_actions.dart lib/screens/group_screen.dart lib/screens/add_item_screen.dart lib/screens/scan_screen.dart test/widgets/group/group_quick_actions_test.dart test/screens/group_screen_test.dart test/screens/add_item_screen_test.dart test/screens/scan_screen_test.dart test/services/group_store_test.dart
+git commit -m "feat: improve group page add flows"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers the weak group item addition path with explicit manual and scan actions, and covers missing additional group creation with a non-empty-state `그룹 추가` action.
+- Business logic boundary: `GroupQuickActions` is callback-only, and `GroupScreen` only performs navigation/dialog presentation. Group creation still goes through `GroupStore.createGroup`, and item saving still goes through `ItemStore`/`SupabaseService`.
+- Tests: New business behavior is protected at widget and store levels, including selected group id propagation and new group selection after creation.
+- Null safety: `GroupQuickActions` only renders when `selectedGroupScope` is non-null. Add/scan scope banners use existing non-null `ItemScope` getters.
+- UI risk: The global FAB remains unchanged, so existing navigation tests and user muscle memory keep working while the group page gains clearer in-context actions.

--- a/docs/superpowers/plans/2026-05-27-group-page-group-only-tabs.md
+++ b/docs/superpowers/plans/2026-05-27-group-page-group-only-tabs.md
@@ -1,0 +1,912 @@
+# Group Page Group-Only Tabs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 그룹 페이지의 상단 탭에서 `내 물품`을 제거하고, 가입한 여러 그룹 사이를 전환하는 그룹 전용 탭으로 바꾼다.
+
+**Architecture:** `ItemScope`는 저장/조회 범위 모델로 유지하되, `GroupStore`가 그룹 화면용 `groupScopes`와 `selectedGroupScope`를 제공한다. `GroupScreen`은 이 그룹 전용 scope만 렌더링하고 로드하며, 하단 전역 FAB도 그룹 탭에서는 선택 가능한 그룹이 있을 때만 노출한다.
+
+**Tech Stack:** Flutter, Dart, `ValueNotifier`, Supabase gateway seam, `flutter_test`.
+
+---
+
+## Current Repo Context
+
+- Root `AGENTS.md` requires Korean PR/review communication and blocks new business logic without tests.
+- Current group page code lives in `lib/screens/group_screen.dart`.
+- Group membership/selection state lives in `lib/services/group_store.dart`.
+- Group item loading is already isolated in `lib/services/group_items_store.dart`.
+- The current top chip widget is `lib/widgets/group/item_scope_tabs.dart` and can render any `ItemScope`, including `ItemScope.personal()`.
+- `GroupState.availableScopes` currently returns `[내 물품, ...joinedGroups]`, and `GroupScreen` passes that directly to `ItemScopeTabs`.
+- `MainNavigation._currentAddScope()` already uses `GroupStore.instance.value.selectedScope` when the current bottom tab is 그룹, so group selection semantics affect FAB-created items.
+- No Supabase schema or migration change is required.
+
+## File Structure
+
+- Modify: `lib/services/group_store.dart`
+  - Add `groupScopes` and `selectedGroupScope`.
+  - Make initialization and leave-group fallback select a group scope when groups exist.
+- Modify: `lib/screens/group_screen.dart`
+  - Render only group scopes in the top tabs.
+  - Do not load or render personal items on the group page.
+  - Keep group item loading synced when group state changes after create/leave.
+- No source change: `lib/widgets/group/item_scope_tabs.dart`
+  - Keep the reusable chip UI as-is; the group-only contract is enforced by `GroupScreen` passing `groupScopes`.
+- Modify: `lib/main.dart`
+  - Hide the global add FAB on the group bottom tab when no group is selectable.
+  - Pass the selected group scope to scan/manual add flows on the group bottom tab.
+- Modify: `test/services/group_store_test.dart`
+  - Cover group-only scopes and group-first selection fallback.
+- Modify: `test/screens/group_screen_test.dart`
+  - Cover removal of `내 물품` from group tabs and group-only initial loading.
+- Modify: `test/widgets/group/item_scope_tabs_test.dart`
+  - Update the widget expectation to joined-group tab rendering.
+- Modify: `test/widget_test.dart`
+  - Cover FAB visibility on the group bottom tab with and without groups.
+
+---
+
+### Task 1: Add Group-Only Scope Semantics to GroupStore
+
+**Files:**
+- Modify: `lib/services/group_store.dart`
+- Test: `test/services/group_store_test.dart`
+
+- [ ] **Step 1: Write failing GroupStore tests**
+
+Add these tests inside the existing `group('GroupStore', () { ... })` block in `test/services/group_store_test.dart`:
+
+```dart
+test('exposes joined groups as group-only scopes', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+
+  await GroupStore.instance.initialize();
+
+  final groupScopes = GroupStore.instance.value.groupScopes;
+  expect(groupScopes.map((scope) => scope.label), ['우리 가족', '사무실']);
+  expect(groupScopes.every((scope) => scope.isGroup), isTrue);
+  expect(groupScopes.any((scope) => scope.label == '내 물품'), isFalse);
+});
+
+test('initialize selects the first joined group for the group page', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+
+  await GroupStore.instance.initialize();
+
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+  expect(
+    GroupStore.instance.value.selectedGroupScope,
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+});
+
+test('selectedGroupScope falls back to the first group when selected scope is personal', () {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[
+      _groupWithMembers(),
+      BuylogGroup(
+        id: 'group-2',
+        name: '사무실',
+        inviteCode: 'BUY-OFFICE',
+        createdBy: 'owner-user',
+        createdAt: DateTime.parse('2026-05-27T00:00:00.000Z'),
+      ),
+    ],
+    selectedScope: const ItemScope.personal(),
+  );
+
+  expect(
+    GroupStore.instance.value.selectedGroupScope,
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+});
+
+test('leaves selected group and selects next remaining group', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+  await GroupStore.instance.initialize();
+  GroupStore.instance.selectScope(
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+
+  await GroupStore.instance.leaveGroup(groupId: 'group-1');
+
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+  expect(
+    GroupStore.instance.value.selectedGroupScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+});
+```
+
+Update the existing test named `builds personal and joined group scopes after initialize` so it still verifies `availableScopes` includes `내 물품`, but expects `selectedScope` to be the first group:
+
+```dart
+test('builds personal and joined group scopes after initialize', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+
+  await GroupStore.instance.initialize();
+
+  final scopes = GroupStore.instance.value.availableScopes;
+  expect(scopes.map((scope) => scope.label), ['내 물품', '우리 가족', '사무실']);
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+});
+```
+
+Update the existing test named `leaves the selected group and reloads joined groups` so the final selected scope is `group-2` instead of `ItemScope.personal()`:
+
+```dart
+expect(
+  GroupStore.instance.value.selectedScope,
+  const ItemScope.group(id: 'group-2', label: '사무실'),
+);
+```
+
+- [ ] **Step 2: Run GroupStore tests and confirm they fail**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart --plain-name "group"
+```
+
+Expected: FAIL because `groupScopes` and `selectedGroupScope` do not exist and leave fallback still selects personal scope.
+
+- [ ] **Step 3: Add group-only derived scopes**
+
+In `lib/services/group_store.dart`, add these getters to `GroupState` below `availableScopes`:
+
+```dart
+List<ItemScope> get groupScopes {
+  return <ItemScope>[
+    for (final group in visibleGroups)
+      ItemScope.group(id: group.id, label: group.name),
+  ];
+}
+
+ItemScope? get selectedGroupScope {
+  final scopes = groupScopes;
+  if (selectedScope.isGroup) {
+    for (final scope in scopes) {
+      if (scope.id == selectedScope.id) {
+        return scope;
+      }
+    }
+  }
+  return scopes.isEmpty ? null : scopes.first;
+}
+```
+
+- [ ] **Step 4: Select the first group after initialization**
+
+In `GroupStore.initialize()` in `lib/services/group_store.dart`, replace the success assignment with:
+
+```dart
+final groups = await SupabaseService.loadGroupsForUser();
+value = GroupState(
+  group: groups.isEmpty ? null : groups.first,
+  groups: groups,
+  selectedScope: _firstGroupScopeOrPersonal(groups),
+);
+```
+
+Add this private helper inside `GroupStore`:
+
+```dart
+ItemScope _firstGroupScopeOrPersonal(List<BuylogGroup> groups) {
+  if (groups.isEmpty) {
+    return const ItemScope.personal();
+  }
+  final first = groups.first;
+  return ItemScope.group(id: first.id, label: first.name);
+}
+```
+
+- [ ] **Step 5: Select the next group after leaving a group**
+
+In `GroupStore.leaveGroup()` in `lib/services/group_store.dart`, replace the `selectedScope` and `availableScopes` block with:
+
+```dart
+final remainingGroupScopes = <ItemScope>[
+  for (final group in groups) ItemScope.group(id: group.id, label: group.name),
+];
+final selectedScope = _scopeAfterLeavingGroup(
+  previousScope: previousState.selectedScope,
+  removedGroupId: trimmedGroupId,
+  remainingGroupScopes: remainingGroupScopes,
+);
+
+value = GroupState(
+  group: groups.isEmpty ? null : groups.first,
+  groups: groups,
+  selectedScope: selectedScope,
+);
+```
+
+Add this private helper inside `GroupStore`:
+
+```dart
+ItemScope _scopeAfterLeavingGroup({
+  required ItemScope previousScope,
+  required String removedGroupId,
+  required List<ItemScope> remainingGroupScopes,
+}) {
+  if (previousScope.isGroup && previousScope.id != removedGroupId) {
+    for (final scope in remainingGroupScopes) {
+      if (scope.id == previousScope.id) {
+        return scope;
+      }
+    }
+  }
+
+  if (remainingGroupScopes.isEmpty) {
+    return const ItemScope.personal();
+  }
+  return remainingGroupScopes.first;
+}
+```
+
+- [ ] **Step 6: Run GroupStore tests**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add lib/services/group_store.dart test/services/group_store_test.dart
+git commit -m "feat: prefer group scopes on group page"
+```
+
+---
+
+### Task 2: Render GroupScreen with Group Tabs Only
+
+**Files:**
+- Modify: `lib/screens/group_screen.dart`
+- Modify: `test/screens/group_screen_test.dart`
+- Modify: `test/widgets/group/item_scope_tabs_test.dart`
+
+- [ ] **Step 1: Update tab widget test to group-only expectations**
+
+Replace the existing test in `test/widgets/group/item_scope_tabs_test.dart` with:
+
+```dart
+testWidgets('renders joined group tabs and reports group selection', (
+  tester,
+) async {
+  ItemScope? selected;
+
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppTheme.lightTheme,
+      home: Scaffold(
+        body: ItemScopeTabs(
+          scopes: const <ItemScope>[
+            ItemScope.group(id: 'group-1', label: '우리 가족'),
+            ItemScope.group(id: 'group-2', label: '사무실'),
+          ],
+          selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+          onSelected: (scope) => selected = scope,
+        ),
+      ),
+    ),
+  );
+
+  expect(find.text('내 물품'), findsNothing);
+  expect(find.text('우리 가족'), findsOneWidget);
+  expect(find.text('사무실'), findsOneWidget);
+
+  await tester.tap(find.text('사무실'));
+  expect(selected, const ItemScope.group(id: 'group-2', label: '사무실'));
+});
+```
+
+- [ ] **Step 2: Add GroupScreen tests for no personal tab and no personal item load**
+
+Add this test to `test/screens/group_screen_test.dart`:
+
+```dart
+testWidgets('group page renders group tabs only and loads the first group', (
+  WidgetTester tester,
+) async {
+  final itemGateway = _RecordingItemDatabaseGateway()
+    ..loadItemsResult = <Map<String, dynamic>>[
+      _itemRow(id: 'group-item-1', groupId: 'group-1'),
+    ];
+  SupabaseService.debugItemDatabaseGateway = itemGateway;
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[
+      _group(id: 'group-1', name: '우리 가족'),
+      _group(id: 'group-2', name: '사무실'),
+    ],
+    selectedScope: const ItemScope.personal(),
+  );
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+
+  expect(find.text('내 물품'), findsNothing);
+  expect(find.text('우리 가족'), findsAtLeastNWidgets(1));
+  expect(find.text('사무실'), findsOneWidget);
+  expect(itemGateway.lastUserId, isNull);
+  expect(itemGateway.lastGroupId, 'group-1');
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+});
+```
+
+Add this test to the same file:
+
+```dart
+testWidgets('empty group page does not render a personal item list', (
+  WidgetTester tester,
+) async {
+  SupabaseService.debugItemDatabaseGateway = _RecordingItemDatabaseGateway();
+  GroupStore.instance.value = const GroupState();
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+
+  expect(find.text('내 물품'), findsNothing);
+  expect(find.text('내 물품 목록'), findsNothing);
+  expect(find.text('그룹에 제품 추가'), findsNothing);
+  expect(find.text('그룹 만들기'), findsOneWidget);
+});
+```
+
+Update `_RecordingItemDatabaseGateway` in `test/screens/group_screen_test.dart` so tests can assert query routing:
+
+```dart
+class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
+  int loadItemsCalls = 0;
+  String? lastUserId;
+  String? lastGroupId;
+  List<Map<String, dynamic>> loadItemsResult = const [];
+
+  @override
+  Future<List<Map<String, dynamic>>> loadItems({
+    required String? userId,
+    required String? groupId,
+  }) async {
+    loadItemsCalls += 1;
+    lastUserId = userId;
+    lastGroupId = groupId;
+    return loadItemsResult;
+  }
+
+  @override
+  Future<String> ensureCategory({
+    required String name,
+    required String? userId,
+    required String? groupId,
+  }) async {
+    return 'category-1';
+  }
+
+  @override
+  Future<void> upsertItem(Map<String, dynamic> payload) async {}
+
+  @override
+  Future<void> insertPurchase(Map<String, dynamic> payload) async {}
+}
+```
+
+Update the existing test named `renders scope tabs and switches selected group tab`:
+
+```dart
+expect(find.text('내 물품'), findsNothing);
+expect(find.text('우리 가족'), findsOneWidget);
+expect(find.text('사무실'), findsOneWidget);
+```
+
+- [ ] **Step 3: Run widget tests and confirm they fail**
+
+Run:
+
+```powershell
+flutter test test/widgets/group/item_scope_tabs_test.dart test/screens/group_screen_test.dart --plain-name "group"
+```
+
+Expected: FAIL because `GroupScreen` still passes `state.availableScopes` and still initializes item loading from `selectedScope`, which can be personal.
+
+- [ ] **Step 4: Sync GroupScreen item loading to selected group scope**
+
+In `lib/screens/group_screen.dart`, update `_GroupScreenState` lifecycle and helpers:
+
+```dart
+@override
+void initState() {
+  super.initState();
+  _itemsStore = GroupItemsStore();
+  GroupStore.instance.addListener(_syncSelectedGroupItems);
+  _syncSelectedGroupItems();
+  ItemStore.instance.lastSaveEvent.addListener(_reloadAfterScopedSave);
+}
+
+@override
+void dispose() {
+  GroupStore.instance.removeListener(_syncSelectedGroupItems);
+  ItemStore.instance.lastSaveEvent.removeListener(_reloadAfterScopedSave);
+  _itemsStore.dispose();
+  super.dispose();
+}
+
+void _syncSelectedGroupItems() {
+  final selectedGroupScope = GroupStore.instance.value.selectedGroupScope;
+  if (selectedGroupScope == null) {
+    return;
+  }
+
+  final selectedScope = GroupStore.instance.value.selectedScope;
+  if (selectedScope.storageKey != selectedGroupScope.storageKey) {
+    GroupStore.instance.selectScope(selectedGroupScope);
+    return;
+  }
+
+  if (_itemsStore.value.scope.storageKey != selectedGroupScope.storageKey) {
+    _itemsStore.load(selectedGroupScope);
+  }
+}
+
+void _selectScope(ItemScope scope) {
+  if (!scope.isGroup) {
+    return;
+  }
+  GroupStore.instance.selectScope(scope);
+  _itemsStore.load(scope);
+}
+
+void _reloadAfterScopedSave() {
+  final event = ItemStore.instance.lastSaveEvent.value;
+  final selectedGroupScope = GroupStore.instance.value.selectedGroupScope;
+  if (event == null ||
+      selectedGroupScope == null ||
+      !event.scope.isGroup ||
+      event.scope.storageKey != selectedGroupScope.storageKey) {
+    return;
+  }
+  _itemsStore.load(event.scope);
+}
+```
+
+- [ ] **Step 5: Render only group tabs and hide the item section when there are no groups**
+
+Inside the `ValueListenableBuilder<GroupState>` builder in `lib/screens/group_screen.dart`, replace the selected group calculation and children after the title with this structure:
+
+```dart
+final selectedGroupScope = state.selectedGroupScope;
+final selectedGroup = selectedGroupScope == null
+    ? null
+    : state.groupForScope(selectedGroupScope);
+
+return SingleChildScrollView(
+  padding: const EdgeInsets.fromLTRB(0, 20, 0, 24),
+  child: Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Text('그룹', style: Theme.of(context).textTheme.headlineMedium),
+      ),
+      const SizedBox(height: 16),
+      if (state.visibleGroups.isEmpty)
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: _EmptyGroupState(errorMessage: state.errorMessage),
+        )
+      else ...[
+        ItemScopeTabs(
+          scopes: state.groupScopes,
+          selectedScope: selectedGroupScope!,
+          onSelected: _selectScope,
+        ),
+        const SizedBox(height: 16),
+        if (selectedGroup != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: _GroupCard(
+              group: selectedGroup,
+              isRefreshingMembers: state.isRefreshingMembers,
+              isLeavingGroup: state.isLeavingGroup,
+              onRefreshMembers: () => GroupStore.instance.refreshMembers(
+                groupId: selectedGroup.id,
+              ),
+              onCopyInviteCode: _copyInviteCode,
+            ),
+          ),
+        const SizedBox(height: 16),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: Text(
+            '${selectedGroupScope.label} 목록',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+        ),
+        ValueListenableBuilder<GroupItemsState>(
+          valueListenable: _itemsStore,
+          builder: (context, itemState, _) {
+            final summary = GroupDashboardSummaryBuilder.build(
+              scope: selectedGroupScope,
+              items: itemState.scope.storageKey == selectedGroupScope.storageKey
+                  ? itemState.items
+                  : const [],
+              selectedFilter: itemState.selectedFilter,
+            );
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+                  child: GroupStatusSummary(summary: summary),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: GroupItemFilterChips(
+                    summary: summary,
+                    onSelected: _itemsStore.selectFilter,
+                  ),
+                ),
+                GroupScopedItemList(
+                  items: summary.filteredItems,
+                  isLoading:
+                      itemState.isLoading &&
+                      itemState.scope.storageKey == selectedGroupScope.storageKey,
+                  errorMessage:
+                      itemState.scope.storageKey == selectedGroupScope.storageKey
+                      ? itemState.errorMessage
+                      : null,
+                  emptyMessage: '아직 이 그룹에 등록한 물품이 없습니다.',
+                  emptyActionLabel: '그룹에 제품 추가',
+                  onEmptyAction: () => _openScopedAdd(selectedGroupScope),
+                ),
+              ],
+            );
+          },
+        ),
+      ],
+    ],
+  ),
+);
+```
+
+- [ ] **Step 6: Run group screen tests**
+
+Run:
+
+```powershell
+flutter test test/widgets/group/item_scope_tabs_test.dart test/screens/group_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add lib/screens/group_screen.dart test/screens/group_screen_test.dart test/widgets/group/item_scope_tabs_test.dart
+git commit -m "feat: show group-only tabs on group page"
+```
+
+---
+
+### Task 3: Keep the Global Add FAB Group-Only on the Group Tab
+
+**Files:**
+- Modify: `lib/main.dart`
+- Test: `test/widget_test.dart`
+
+- [ ] **Step 1: Add FAB visibility tests**
+
+Add imports to `test/widget_test.dart`:
+
+```dart
+import 'package:buylog/models/group.dart';
+```
+
+Add this test:
+
+```dart
+testWidgets('group tab hides add FAB when no group exists', (
+  WidgetTester tester,
+) async {
+  GroupStore.instance.value = const GroupState();
+
+  await tester.pumpWidget(const BuylogApp());
+  await tester.tap(find.text('그룹'));
+  await tester.pump();
+
+  expect(find.byTooltip('제품 추가'), findsNothing);
+});
+```
+
+Add this test:
+
+```dart
+testWidgets('group tab shows add FAB when a group is selected', (
+  WidgetTester tester,
+) async {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group()],
+  );
+
+  await tester.pumpWidget(const BuylogApp());
+  await tester.tap(find.text('그룹'));
+  await tester.pump();
+
+  expect(find.byTooltip('제품 추가'), findsOneWidget);
+});
+```
+
+Add this helper at the bottom of `test/widget_test.dart`:
+
+```dart
+BuylogGroup _group({String id = 'group-1', String name = '우리 가족'}) {
+  return BuylogGroup(
+    id: id,
+    name: name,
+    inviteCode: 'BUY-ABC123',
+    createdBy: 'user-1',
+    createdAt: DateTime.parse('2026-05-27T00:00:00.000Z'),
+  );
+}
+```
+
+- [ ] **Step 2: Run FAB tests and confirm they fail**
+
+Run:
+
+```powershell
+flutter test test/widget_test.dart --plain-name "group tab"
+```
+
+Expected: FAIL because the FAB is still shown on the group bottom tab even when no group exists.
+
+- [ ] **Step 3: Make MainNavigation listen to GroupStore for FAB state**
+
+In `lib/main.dart`, replace `_currentAddScope()` with:
+
+```dart
+ItemScope _currentAddScope(GroupState groupState) {
+  if (_currentIndex != 1) {
+    return const ItemScope.personal();
+  }
+
+  return groupState.selectedGroupScope ?? const ItemScope.personal();
+}
+
+bool _shouldShowFab(GroupState groupState) {
+  return switch (_currentIndex) {
+    0 => true,
+    1 => groupState.selectedGroupScope != null,
+    2 => true,
+    _ => false,
+  };
+}
+```
+
+Replace `_openAddSheet()` with:
+
+```dart
+Future<void> _openAddSheet(GroupState groupState) async {
+  final choice = await showModalBottomSheet<_AddChoice>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    barrierColor: Colors.black.withValues(alpha: 0.45),
+    builder: (_) => const _AddActionSheet(),
+  );
+  if (!mounted || choice == null) return;
+  final targetScope = _currentAddScope(groupState);
+  switch (choice) {
+    case _AddChoice.scan:
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (ctx) => Scaffold(
+            backgroundColor: AppColors.background,
+            body: Stack(
+              children: [
+                ScanScreen(targetScope: targetScope),
+                Positioned(
+                  top: MediaQuery.of(ctx).padding.top + 8,
+                  right: 12,
+                  child: Material(
+                    color: AppColors.surface,
+                    shape: const CircleBorder(),
+                    elevation: 1,
+                    child: IconButton(
+                      icon: const Icon(Icons.close, size: 18),
+                      color: AppColors.text,
+                      onPressed: () => Navigator.of(ctx).pop(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    case _AddChoice.manual:
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => AddItemScreen(targetScope: targetScope),
+        ),
+      );
+  }
+}
+```
+
+Wrap the `Scaffold` returned by `MainNavigationState.build()` in a `ValueListenableBuilder<GroupState>`:
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return ValueListenableBuilder<GroupState>(
+    valueListenable: GroupStore.instance,
+    builder: (context, groupState, _) {
+      final showFab = _shouldShowFab(groupState);
+
+      return Scaffold(
+        body: IndexedStack(
+          index: _currentIndex,
+          children: [for (var i = 0; i < _tabs.length; i++) _screenAt(i)],
+        ),
+        floatingActionButton: showFab
+            ? FloatingActionButton(
+                onPressed: () => _openAddSheet(groupState),
+                backgroundColor: AppColors.success,
+                foregroundColor: Colors.white,
+                elevation: 6,
+                tooltip: '제품 추가',
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(18),
+                ),
+                child: const Icon(Icons.add, size: 26),
+              )
+            : null,
+        bottomNavigationBar: Container(
+          decoration: const BoxDecoration(
+            color: AppColors.surface,
+            border: Border(
+              top: BorderSide(color: AppColors.border, width: 0.5),
+            ),
+          ),
+          child: BottomNavigationBar(
+            currentIndex: _currentIndex,
+            onTap: switchTab,
+            items: [
+              for (final t in _tabs)
+                BottomNavigationBarItem(
+                  icon: Icon(t.icon),
+                  activeIcon: Icon(t.activeIcon),
+                  label: t.label,
+                ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+```
+
+- [ ] **Step 4: Run FAB tests**
+
+Run:
+
+```powershell
+flutter test test/widget_test.dart --plain-name "group tab"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add lib/main.dart test/widget_test.dart
+git commit -m "feat: keep group tab add action scoped"
+```
+
+---
+
+### Task 4: Full Verification
+
+**Files:**
+- No new source files.
+
+- [ ] **Step 1: Run analyzer**
+
+Run:
+
+```powershell
+flutter analyze --no-fatal-infos
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart test/screens/group_screen_test.dart test/widgets/group/item_scope_tabs_test.dart test/widget_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```powershell
+flutter test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Check worktree scope**
+
+Run:
+
+```powershell
+git status --short
+```
+
+Expected: only these files are modified:
+
+```text
+lib/services/group_store.dart
+lib/screens/group_screen.dart
+lib/main.dart
+test/services/group_store_test.dart
+test/screens/group_screen_test.dart
+test/widgets/group/item_scope_tabs_test.dart
+test/widget_test.dart
+```
+
+- [ ] **Step 5: Final commit if earlier task commits were skipped**
+
+```powershell
+git add lib/services/group_store.dart lib/screens/group_screen.dart lib/main.dart test/services/group_store_test.dart test/screens/group_screen_test.dart test/widgets/group/item_scope_tabs_test.dart test/widget_test.dart
+git commit -m "feat: switch group page to group-only tabs"
+```
+
+Expected: commit contains only the group-only tab behavior and related tests.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan removes `내 물품` from the group page tabs, uses joined groups as the tab source, and keeps group item loading scoped to the selected group.
+- Business logic boundary: Group-scope fallback and selection semantics live in `GroupStore`; widgets only render state and dispatch selection callbacks.
+- Test coverage: New business logic has service tests; UI behavior has screen/widget tests; bottom-tab add behavior has app-shell tests.
+- No DB changes: Existing `ItemScope.group` and `SupabaseService.loadItemsForScope` already support group item loading.
+- Regression risk: `availableScopes` remains available for existing code, while `groupScopes` becomes the group-page-specific API.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -112,18 +112,21 @@ class MainNavigationState extends State<MainNavigation> {
     setState(() => _currentIndex = index);
   }
 
-  ItemScope _currentAddScope() {
+  ItemScope _currentAddScope(GroupState groupState) {
     if (_currentIndex != 1) {
       return const ItemScope.personal();
     }
 
-    final state = GroupStore.instance.value;
-    final scope = state.selectedScope;
-    if (scope.isGroup) {
-      return scope;
-    }
+    return groupState.selectedGroupScope ?? const ItemScope.personal();
+  }
 
-    return const ItemScope.personal();
+  bool _shouldShowFab(GroupState groupState) {
+    return switch (_currentIndex) {
+      0 => true,
+      1 => groupState.selectedGroupScope != null,
+      2 => true,
+      _ => false,
+    };
   }
 
   Widget _screenAt(int index) => switch (index) {
@@ -135,7 +138,7 @@ class MainNavigationState extends State<MainNavigation> {
     _ => throw StateError('No screen registered for tab $index'),
   };
 
-  Future<void> _openAddSheet() async {
+  Future<void> _openAddSheet(GroupState groupState) async {
     final choice = await showModalBottomSheet<_AddChoice>(
       context: context,
       backgroundColor: Colors.transparent,
@@ -143,7 +146,7 @@ class MainNavigationState extends State<MainNavigation> {
       builder: (_) => const _AddActionSheet(),
     );
     if (!mounted || choice == null) return;
-    final targetScope = _currentAddScope();
+    final targetScope = _currentAddScope(groupState);
     switch (choice) {
       case _AddChoice.scan:
         // ScanScreen 코드는 변경하지 않음. 자체 헤더가 있으니 AppBar 없이
@@ -185,45 +188,51 @@ class MainNavigationState extends State<MainNavigation> {
 
   @override
   Widget build(BuildContext context) {
-    final showFab =
-        _currentIndex == 0 || _currentIndex == 1 || _currentIndex == 2;
+    return ValueListenableBuilder<GroupState>(
+      valueListenable: GroupStore.instance,
+      builder: (context, groupState, _) {
+        final showFab = _shouldShowFab(groupState);
 
-    return Scaffold(
-      body: IndexedStack(
-        index: _currentIndex,
-        children: [for (var i = 0; i < _tabs.length; i++) _screenAt(i)],
-      ),
-      floatingActionButton: showFab
-          ? FloatingActionButton(
-              onPressed: _openAddSheet,
-              backgroundColor: AppColors.success,
-              foregroundColor: Colors.white,
-              elevation: 6,
-              tooltip: '제품 추가',
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(18),
+        return Scaffold(
+          body: IndexedStack(
+            index: _currentIndex,
+            children: [for (var i = 0; i < _tabs.length; i++) _screenAt(i)],
+          ),
+          floatingActionButton: showFab
+              ? FloatingActionButton(
+                  onPressed: () => _openAddSheet(groupState),
+                  backgroundColor: AppColors.success,
+                  foregroundColor: Colors.white,
+                  elevation: 6,
+                  tooltip: '제품 추가',
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(18),
+                  ),
+                  child: const Icon(Icons.add, size: 26),
+                )
+              : null,
+          bottomNavigationBar: Container(
+            decoration: const BoxDecoration(
+              color: AppColors.surface,
+              border: Border(
+                top: BorderSide(color: AppColors.border, width: 0.5),
               ),
-              child: const Icon(Icons.add, size: 26),
-            )
-          : null,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          color: AppColors.surface,
-          border: Border(top: BorderSide(color: AppColors.border, width: 0.5)),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: _currentIndex,
-          onTap: switchTab,
-          items: [
-            for (final t in _tabs)
-              BottomNavigationBarItem(
-                icon: Icon(t.icon),
-                activeIcon: Icon(t.activeIcon),
-                label: t.label,
-              ),
-          ],
-        ),
-      ),
+            ),
+            child: BottomNavigationBar(
+              currentIndex: _currentIndex,
+              onTap: switchTab,
+              items: [
+                for (final t in _tabs)
+                  BottomNavigationBarItem(
+                    icon: Icon(t.icon),
+                    activeIcon: Icon(t.activeIcon),
+                    label: t.label,
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -141,10 +141,12 @@ class PriceComparison {
   final String store;
   final int price;
   final bool isLowest;
+  final String? link;
 
   const PriceComparison({
     required this.store,
     required this.price,
     this.isLowest = false,
+    this.link,
   });
 }

--- a/lib/models/price_cache_data.dart
+++ b/lib/models/price_cache_data.dart
@@ -2,14 +2,9 @@ import '../models/item.dart'; // PriceComparison 사용
 
 class PriceCacheData {
   final List<PriceComparison> priceData;
-  final String buyLink;
   final DateTime fetchedAt;
 
-  PriceCacheData({
-    required this.priceData,
-    required this.buyLink,
-    required this.fetchedAt,
-  });
+  PriceCacheData({required this.priceData, required this.fetchedAt});
 
   // 캐시 만료 여부 확인 (예: 1시간이 지나면 만료된 것으로 처리)
   bool get isExpired => DateTime.now().difference(fetchedAt).inHours >= 1;

--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -419,6 +419,10 @@ class _AddItemScreenState extends State<AddItemScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              if (_effectiveScope.isGroup) ...[
+                _buildScopeBanner(),
+                const SizedBox(height: 20),
+              ],
               if (widget.isOcrReview) ...[
                 _buildOcrBanner(),
                 const SizedBox(height: 20),
@@ -462,6 +466,39 @@ class _AddItemScreenState extends State<AddItemScreen> {
         fontSize: 16,
         fontWeight: FontWeight.w700,
         color: AppColors.text,
+      ),
+    );
+  }
+
+  Widget _buildScopeBanner() {
+    final scope = _effectiveScope;
+    if (!scope.isGroup) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.primaryLight2,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.primaryLight, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.group_outlined, size: 18, color: AppColors.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${scope.label}에 추가 중',
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.primaryDark,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screens/group_screen.dart
+++ b/lib/screens/group_screen.dart
@@ -29,26 +29,51 @@ class _GroupScreenState extends State<GroupScreen> {
   void initState() {
     super.initState();
     _itemsStore = GroupItemsStore();
-    _itemsStore.load(GroupStore.instance.value.selectedScope);
+    GroupStore.instance.addListener(_syncSelectedGroupItems);
+    _syncSelectedGroupItems();
     ItemStore.instance.lastSaveEvent.addListener(_reloadAfterScopedSave);
   }
 
   @override
   void dispose() {
+    GroupStore.instance.removeListener(_syncSelectedGroupItems);
     ItemStore.instance.lastSaveEvent.removeListener(_reloadAfterScopedSave);
     _itemsStore.dispose();
     super.dispose();
   }
 
+  void _syncSelectedGroupItems() {
+    final selectedGroupScope = GroupStore.instance.value.selectedGroupScope;
+    if (selectedGroupScope == null) {
+      return;
+    }
+
+    final selectedScope = GroupStore.instance.value.selectedScope;
+    if (selectedScope.storageKey != selectedGroupScope.storageKey) {
+      GroupStore.instance.selectScope(selectedGroupScope);
+      return;
+    }
+
+    if (_itemsStore.value.scope.storageKey != selectedGroupScope.storageKey) {
+      _itemsStore.load(selectedGroupScope);
+    }
+  }
+
   void _selectScope(ItemScope scope) {
+    if (!scope.isGroup) {
+      return;
+    }
     GroupStore.instance.selectScope(scope);
     _itemsStore.load(scope);
   }
 
   void _reloadAfterScopedSave() {
     final event = ItemStore.instance.lastSaveEvent.value;
-    final selectedScope = GroupStore.instance.value.selectedScope;
-    if (event == null || event.scope.storageKey != selectedScope.storageKey) {
+    final selectedGroupScope = GroupStore.instance.value.selectedGroupScope;
+    if (event == null ||
+        selectedGroupScope == null ||
+        !event.scope.isGroup ||
+        event.scope.storageKey != selectedGroupScope.storageKey) {
       return;
     }
     _itemsStore.load(event.scope);
@@ -78,7 +103,10 @@ class _GroupScreenState extends State<GroupScreen> {
             return const Center(child: CircularProgressIndicator());
           }
 
-          final selectedGroup = state.groupForScope(state.selectedScope);
+          final selectedGroupScope = state.selectedGroupScope;
+          final selectedGroup = selectedGroupScope == null
+              ? null
+              : state.groupForScope(selectedGroupScope);
 
           return SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(0, 20, 0, 24),
@@ -93,75 +121,80 @@ class _GroupScreenState extends State<GroupScreen> {
                   ),
                 ),
                 const SizedBox(height: 16),
-                ItemScopeTabs(
-                  scopes: state.availableScopes,
-                  selectedScope: state.selectedScope,
-                  onSelected: _selectScope,
-                ),
-                const SizedBox(height: 16),
-                if (selectedGroup != null)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    child: _GroupCard(
-                      group: selectedGroup,
-                      isRefreshingMembers: state.isRefreshingMembers,
-                      isLeavingGroup: state.isLeavingGroup,
-                      onRefreshMembers: () => GroupStore.instance
-                          .refreshMembers(groupId: selectedGroup.id),
-                      onCopyInviteCode: _copyInviteCode,
-                    ),
-                  )
-                else if (state.visibleGroups.isEmpty)
+                if (state.visibleGroups.isEmpty)
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 20),
                     child: _EmptyGroupState(errorMessage: state.errorMessage),
+                  )
+                else ...[
+                  ItemScopeTabs(
+                    scopes: state.groupScopes,
+                    selectedScope: selectedGroupScope!,
+                    onSelected: _selectScope,
                   ),
-                const SizedBox(height: 16),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  child: Text(
-                    '${state.selectedScope.label} 목록',
-                    style: Theme.of(context).textTheme.titleLarge,
+                  const SizedBox(height: 16),
+                  if (selectedGroup != null)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: _GroupCard(
+                        group: selectedGroup,
+                        isRefreshingMembers: state.isRefreshingMembers,
+                        isLeavingGroup: state.isLeavingGroup,
+                        onRefreshMembers: () => GroupStore.instance
+                            .refreshMembers(groupId: selectedGroup.id),
+                        onCopyInviteCode: _copyInviteCode,
+                      ),
+                    ),
+                  const SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    child: Text(
+                      '${selectedGroupScope.label} 목록',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
                   ),
-                ),
-                ValueListenableBuilder<GroupItemsState>(
-                  valueListenable: _itemsStore,
-                  builder: (context, itemState, _) {
-                    final summary = GroupDashboardSummaryBuilder.build(
-                      scope: itemState.scope,
-                      items: itemState.items,
-                      selectedFilter: itemState.selectedFilter,
-                    );
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
-                          child: GroupStatusSummary(summary: summary),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 20),
-                          child: GroupItemFilterChips(
-                            summary: summary,
-                            onSelected: _itemsStore.selectFilter,
+                  ValueListenableBuilder<GroupItemsState>(
+                    valueListenable: _itemsStore,
+                    builder: (context, itemState, _) {
+                      final isSelectedItemScope =
+                          itemState.scope.storageKey ==
+                          selectedGroupScope.storageKey;
+                      final summary = GroupDashboardSummaryBuilder.build(
+                        scope: selectedGroupScope,
+                        items: isSelectedItemScope ? itemState.items : const [],
+                        selectedFilter: itemState.selectedFilter,
+                      );
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+                            child: GroupStatusSummary(summary: summary),
                           ),
-                        ),
-                        GroupScopedItemList(
-                          items: summary.filteredItems,
-                          isLoading: itemState.isLoading,
-                          errorMessage: itemState.errorMessage,
-                          emptyMessage: summary.scope.isGroup
-                              ? '아직 이 그룹에 등록된 물품이 없습니다.'
-                              : '표시할 내 물품이 없습니다.',
-                          emptyActionLabel: summary.scope.isGroup
-                              ? '그룹에 제품 추가'
-                              : '내 물품 추가',
-                          onEmptyAction: () => _openScopedAdd(summary.scope),
-                        ),
-                      ],
-                    );
-                  },
-                ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 20),
+                            child: GroupItemFilterChips(
+                              summary: summary,
+                              onSelected: _itemsStore.selectFilter,
+                            ),
+                          ),
+                          GroupScopedItemList(
+                            items: summary.filteredItems,
+                            isLoading:
+                                itemState.isLoading && isSelectedItemScope,
+                            errorMessage: isSelectedItemScope
+                                ? itemState.errorMessage
+                                : null,
+                            emptyMessage: '아직 이 그룹에 등록된 물품이 없습니다.',
+                            emptyActionLabel: '그룹에 제품 추가',
+                            onEmptyAction: () =>
+                                _openScopedAdd(selectedGroupScope),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                ],
               ],
             ),
           );

--- a/lib/screens/group_screen.dart
+++ b/lib/screens/group_screen.dart
@@ -50,7 +50,17 @@ class _GroupScreenState extends State<GroupScreen> {
 
     final selectedScope = GroupStore.instance.value.selectedScope;
     if (selectedScope.storageKey != selectedGroupScope.storageKey) {
-      GroupStore.instance.selectScope(selectedGroupScope);
+      if (_itemsStore.value.scope.storageKey != selectedGroupScope.storageKey) {
+        _itemsStore.load(selectedGroupScope);
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final currentState = GroupStore.instance.value;
+        if (currentState.selectedScope.storageKey !=
+            selectedGroupScope.storageKey) {
+          GroupStore.instance.selectScope(selectedGroupScope);
+        }
+      });
       return;
     }
 

--- a/lib/screens/group_screen.dart
+++ b/lib/screens/group_screen.dart
@@ -10,10 +10,12 @@ import '../services/item_store.dart';
 import '../services/supabase_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/group/group_item_filter_chips.dart';
+import '../widgets/group/group_quick_actions.dart';
 import '../widgets/group/group_scoped_item_list.dart';
 import '../widgets/group/group_status_summary.dart';
 import '../widgets/group/item_scope_tabs.dart';
 import 'add_item_screen.dart';
+import 'scan_screen.dart';
 
 class GroupScreen extends StatefulWidget {
   const GroupScreen({super.key});
@@ -103,6 +105,42 @@ class _GroupScreenState extends State<GroupScreen> {
     );
   }
 
+  void _openScopedScan(ItemScope scope) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (scanContext) => Scaffold(
+          backgroundColor: AppColors.background,
+          body: Stack(
+            children: [
+              ScanScreen(targetScope: scope),
+              Positioned(
+                top: MediaQuery.of(scanContext).padding.top + 8,
+                right: 12,
+                child: Material(
+                  color: AppColors.surface,
+                  shape: const CircleBorder(),
+                  elevation: 1,
+                  child: IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    color: AppColors.text,
+                    onPressed: () => Navigator.of(scanContext).pop(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openCreateGroupDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (_) => const _CreateGroupDialog(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -141,6 +179,16 @@ class _GroupScreenState extends State<GroupScreen> {
                     scopes: state.groupScopes,
                     selectedScope: selectedGroupScope!,
                     onSelected: _selectScope,
+                  ),
+                  const SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    child: GroupQuickActions(
+                      onAddItem: () => _openScopedAdd(selectedGroupScope),
+                      onScanReceipt: () => _openScopedScan(selectedGroupScope),
+                      onCreateGroup: _openCreateGroupDialog,
+                      isCreateGroupDisabled: state.isSaving,
+                    ),
                   ),
                   const SizedBox(height: 16),
                   if (selectedGroup != null)

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -1,15 +1,15 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../models/item.dart';
+import '../models/price_cache_data.dart';
 import '../services/item_store.dart';
+import '../services/price_comparison_service.dart';
+import '../services/supabase_price_comparison_proxy.dart';
 import '../theme/app_theme.dart';
 import '../widgets/countdown_ring.dart';
 import 'add_item_screen.dart';
-import 'dart:convert';
-import 'package:http/http.dart' as http;
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:url_launcher/url_launcher.dart';
-import '../models/price_cache_data.dart';
 
 class ItemDetailScreen extends StatefulWidget {
   final ConsumableItem item;
@@ -28,7 +28,6 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
   // 실시간 가격 데이터 변수
   bool _isLoadingPrice = true;
   List<PriceComparison> _realPriceData = [];
-  String? _buyLink; // 구매 링크 저장용
 
   @override
   void initState() {
@@ -46,138 +45,45 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
       if (mounted) {
         setState(() {
           _realPriceData = cached.priceData;
-          _buyLink = cached.buyLink;
           _isLoadingPrice = false;
         });
       }
-      debugPrint('⚡ 최적화: 캐시된 가격 데이터 사용 (API 호출 생략)');
+      debugPrint('캐시된 가격 데이터 사용 (API 호출 생략)');
       return; // 캐시가 있으면 여기서 함수 끝내기
     }
 
-    final String naverId = dotenv.env['NAVER_CLIENT_ID'] ?? '';
-    final String naverSecret = dotenv.env['NAVER_CLIENT_SECRET'] ?? '';
-    final String openaiKey = dotenv.env['OPENAI_API_KEY'] ?? '';
-
-    if (naverId.isEmpty || naverSecret.isEmpty || openaiKey.isEmpty) {
-      debugPrint('API 키가 설정되지 않았습니다.');
-      if (mounted) setState(() => _isLoadingPrice = false);
-      return;
-    }
-
-    // 네이버 쇼핑 검색 API 호출
-    final String searchQuery = '${_item.brand} ${_item.name}'.trim();
-    final naverUrl =
-        'https://openapi.naver.com/v1/search/shop.json?query=${Uri.encodeComponent(searchQuery)}&display=1';
-
     try {
-      final naverResponse = await http.get(
-        Uri.parse(naverUrl),
-        headers: {
-          'X-Naver-Client-Id': naverId,
-          'X-Naver-Client-Secret': naverSecret,
-        },
-      );
+      final proxy = kIsWeb ? const SupabasePriceComparisonProxy() : null;
+      final priceData = await PriceComparisonService(
+        serverProxy: proxy?.fetchComparisons,
+      ).fetchComparisons(itemName: _item.name, brand: _item.brand);
 
-      if (naverResponse.statusCode == 200) {
-        final naverData = jsonDecode(utf8.decode(naverResponse.bodyBytes));
-        final items = naverData['items'] as List;
-
-        if (items.isNotEmpty) {
-          final firstItem = items[0];
-          final String rawTitle = firstItem['title'];
-          final int totalPrice = int.parse(firstItem['lprice']);
-          final String link = firstItem['link'];
-
-          // 쇼핑몰 이름
-          final String mallName = firstItem['mallName'];
-
-          // OpenAI Structured Outputs로 데이터 정제 요청
-          const openaiUrl = 'https://api.openai.com/v1/chat/completions';
-          final openaiResponse = await http.post(
-            Uri.parse(openaiUrl),
-            headers: {
-              'Content-Type': 'application/json',
-              'Authorization': 'Bearer $openaiKey',
-            },
-            body: jsonEncode({
-              'model': 'gpt-4o-mini',
-              'messages': [
-                {
-                  'role': 'system',
-                  'content':
-                      '너는 쇼핑 데이터 분석가야. 상품명에서 총 수량(개수)을 파악하고 단가를 계산해 무조건 지정된 JSON 스키마로만 응답해.',
-                },
-                {
-                  'role': 'user',
-                  'content': '상품명: $rawTitle, 전체가격: $totalPrice원',
-                },
-              ],
-              'response_format': {
-                'type': 'json_schema',
-                'json_schema': {
-                  'name': 'product_analysis',
-                  'strict': true,
-                  'schema': {
-                    'type': 'object',
-                    'properties': {
-                      'total_count': {'type': 'integer'},
-                      'unit_price': {'type': 'integer'},
-                      'pure_name': {'type': 'string'},
-                    },
-                    'required': ['total_count', 'unit_price', 'pure_name'],
-                    'additionalProperties': false,
-                  },
-                },
-              },
-            }),
-          );
-
-          if (openaiResponse.statusCode == 200) {
-            final openaiData = jsonDecode(
-              utf8.decode(openaiResponse.bodyBytes),
-            );
-            final String aiJsonString =
-                openaiData['choices'][0]['message']['content'];
-            final Map<String, dynamic> aiResult = jsonDecode(aiJsonString);
-
-            // AI가 계산해 준 단가를 UI 모델에 매핑
-            final int unitPrice = aiResult['unit_price'];
-            final int totalCount = aiResult['total_count'];
-            final String pureName = aiResult['pure_name'];
-
-            final lowestPrice = PriceComparison(
-              store: '[$mallName] $pureName (총 $totalCount개 / 개당 $unitPrice원)',
-              price: totalPrice,
-              isLowest: true,
-            );
-
-            if (mounted) {
-              setState(() {
-                _realPriceData = [lowestPrice];
-                _buyLink = link; // 나중에 터치 시 이동할 링크 저장
-                _isLoadingPrice = false;
-              });
-            }
-            return;
-          }
-        }
+      if (priceData.isNotEmpty) {
+        _priceCache[_item.id] = PriceCacheData(
+          priceData: priceData,
+          fetchedAt: DateTime.now(),
+        );
       }
 
-      // 검색 결과가 없거나 통신 에러 시 예외 처리
-      if (mounted) setState(() => _isLoadingPrice = false);
+      if (mounted) {
+        setState(() {
+          _realPriceData = priceData;
+          _isLoadingPrice = false;
+        });
+      }
     } catch (e) {
       debugPrint('통신 및 파싱 에러: $e');
       if (mounted) setState(() => _isLoadingPrice = false);
     }
   }
 
-  Future<void> _launchBuyLink() async {
+  Future<void> _launchBuyLink(String? link) async {
     // null 방어
-    if (_buyLink == null || _buyLink!.isEmpty) return;
-    final Uri url = Uri.parse(_buyLink!);
+    if (link == null || link.isEmpty) return;
+    final Uri url = Uri.parse(link);
     try {
       if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
-        debugPrint('링크 이동 실패: $_buyLink');
+        debugPrint('링크 이동 실패: $link');
       }
     } catch (e) {
       debugPrint('링크 실행 중 에러 발생: $e');
@@ -555,7 +461,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                 padding: const EdgeInsets.only(bottom: 10),
                 // Row 전체를 InkWell로 감싸고 터치 이벤트(_launchBuyLink)를 연결
                 child: InkWell(
-                  onTap: _launchBuyLink,
+                  onTap: p.link == null || p.link!.isEmpty
+                      ? null
+                      : () => _launchBuyLink(p.link),
                   borderRadius: BorderRadius.circular(8), // 터치할 때 물결 효과를 부드럽게
                   child: Padding(
                     padding: const EdgeInsets.symmetric(

--- a/lib/screens/scan_screen.dart
+++ b/lib/screens/scan_screen.dart
@@ -231,6 +231,7 @@ class _ScanScreenState extends State<ScanScreen>
           '영수증 사진을 찍거나 앨범에서 선택하세요',
           style: Theme.of(context).textTheme.bodyMedium,
         ),
+        _buildScopeBanner(),
         const SizedBox(height: 32),
         Expanded(
           child: Padding(
@@ -285,6 +286,45 @@ class _ScanScreenState extends State<ScanScreen>
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildScopeBanner() {
+    if (!widget.targetScope.isGroup) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 10, 20, 0),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        decoration: BoxDecoration(
+          color: AppColors.primaryLight2,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: AppColors.primaryLight, width: 0.5),
+        ),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.group_outlined,
+              size: 18,
+              color: AppColors.primary,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                '${widget.targetScope.label}에 스캔 추가',
+                style: const TextStyle(
+                  fontSize: 13,
+                  color: AppColors.primaryDark,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/services/group_store.dart
+++ b/lib/services/group_store.dart
@@ -42,6 +42,25 @@ class GroupState {
     ];
   }
 
+  List<ItemScope> get groupScopes {
+    return <ItemScope>[
+      for (final group in visibleGroups)
+        ItemScope.group(id: group.id, label: group.name),
+    ];
+  }
+
+  ItemScope? get selectedGroupScope {
+    final scopes = groupScopes;
+    if (selectedScope.isGroup) {
+      for (final scope in scopes) {
+        if (scope.id == selectedScope.id) {
+          return scope;
+        }
+      }
+    }
+    return scopes.isEmpty ? null : scopes.first;
+  }
+
   BuylogGroup? groupForScope(ItemScope scope) {
     if (!scope.isGroup) return null;
     for (final group in visibleGroups) {
@@ -97,6 +116,7 @@ class GroupStore extends ValueNotifier<GroupState> {
       value = GroupState(
         group: groups.isEmpty ? null : groups.first,
         groups: groups,
+        selectedScope: _firstGroupScopeOrPersonal(groups),
       );
     } catch (_) {
       _initialized = false;
@@ -143,6 +163,33 @@ class GroupStore extends ValueNotifier<GroupState> {
     );
     if (!allowed) return;
     value = value.copyWith(selectedScope: scope, errorMessage: null);
+  }
+
+  ItemScope _firstGroupScopeOrPersonal(List<BuylogGroup> groups) {
+    if (groups.isEmpty) {
+      return const ItemScope.personal();
+    }
+    final first = groups.first;
+    return ItemScope.group(id: first.id, label: first.name);
+  }
+
+  ItemScope _scopeAfterLeavingGroup({
+    required ItemScope previousScope,
+    required String removedGroupId,
+    required List<ItemScope> remainingGroupScopes,
+  }) {
+    if (previousScope.isGroup && previousScope.id != removedGroupId) {
+      for (final scope in remainingGroupScopes) {
+        if (scope.id == previousScope.id) {
+          return scope;
+        }
+      }
+    }
+
+    if (remainingGroupScopes.isEmpty) {
+      return const ItemScope.personal();
+    }
+    return remainingGroupScopes.first;
   }
 
   Future<void> refreshMembers({String? groupId}) async {
@@ -200,23 +247,19 @@ class GroupStore extends ValueNotifier<GroupState> {
         newOwnerUserId: newOwnerUserId,
       );
       final groups = await SupabaseService.loadGroupsForUser();
-      final selectedScope =
-          previousState.selectedScope.isGroup &&
-              previousState.selectedScope.id == trimmedGroupId
-          ? const ItemScope.personal()
-          : previousState.selectedScope;
-      final availableScopes = <ItemScope>[
-        const ItemScope.personal(),
-        for (final group in groups)
-          ItemScope.group(id: group.id, label: group.name),
+      final remainingGroupScopes = <ItemScope>[
+        for (final group in groups) ItemScope.group(id: group.id, label: group.name),
       ];
+      final selectedScope = _scopeAfterLeavingGroup(
+        previousScope: previousState.selectedScope,
+        removedGroupId: trimmedGroupId,
+        remainingGroupScopes: remainingGroupScopes,
+      );
 
       value = GroupState(
         group: groups.isEmpty ? null : groups.first,
         groups: groups,
-        selectedScope: availableScopes.contains(selectedScope)
-            ? selectedScope
-            : const ItemScope.personal(),
+        selectedScope: selectedScope,
       );
     } catch (_) {
       value = previousState.copyWith(

--- a/lib/services/group_store.dart
+++ b/lib/services/group_store.dart
@@ -248,7 +248,8 @@ class GroupStore extends ValueNotifier<GroupState> {
       );
       final groups = await SupabaseService.loadGroupsForUser();
       final remainingGroupScopes = <ItemScope>[
-        for (final group in groups) ItemScope.group(id: group.id, label: group.name),
+        for (final group in groups)
+          ItemScope.group(id: group.id, label: group.name),
       ];
       final selectedScope = _scopeAfterLeavingGroup(
         previousScope: previousState.selectedScope,

--- a/lib/services/price_comparison_service.dart
+++ b/lib/services/price_comparison_service.dart
@@ -1,0 +1,314 @@
+import 'dart:convert';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+import '../models/item.dart';
+
+typedef PriceComparisonServerProxy =
+    Future<List<PriceComparison>> Function({
+      required String itemName,
+      required String brand,
+      required int display,
+    });
+
+class PriceComparisonService {
+  PriceComparisonService({
+    http.Client? client,
+    String? naverClientId,
+    String? naverClientSecret,
+    String? openAiApiKey,
+    PriceComparisonServerProxy? serverProxy,
+  }) : _client = client ?? http.Client(),
+       _naverClientId = naverClientId,
+       _naverClientSecret = naverClientSecret,
+       _openAiApiKey = openAiApiKey,
+       _serverProxy = serverProxy;
+
+  final http.Client _client;
+  final String? _naverClientId;
+  final String? _naverClientSecret;
+  final String? _openAiApiKey;
+  final PriceComparisonServerProxy? _serverProxy;
+
+  Future<List<PriceComparison>> fetchComparisons({
+    required String itemName,
+    required String brand,
+    int display = 5,
+  }) async {
+    final serverProxy = _serverProxy;
+    if (serverProxy != null) {
+      try {
+        final proxiedData = await serverProxy(
+          itemName: itemName,
+          brand: brand,
+          display: display,
+        );
+        if (proxiedData.isNotEmpty) return proxiedData;
+      } catch (_) {
+        // Fall back to direct calls on native platforms.
+      }
+    }
+
+    final naverClientId =
+        (_naverClientId ?? dotenv.env['NAVER_CLIENT_ID'] ?? '').trim();
+    final naverClientSecret =
+        (_naverClientSecret ?? dotenv.env['NAVER_CLIENT_SECRET'] ?? '').trim();
+
+    if (naverClientId.isEmpty || naverClientSecret.isEmpty) {
+      return const [];
+    }
+
+    final query = [
+      brand.trim(),
+      itemName.trim(),
+    ].where((part) => part.isNotEmpty).join(' ');
+    if (query.isEmpty) return const [];
+
+    final uri = Uri.https('openapi.naver.com', '/v1/search/shop.json', {
+      'query': query,
+      'display': display.clamp(1, 10).toString(),
+      'sort': 'sim',
+    });
+
+    final response = await _client.get(
+      uri,
+      headers: {
+        'X-Naver-Client-Id': naverClientId,
+        'X-Naver-Client-Secret': naverClientSecret,
+      },
+    );
+
+    if (response.statusCode != 200) return const [];
+
+    final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+    final rawItems = decoded is Map<String, dynamic>
+        ? decoded['items'] as List<dynamic>? ?? const []
+        : const [];
+    final shopItems = rawItems
+        .whereType<Map<String, dynamic>>()
+        .toList()
+        .asMap()
+        .entries
+        .map((entry) => _NaverShopItem.fromJson(entry.key, entry.value))
+        .where((item) => item != null)
+        .cast<_NaverShopItem>()
+        .toList();
+
+    if (shopItems.isEmpty) return const [];
+
+    final analyses = await _analyzeWithOpenAi(shopItems);
+
+    final comparisons = shopItems.map((item) {
+      final analysis = analyses[item.index];
+      final productName = analysis?.pureName ?? item.title;
+      final count = analysis?.totalCount;
+      final unitPrice = analysis?.unitPrice;
+      final suffix = count != null && unitPrice != null
+          ? ' (총 $count개 / 개당 ${_formatPrice(unitPrice)})'
+          : '';
+
+      return PriceComparison(
+        store: '[${item.mallName}] $productName$suffix',
+        price: item.price,
+        link: item.link,
+      );
+    }).toList()..sort((a, b) => a.price.compareTo(b.price));
+
+    return [
+      for (var i = 0; i < comparisons.length; i++)
+        PriceComparison(
+          store: comparisons[i].store,
+          price: comparisons[i].price,
+          link: comparisons[i].link,
+          isLowest: i == 0,
+        ),
+    ];
+  }
+
+  Future<Map<int, _OpenAiProductAnalysis>> _analyzeWithOpenAi(
+    List<_NaverShopItem> items,
+  ) async {
+    final openAiApiKey = (_openAiApiKey ?? dotenv.env['OPENAI_API_KEY'] ?? '')
+        .trim();
+    if (openAiApiKey.isEmpty) return const {};
+
+    try {
+      final response = await _client.post(
+        Uri.parse('https://api.openai.com/v1/chat/completions'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $openAiApiKey',
+        },
+        body: jsonEncode({
+          'model': 'gpt-4o-mini',
+          'messages': [
+            {
+              'role': 'system',
+              'content': '너는 쇼핑 데이터 분석가야. 상품명에서 총 수량과 단가를 계산하고 JSON 스키마로만 응답해.',
+            },
+            {
+              'role': 'user',
+              'content': jsonEncode({
+                'products': items
+                    .map(
+                      (item) => {
+                        'index': item.index,
+                        'title': item.title,
+                        'price': item.price,
+                      },
+                    )
+                    .toList(),
+              }),
+            },
+          ],
+          'response_format': {
+            'type': 'json_schema',
+            'json_schema': {
+              'name': 'product_price_analysis',
+              'strict': true,
+              'schema': {
+                'type': 'object',
+                'properties': {
+                  'items': {
+                    'type': 'array',
+                    'items': {
+                      'type': 'object',
+                      'properties': {
+                        'index': {'type': 'integer'},
+                        'total_count': {'type': 'integer'},
+                        'unit_price': {'type': 'integer'},
+                        'pure_name': {'type': 'string'},
+                      },
+                      'required': [
+                        'index',
+                        'total_count',
+                        'unit_price',
+                        'pure_name',
+                      ],
+                      'additionalProperties': false,
+                    },
+                  },
+                },
+                'required': ['items'],
+                'additionalProperties': false,
+              },
+            },
+          },
+        }),
+      );
+
+      if (response.statusCode != 200) return const {};
+
+      final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+      final choices = decoded is Map<String, dynamic>
+          ? decoded['choices'] as List<dynamic>? ?? const []
+          : const [];
+      final firstChoice = choices.isEmpty ? null : choices.first;
+      final message = firstChoice is Map<String, dynamic>
+          ? firstChoice['message'] as Map<String, dynamic>?
+          : null;
+      final content = message?['content'] as String?;
+      if (content == null || content.isEmpty) return const {};
+
+      final contentJson = jsonDecode(content);
+      final rawAnalyses = contentJson is Map<String, dynamic>
+          ? contentJson['items'] as List<dynamic>? ?? const []
+          : const [];
+
+      final analyses = rawAnalyses
+          .whereType<Map<String, dynamic>>()
+          .map(_OpenAiProductAnalysis.fromJson)
+          .whereType<_OpenAiProductAnalysis>();
+
+      return {for (final analysis in analyses) analysis.index: analysis};
+    } catch (_) {
+      return const {};
+    }
+  }
+}
+
+class _NaverShopItem {
+  const _NaverShopItem({
+    required this.index,
+    required this.title,
+    required this.price,
+    required this.mallName,
+    required this.link,
+  });
+
+  final int index;
+  final String title;
+  final int price;
+  final String mallName;
+  final String link;
+
+  static _NaverShopItem? fromJson(int index, Map<String, dynamic> json) {
+    final price = int.tryParse((json['lprice'] as String? ?? '').trim());
+    if (price == null || price <= 0) return null;
+
+    return _NaverShopItem(
+      index: index,
+      title: _cleanTitle(json['title'] as String? ?? ''),
+      price: price,
+      mallName: (json['mallName'] as String? ?? '네이버쇼핑').trim(),
+      link: (json['link'] as String? ?? '').trim(),
+    );
+  }
+}
+
+class _OpenAiProductAnalysis {
+  const _OpenAiProductAnalysis({
+    required this.index,
+    required this.totalCount,
+    required this.unitPrice,
+    required this.pureName,
+  });
+
+  final int index;
+  final int totalCount;
+  final int unitPrice;
+  final String pureName;
+
+  static _OpenAiProductAnalysis? fromJson(Map<String, dynamic> json) {
+    final index = (json['index'] as num?)?.toInt();
+    final totalCount = (json['total_count'] as num?)?.toInt();
+    final unitPrice = (json['unit_price'] as num?)?.toInt();
+    final pureName = (json['pure_name'] as String?)?.trim();
+
+    if (index == null ||
+        totalCount == null ||
+        unitPrice == null ||
+        pureName == null ||
+        pureName.isEmpty) {
+      return null;
+    }
+
+    return _OpenAiProductAnalysis(
+      index: index,
+      totalCount: totalCount,
+      unitPrice: unitPrice,
+      pureName: pureName,
+    );
+  }
+}
+
+String _cleanTitle(String value) {
+  return value
+      .replaceAll(RegExp('<[^>]*>'), '')
+      .replaceAll('&quot;', '"')
+      .replaceAll('&amp;', '&')
+      .replaceAll('&lt;', '<')
+      .replaceAll('&gt;', '>')
+      .trim();
+}
+
+String _formatPrice(int price) {
+  final digits = price.toString();
+  final buffer = StringBuffer();
+  for (var i = 0; i < digits.length; i++) {
+    if (i > 0 && (digits.length - i) % 3 == 0) buffer.write(',');
+    buffer.write(digits[i]);
+  }
+  return '$buffer원';
+}

--- a/lib/services/supabase_price_comparison_proxy.dart
+++ b/lib/services/supabase_price_comparison_proxy.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../models/item.dart';
+
+class SupabasePriceComparisonProxy {
+  const SupabasePriceComparisonProxy();
+
+  Future<List<PriceComparison>> fetchComparisons({
+    required String itemName,
+    required String brand,
+    required int display,
+  }) async {
+    final response = await Supabase.instance.client.functions.invoke(
+      'price-comparison',
+      body: {'itemName': itemName, 'brand': brand, 'display': display},
+    );
+
+    final data = _decodeResponseData(response.data);
+    final rawComparisons = data['comparisons'] as List<dynamic>? ?? const [];
+
+    return rawComparisons
+        .whereType<Map<String, dynamic>>()
+        .map(
+          (row) => PriceComparison(
+            store: row['store'] as String? ?? '',
+            price: (row['price'] as num?)?.toInt() ?? 0,
+            isLowest: row['isLowest'] as bool? ?? false,
+            link: row['link'] as String?,
+          ),
+        )
+        .where((comparison) => comparison.store.isNotEmpty)
+        .toList(growable: false);
+  }
+}
+
+Map<String, dynamic> _decodeResponseData(dynamic data) {
+  if (data is Map<String, dynamic>) return data;
+  if (data is String && data.isNotEmpty) {
+    final decoded = jsonDecode(data);
+    if (decoded is Map<String, dynamic>) return decoded;
+  }
+  return const {};
+}

--- a/lib/widgets/group/group_quick_actions.dart
+++ b/lib/widgets/group/group_quick_actions.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/app_theme.dart';
+
+class GroupQuickActions extends StatelessWidget {
+  const GroupQuickActions({
+    super.key,
+    required this.onAddItem,
+    required this.onScanReceipt,
+    required this.onCreateGroup,
+    this.isCreateGroupDisabled = false,
+  });
+
+  final VoidCallback onAddItem;
+  final VoidCallback onScanReceipt;
+  final VoidCallback onCreateGroup;
+  final bool isCreateGroupDisabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: FilledButton.icon(
+                onPressed: onAddItem,
+                icon: const Icon(Icons.add, size: 18),
+                label: const Text('물품 추가'),
+                style: FilledButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(vertical: 13),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: onScanReceipt,
+                icon: const Icon(Icons.document_scanner_outlined, size: 18),
+                label: const Text('영수증 스캔'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: AppColors.primary,
+                  side: const BorderSide(color: AppColors.primary),
+                  padding: const EdgeInsets.symmetric(vertical: 13),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton.icon(
+            onPressed: isCreateGroupDisabled ? null : onCreateGroup,
+            icon: const Icon(Icons.group_add_outlined, size: 18),
+            label: const Text('그룹 추가'),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.textSecondary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,5 @@
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+}

--- a/supabase/functions/price-comparison/index.ts
+++ b/supabase/functions/price-comparison/index.ts
@@ -1,0 +1,251 @@
+import { corsHeaders } from '../_shared/cors.ts'
+
+type NaverShopItem = {
+  index: number
+  title: string
+  price: number
+  mallName: string
+  link: string
+}
+
+type OpenAiProductAnalysis = {
+  index: number
+  total_count: number
+  unit_price: number
+  pure_name: string
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const { itemName, brand, display = 5 } = await req.json()
+    const comparisons = await fetchComparisons({
+      itemName: String(itemName ?? ''),
+      brand: String(brand ?? ''),
+      display: Number(display),
+    })
+
+    return jsonResponse({ comparisons })
+  } catch (error) {
+    return jsonResponse(
+      { error: error instanceof Error ? error.message : 'Unknown error' },
+      400,
+    )
+  }
+})
+
+async function fetchComparisons({
+  itemName,
+  brand,
+  display,
+}: {
+  itemName: string
+  brand: string
+  display: number
+}) {
+  const naverClientId = Deno.env.get('NAVER_CLIENT_ID')?.trim()
+  const naverClientSecret = Deno.env.get('NAVER_CLIENT_SECRET')?.trim()
+
+  if (!naverClientId || !naverClientSecret) {
+    throw new Error('Missing Naver API credentials')
+  }
+
+  const query = [brand.trim(), itemName.trim()]
+    .filter((part) => part.length > 0)
+    .join(' ')
+  if (!query) return []
+
+  const url = new URL('https://openapi.naver.com/v1/search/shop.json')
+  url.searchParams.set('query', query)
+  url.searchParams.set('display', String(Math.min(Math.max(display, 1), 10)))
+  url.searchParams.set('sort', 'sim')
+
+  const response = await fetch(url, {
+    headers: {
+      'X-Naver-Client-Id': naverClientId,
+      'X-Naver-Client-Secret': naverClientSecret,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Naver API failed with status ${response.status}`)
+  }
+
+  const data = await response.json()
+  const shopItems = ((data.items ?? []) as unknown[])
+    .map((item, index) => parseNaverShopItem(item, index))
+    .filter((item): item is NaverShopItem => item !== null)
+
+  if (shopItems.length === 0) return []
+
+  const analyses = await analyzeWithOpenAi(shopItems)
+  const comparisons = shopItems
+    .map((item) => {
+      const analysis = analyses.get(item.index)
+      const productName = analysis?.pure_name ?? item.title
+      const suffix = analysis
+        ? ` (총 ${analysis.total_count}개 / 개당 ${formatPrice(
+            analysis.unit_price,
+          )})`
+        : ''
+
+      return {
+        store: `[${item.mallName}] ${productName}${suffix}`,
+        price: item.price,
+        link: item.link,
+        isLowest: false,
+      }
+    })
+    .sort((a, b) => a.price - b.price)
+
+  return comparisons.map((item, index) => ({
+    ...item,
+    isLowest: index === 0,
+  }))
+}
+
+async function analyzeWithOpenAi(items: NaverShopItem[]) {
+  const openAiApiKey = Deno.env.get('OPENAI_API_KEY')?.trim()
+  if (!openAiApiKey) return new Map<number, OpenAiProductAnalysis>()
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${openAiApiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content:
+              '너는 쇼핑 데이터 분석가야. 상품명에서 총 수량과 단가를 계산하고 JSON 스키마로만 응답해.',
+          },
+          {
+            role: 'user',
+            content: JSON.stringify({
+              products: items.map((item) => ({
+                index: item.index,
+                title: item.title,
+                price: item.price,
+              })),
+            }),
+          },
+        ],
+        response_format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'product_price_analysis',
+            strict: true,
+            schema: {
+              type: 'object',
+              properties: {
+                items: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      index: { type: 'integer' },
+                      total_count: { type: 'integer' },
+                      unit_price: { type: 'integer' },
+                      pure_name: { type: 'string' },
+                    },
+                    required: [
+                      'index',
+                      'total_count',
+                      'unit_price',
+                      'pure_name',
+                    ],
+                    additionalProperties: false,
+                  },
+                },
+              },
+              required: ['items'],
+              additionalProperties: false,
+            },
+          },
+        },
+      }),
+    })
+
+    if (!response.ok) return new Map<number, OpenAiProductAnalysis>()
+
+    const data = await response.json()
+    const content = data.choices?.[0]?.message?.content
+    if (typeof content !== 'string' || content.length === 0) {
+      return new Map<number, OpenAiProductAnalysis>()
+    }
+
+    const parsed = JSON.parse(content)
+    const analyses = ((parsed.items ?? []) as unknown[]).filter(
+      isOpenAiProductAnalysis,
+    )
+
+    return new Map(analyses.map((analysis) => [analysis.index, analysis]))
+  } catch {
+    return new Map<number, OpenAiProductAnalysis>()
+  }
+}
+
+function parseNaverShopItem(
+  item: unknown,
+  index: number,
+): NaverShopItem | null {
+  if (!item || typeof item !== 'object') return null
+
+  const record = item as Record<string, unknown>
+  const price = Number.parseInt(String(record.lprice ?? ''), 10)
+  if (!Number.isFinite(price) || price <= 0) return null
+
+  return {
+    index,
+    title: cleanTitle(String(record.title ?? '')),
+    price,
+    mallName: String(record.mallName ?? '네이버쇼핑').trim(),
+    link: String(record.link ?? '').trim(),
+  }
+}
+
+function isOpenAiProductAnalysis(
+  value: unknown,
+): value is OpenAiProductAnalysis {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+
+  return (
+    Number.isInteger(record.index) &&
+    Number.isInteger(record.total_count) &&
+    Number.isInteger(record.unit_price) &&
+    typeof record.pure_name === 'string' &&
+    record.pure_name.trim().length > 0
+  )
+}
+
+function cleanTitle(value: string) {
+  return value
+    .replace(/<[^>]*>/g, '')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .trim()
+}
+
+function formatPrice(price: number) {
+  return `${Math.trunc(price).toLocaleString('ko-KR')}원`
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+  })
+}

--- a/test/screens/add_item_screen_test.dart
+++ b/test/screens/add_item_screen_test.dart
@@ -43,6 +43,21 @@ void main() {
     expect(gateway.upsertedItemPayload?['group_id'], 'group-1');
     expect(gateway.upsertedItemPayload?['user_id'], isNull);
   });
+
+  testWidgets('shows the target group while adding a group item', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: const AddItemScreen(
+          targetScope: ItemScope.group(id: 'group-1', label: '우리 가족'),
+        ),
+      ),
+    );
+
+    expect(find.text('우리 가족에 추가 중'), findsOneWidget);
+  });
 }
 
 class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {

--- a/test/screens/group_screen_test.dart
+++ b/test/screens/group_screen_test.dart
@@ -135,8 +135,8 @@ void main() {
 
     await tester.pumpWidget(_wrap());
 
-    expect(find.text('내 물품'), findsOneWidget);
-    expect(find.text('우리 가족'), findsOneWidget);
+    expect(find.text('내 물품'), findsNothing);
+    expect(find.text('우리 가족'), findsAtLeastNWidgets(1));
     expect(find.text('사무실'), findsOneWidget);
 
     await tester.tap(find.text('사무실'));
@@ -146,6 +146,51 @@ void main() {
       GroupStore.instance.value.selectedScope,
       const ItemScope.group(id: 'group-2', label: '사무실'),
     );
+  });
+
+  testWidgets('group page renders group tabs only and loads the first group', (
+    WidgetTester tester,
+  ) async {
+    final itemGateway = _RecordingItemDatabaseGateway()
+      ..loadItemsResult = <Map<String, dynamic>>[
+        _itemRow(id: 'group-item-1', groupId: 'group-1'),
+      ];
+    SupabaseService.debugItemDatabaseGateway = itemGateway;
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[
+        _group(id: 'group-1', name: '우리 가족'),
+        _group(id: 'group-2', name: '사무실'),
+      ],
+      selectedScope: const ItemScope.personal(),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.pump();
+
+    expect(find.text('내 물품'), findsNothing);
+    expect(find.text('우리 가족'), findsAtLeastNWidgets(1));
+    expect(find.text('사무실'), findsOneWidget);
+    expect(itemGateway.lastUserId, isNull);
+    expect(itemGateway.lastGroupId, 'group-1');
+    expect(
+      GroupStore.instance.value.selectedScope,
+      const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+  });
+
+  testWidgets('empty group page does not render a personal item list', (
+    WidgetTester tester,
+  ) async {
+    SupabaseService.debugItemDatabaseGateway = _RecordingItemDatabaseGateway();
+    GroupStore.instance.value = const GroupState();
+
+    await tester.pumpWidget(_wrap());
+    await tester.pump();
+
+    expect(find.text('내 물품'), findsNothing);
+    expect(find.text('내 물품 목록'), findsNothing);
+    expect(find.text('그룹에 제품 추가'), findsNothing);
+    expect(find.text('그룹 만들기'), findsOneWidget);
   });
 
   testWidgets('member refresh button reloads and renders latest members', (
@@ -575,6 +620,8 @@ Map<String, dynamic> _itemRow({
 
 class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
   int loadItemsCalls = 0;
+  String? lastUserId;
+  String? lastGroupId;
   List<Map<String, dynamic>> loadItemsResult = const [];
 
   @override
@@ -583,6 +630,8 @@ class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
     required String? groupId,
   }) async {
     loadItemsCalls += 1;
+    lastUserId = userId;
+    lastGroupId = groupId;
     return loadItemsResult;
   }
 

--- a/test/screens/group_screen_test.dart
+++ b/test/screens/group_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:buylog/models/group.dart';
 import 'package:buylog/models/item.dart';
 import 'package:buylog/models/item_scope.dart';
+import 'package:buylog/screens/add_item_screen.dart';
 import 'package:buylog/screens/group_screen.dart';
+import 'package:buylog/screens/scan_screen.dart';
 import 'package:buylog/services/group_store.dart';
 import 'package:buylog/services/item_store.dart';
 import 'package:buylog/services/supabase_service.dart';
@@ -406,6 +408,98 @@ void main() {
     expect(itemGateway.loadItemsCalls, 1);
   });
 
+  testWidgets('existing group page exposes in-page add actions', (
+    tester,
+  ) async {
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.pump();
+
+    expect(find.text('물품 추가'), findsOneWidget);
+    expect(find.text('영수증 스캔'), findsOneWidget);
+    expect(find.text('그룹 추가'), findsOneWidget);
+  });
+
+  testWidgets('manual group page add saves with the selected group id', (
+    tester,
+  ) async {
+    final itemGateway = _RecordingItemDatabaseGateway();
+    SupabaseService.debugItemDatabaseGateway = itemGateway;
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.pump();
+    await tester.tap(find.text('물품 추가'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddItemScreen), findsOneWidget);
+
+    await tester.enterText(find.byType(TextFormField).at(0), '세제');
+    await tester.enterText(find.byType(TextFormField).at(1), '브랜드');
+    await tester.enterText(find.byType(TextFormField).at(2), '30');
+    await tester.enterText(find.byType(TextFormField).at(3), '8900');
+    await tester.enterText(find.byType(TextFormField).at(4), '마트');
+    await tester.tap(find.text('등록 완료'));
+    await tester.pumpAndSettle();
+
+    expect(itemGateway.upsertedItemPayload?['group_id'], 'group-1');
+    expect(itemGateway.upsertedItemPayload?['user_id'], isNull);
+  });
+
+  testWidgets('scan group page action opens ScanScreen', (tester) async {
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.pump();
+    await tester.tap(find.text('영수증 스캔'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byType(ScanScreen), findsOneWidget);
+  });
+
+  testWidgets('group add action creates another group from non-empty state', (
+    tester,
+  ) async {
+    final gateway = _FakeGroupDatabaseGateway()..nextCreatedGroupId = 'group-2';
+    SupabaseService.debugGroupDatabaseGateway = gateway;
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group(id: 'group-1', name: '우리 가족')],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.pump();
+    await tester.tap(find.text('그룹 추가'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextFormField), '사무실');
+    await tester.tap(find.text('만들기'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(gateway.createGroupWithOwnerCalls, 1);
+    expect(gateway.createdGroupValues?['name'], '사무실');
+    expect(GroupStore.instance.value.groups.map((group) => group.name), [
+      '우리 가족',
+      '사무실',
+    ]);
+    expect(
+      GroupStore.instance.value.selectedScope,
+      const ItemScope.group(id: 'group-2', label: '사무실'),
+    );
+  });
+
   testWidgets('empty group item list shows add CTA', (tester) async {
     SupabaseService.debugItemDatabaseGateway = _RecordingItemDatabaseGateway();
     GroupStore.instance.value = GroupState(
@@ -484,6 +578,7 @@ class _FakeGroupDatabaseGateway implements GroupDatabaseGateway {
   String? leaveGroupGroupId;
   String? leaveGroupNewOwnerUserId;
   Map<String, dynamic>? _currentGroup;
+  String nextCreatedGroupId = 'group-1';
 
   @override
   Future<Map<String, dynamic>?> loadDefaultGroup(String userId) async {
@@ -514,7 +609,11 @@ class _FakeGroupDatabaseGateway implements GroupDatabaseGateway {
       'name': name,
       'invite_code': inviteCode,
     };
-    final group = _groupRow(name: name, inviteCode: inviteCode);
+    final group = _groupRow(
+      id: nextCreatedGroupId,
+      name: name,
+      inviteCode: inviteCode,
+    );
     _currentGroup = group;
     return group;
   }
@@ -623,6 +722,7 @@ class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
   String? lastUserId;
   String? lastGroupId;
   List<Map<String, dynamic>> loadItemsResult = const [];
+  Map<String, dynamic>? upsertedItemPayload;
 
   @override
   Future<List<Map<String, dynamic>>> loadItems({
@@ -645,7 +745,9 @@ class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
   }
 
   @override
-  Future<void> upsertItem(Map<String, dynamic> payload) async {}
+  Future<void> upsertItem(Map<String, dynamic> payload) async {
+    upsertedItemPayload = Map<String, dynamic>.from(payload);
+  }
 
   @override
   Future<void> insertPurchase(Map<String, dynamic> payload) async {}

--- a/test/screens/scan_screen_test.dart
+++ b/test/screens/scan_screen_test.dart
@@ -1,0 +1,24 @@
+import 'package:buylog/models/item_scope.dart';
+import 'package:buylog/screens/scan_screen.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('shows the target group while scanning for a group', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: const Scaffold(
+          body: ScanScreen(
+            targetScope: ItemScope.group(id: 'group-1', label: '우리 가족'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('우리 가족에 스캔 추가'), findsOneWidget);
+  });
+}

--- a/test/services/group_store_test.dart
+++ b/test/services/group_store_test.dart
@@ -243,9 +243,65 @@ void main() {
       expect(scopes.map((scope) => scope.label), ['내 물품', '우리 가족', '사무실']);
       expect(
         GroupStore.instance.value.selectedScope,
-        const ItemScope.personal(),
+        const ItemScope.group(id: 'group-1', label: '우리 가족'),
       );
     });
+
+    test('exposes joined groups as group-only scopes', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+
+      await GroupStore.instance.initialize();
+
+      final groupScopes = GroupStore.instance.value.groupScopes;
+      expect(groupScopes.map((scope) => scope.label), ['우리 가족', '사무실']);
+      expect(groupScopes.every((scope) => scope.isGroup), isTrue);
+      expect(groupScopes.any((scope) => scope.label == '내 물품'), isFalse);
+    });
+
+    test('initialize selects the first joined group for the group page', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+
+      await GroupStore.instance.initialize();
+
+      expect(
+        GroupStore.instance.value.selectedScope,
+        const ItemScope.group(id: 'group-1', label: '우리 가족'),
+      );
+      expect(
+        GroupStore.instance.value.selectedGroupScope,
+        const ItemScope.group(id: 'group-1', label: '우리 가족'),
+      );
+    });
+
+    test(
+      'selectedGroupScope falls back to the first group when selected scope is personal',
+      () {
+        GroupStore.instance.value = GroupState(
+          groups: <BuylogGroup>[
+            _groupWithMembers(),
+            BuylogGroup(
+              id: 'group-2',
+              name: '사무실',
+              inviteCode: 'BUY-OFFICE',
+              createdBy: 'owner-user',
+              createdAt: DateTime.parse('2026-05-27T00:00:00.000Z'),
+            ),
+          ],
+          selectedScope: const ItemScope.personal(),
+        );
+
+        expect(
+          GroupStore.instance.value.selectedGroupScope,
+          const ItemScope.group(id: 'group-1', label: '우리 가족'),
+        );
+      },
+    );
 
     test('selectScope switches to a joined group scope', () async {
       gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
@@ -376,10 +432,35 @@ void main() {
       ]);
       expect(
         GroupStore.instance.value.selectedScope,
-        const ItemScope.personal(),
+        const ItemScope.group(id: 'group-2', label: '사무실'),
       );
       expect(GroupStore.instance.value.isLeavingGroup, isFalse);
       expect(GroupStore.instance.value.errorMessage, isNull);
+    });
+
+    test('leaves selected group and selects next remaining group', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+      await GroupStore.instance.initialize();
+      GroupStore.instance.selectScope(
+        const ItemScope.group(id: 'group-1', label: '우리 가족'),
+      );
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+
+      await GroupStore.instance.leaveGroup(groupId: 'group-1');
+
+      expect(
+        GroupStore.instance.value.selectedScope,
+        const ItemScope.group(id: 'group-2', label: '사무실'),
+      );
+      expect(
+        GroupStore.instance.value.selectedGroupScope,
+        const ItemScope.group(id: 'group-2', label: '사무실'),
+      );
     });
 
     test('passes owner delegation user id when leaving as owner', () async {

--- a/test/services/group_store_test.dart
+++ b/test/services/group_store_test.dart
@@ -231,6 +231,32 @@ void main() {
       expect(gateway.loadDefaultGroupCalls, 0);
     });
 
+    test(
+      'createGroup appends a new group and selects it when groups already exist',
+      () async {
+        GroupStore.instance.value = GroupState(
+          groups: <BuylogGroup>[_groupWithMembers()],
+          selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+        );
+        gateway.nextCreatedGroupId = 'group-2';
+
+        await GroupStore.instance.createGroup('사무실');
+
+        expect(GroupStore.instance.value.groups.map((group) => group.name), [
+          '우리 가족',
+          '사무실',
+        ]);
+        expect(
+          GroupStore.instance.value.selectedScope,
+          const ItemScope.group(id: 'group-2', label: '사무실'),
+        );
+        expect(
+          GroupStore.instance.value.selectedGroupScope,
+          const ItemScope.group(id: 'group-2', label: '사무실'),
+        );
+      },
+    );
+
     test('builds personal and joined group scopes after initialize', () async {
       gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
         _groupRow(id: 'group-1', name: '우리 가족'),
@@ -584,6 +610,7 @@ class _RecordingGroupDatabaseGateway implements GroupDatabaseGateway {
   Map<String, dynamic>? createdGroupValues;
   Object? createGroupWithOwnerError;
   List<Map<String, dynamic>> loadGroupMembersResult = const [];
+  String nextCreatedGroupId = 'group-1';
 
   @override
   Future<Map<String, dynamic>?> loadDefaultGroup(String userId) async {
@@ -622,7 +649,7 @@ class _RecordingGroupDatabaseGateway implements GroupDatabaseGateway {
       'invite_code': inviteCode,
     };
     return <String, dynamic>{
-      'id': 'group-1',
+      'id': nextCreatedGroupId,
       'name': name,
       'invite_code': inviteCode,
       'created_by': SupabaseService.currentUserId,

--- a/test/services/group_store_test.dart
+++ b/test/services/group_store_test.dart
@@ -261,23 +261,26 @@ void main() {
       expect(groupScopes.any((scope) => scope.label == '내 물품'), isFalse);
     });
 
-    test('initialize selects the first joined group for the group page', () async {
-      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
-        _groupRow(id: 'group-1', name: '우리 가족'),
-        _groupRow(id: 'group-2', name: '사무실'),
-      ];
+    test(
+      'initialize selects the first joined group for the group page',
+      () async {
+        gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+          _groupRow(id: 'group-1', name: '우리 가족'),
+          _groupRow(id: 'group-2', name: '사무실'),
+        ];
 
-      await GroupStore.instance.initialize();
+        await GroupStore.instance.initialize();
 
-      expect(
-        GroupStore.instance.value.selectedScope,
-        const ItemScope.group(id: 'group-1', label: '우리 가족'),
-      );
-      expect(
-        GroupStore.instance.value.selectedGroupScope,
-        const ItemScope.group(id: 'group-1', label: '우리 가족'),
-      );
-    });
+        expect(
+          GroupStore.instance.value.selectedScope,
+          const ItemScope.group(id: 'group-1', label: '우리 가족'),
+        );
+        expect(
+          GroupStore.instance.value.selectedGroupScope,
+          const ItemScope.group(id: 'group-1', label: '우리 가족'),
+        );
+      },
+    );
 
     test(
       'selectedGroupScope falls back to the first group when selected scope is personal',

--- a/test/services/price_comparison_service_test.dart
+++ b/test/services/price_comparison_service_test.dart
@@ -1,0 +1,154 @@
+import 'package:buylog/models/item.dart';
+import 'package:buylog/services/price_comparison_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  group('PriceComparisonService', () {
+    test('네이버 쇼핑 결과를 OpenAI 분석값으로 보강하고 최저가순으로 정렬한다', () async {
+      final requestedHeaders = <String, String>{};
+      final requestedUris = <Uri>[];
+      final service = PriceComparisonService(
+        client: MockClient((request) async {
+          requestedUris.add(request.url);
+          requestedHeaders.addAll(request.headers);
+
+          if (request.url.host == 'openapi.naver.com') {
+            return http.Response(
+              '''
+              {
+                "items": [
+                  {
+                    "title": "<b>브랜드</b> 샴푸 2개",
+                    "lprice": "12000",
+                    "mallName": "스토어A",
+                    "link": "https://example.com/a"
+                  },
+                  {
+                    "title": "브랜드 샴푸 단품",
+                    "lprice": "9000",
+                    "mallName": "스토어B",
+                    "link": "https://example.com/b"
+                  }
+                ]
+              }
+              ''',
+              200,
+              headers: {'content-type': 'application/json; charset=utf-8'},
+            );
+          }
+
+          return http.Response(
+            '''
+            {
+              "choices": [
+                {
+                  "message": {
+                    "content": "{\\"items\\":[{\\"index\\":0,\\"total_count\\":2,\\"unit_price\\":6000,\\"pure_name\\":\\"브랜드 샴푸\\"},{\\"index\\":1,\\"total_count\\":1,\\"unit_price\\":9000,\\"pure_name\\":\\"브랜드 샴푸\\"}]}"
+                  }
+                }
+              ]
+            }
+            ''',
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }),
+        naverClientId: 'naver-id',
+        naverClientSecret: 'naver-secret',
+        openAiApiKey: 'openai-key',
+      );
+
+      final result = await service.fetchComparisons(
+        itemName: '샴푸',
+        brand: '브랜드',
+      );
+
+      expect(requestedHeaders['X-Naver-Client-Id'], 'naver-id');
+      expect(requestedHeaders['X-Naver-Client-Secret'], 'naver-secret');
+      expect(requestedHeaders['Authorization'], 'Bearer openai-key');
+      expect(requestedUris.first.queryParameters['query'], '브랜드 샴푸');
+      expect(result, hasLength(2));
+      expect(result.first.store, '[스토어B] 브랜드 샴푸 (총 1개 / 개당 9,000원)');
+      expect(result.first.price, 9000);
+      expect(result.first.link, 'https://example.com/b');
+      expect(result.first.isLowest, isTrue);
+      expect(result.last.store, '[스토어A] 브랜드 샴푸 (총 2개 / 개당 6,000원)');
+      expect(result.last.isLowest, isFalse);
+    });
+
+    test('OpenAI 분석 실패 시 네이버 쇼핑 결과만으로 가격 비교를 유지한다', () async {
+      final service = PriceComparisonService(
+        client: MockClient((request) async {
+          if (request.url.host == 'openapi.naver.com') {
+            return http.Response(
+              '''
+              {
+                "items": [
+                  {
+                    "title": "<b>브랜드</b> 샴푸 2개",
+                    "lprice": "12000",
+                    "mallName": "스토어A",
+                    "link": "https://example.com/a"
+                  }
+                ]
+              }
+              ''',
+              200,
+              headers: {'content-type': 'application/json; charset=utf-8'},
+            );
+          }
+
+          return http.Response('server error', 500);
+        }),
+        naverClientId: 'naver-id',
+        naverClientSecret: 'naver-secret',
+        openAiApiKey: 'openai-key',
+      );
+
+      final result = await service.fetchComparisons(
+        itemName: '샴푸',
+        brand: '브랜드',
+      );
+
+      expect(result, hasLength(1));
+      expect(result.single.store, '[스토어A] 브랜드 샴푸 2개');
+      expect(result.single.price, 12000);
+      expect(result.single.link, 'https://example.com/a');
+      expect(result.single.isLowest, isTrue);
+    });
+
+    test('서버 프록시가 있으면 클라이언트 직접 호출보다 우선 사용한다', () async {
+      var directCallCount = 0;
+      var proxyCallCount = 0;
+      final service = PriceComparisonService(
+        client: MockClient((request) async {
+          directCallCount++;
+          return http.Response('unexpected', 500);
+        }),
+        serverProxy:
+            ({required brand, required display, required itemName}) async {
+              proxyCallCount++;
+              return const [
+                PriceComparison(
+                  store: '[프록시몰] 브랜드 샴푸',
+                  price: 7000,
+                  link: 'https://example.com/proxy',
+                  isLowest: true,
+                ),
+              ];
+            },
+      );
+
+      final result = await service.fetchComparisons(
+        itemName: '샴푸',
+        brand: '브랜드',
+      );
+
+      expect(proxyCallCount, 1);
+      expect(directCallCount, 0);
+      expect(result.single.store, '[프록시몰] 브랜드 샴푸');
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:buylog/models/group.dart';
 import 'package:buylog/services/group_store.dart';
 import 'package:buylog/services/supabase_service.dart';
 import 'package:buylog/main.dart';
@@ -80,6 +81,30 @@ void main() {
     // 하단 탭의 '모든 제품' 라벨로 새 디자인 셸이 렌더링되었는지 확인합니다.
     expect(find.text('모든 제품'), findsOneWidget);
   });
+
+  testWidgets('group tab hides add FAB when no group exists', (
+    WidgetTester tester,
+  ) async {
+    GroupStore.instance.value = const GroupState();
+
+    await tester.pumpWidget(const BuylogApp());
+    await tester.tap(find.text('그룹'));
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('제품 추가'), findsNothing);
+  });
+
+  testWidgets('group tab shows add FAB when a group is selected', (
+    WidgetTester tester,
+  ) async {
+    GroupStore.instance.value = GroupState(groups: <BuylogGroup>[_group()]);
+
+    await tester.pumpWidget(const BuylogApp());
+    await tester.tap(find.text('그룹'));
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('제품 추가'), findsOneWidget);
+  });
 }
 
 class _ThrowingGroupDatabaseGateway implements GroupDatabaseGateway {
@@ -115,4 +140,14 @@ class _ThrowingGroupDatabaseGateway implements GroupDatabaseGateway {
   }) {
     throw UnsupportedError('leaveGroup is not used in this test');
   }
+}
+
+BuylogGroup _group({String id = 'group-1', String name = '우리 가족'}) {
+  return BuylogGroup(
+    id: id,
+    name: name,
+    inviteCode: 'BUY-ABC123',
+    createdBy: 'user-1',
+    createdAt: DateTime.parse('2026-05-27T00:00:00.000Z'),
+  );
 }

--- a/test/widgets/group/group_quick_actions_test.dart
+++ b/test/widgets/group/group_quick_actions_test.dart
@@ -1,0 +1,79 @@
+import 'package:buylog/theme/app_theme.dart';
+import 'package:buylog/widgets/group/group_quick_actions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('renders group page quick actions', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: GroupQuickActions(
+            onAddItem: () {},
+            onScanReceipt: () {},
+            onCreateGroup: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('물품 추가'), findsOneWidget);
+    expect(find.text('영수증 스캔'), findsOneWidget);
+    expect(find.text('그룹 추가'), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsWidgets);
+    expect(find.byIcon(Icons.document_scanner_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.group_add_outlined), findsOneWidget);
+  });
+
+  testWidgets('invokes each quick action callback', (tester) async {
+    var addItemCalls = 0;
+    var scanCalls = 0;
+    var createGroupCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: GroupQuickActions(
+            onAddItem: () => addItemCalls += 1,
+            onScanReceipt: () => scanCalls += 1,
+            onCreateGroup: () => createGroupCalls += 1,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('물품 추가'));
+    await tester.tap(find.text('영수증 스캔'));
+    await tester.tap(find.text('그룹 추가'));
+
+    expect(addItemCalls, 1);
+    expect(scanCalls, 1);
+    expect(createGroupCalls, 1);
+  });
+
+  testWidgets('disables group creation while the store is saving', (
+    tester,
+  ) async {
+    var createGroupCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: GroupQuickActions(
+            onAddItem: () {},
+            onScanReceipt: () {},
+            onCreateGroup: () => createGroupCalls += 1,
+            isCreateGroupDisabled: true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('그룹 추가'));
+
+    expect(createGroupCalls, 0);
+  });
+}

--- a/test/widgets/group/item_scope_tabs_test.dart
+++ b/test/widgets/group/item_scope_tabs_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('renders personal and group tabs and reports selection', (
+  testWidgets('renders joined group tabs and reports group selection', (
     tester,
   ) async {
     ItemScope? selected;
@@ -16,18 +16,17 @@ void main() {
         home: Scaffold(
           body: ItemScopeTabs(
             scopes: const <ItemScope>[
-              ItemScope.personal(),
               ItemScope.group(id: 'group-1', label: '우리 가족'),
               ItemScope.group(id: 'group-2', label: '사무실'),
             ],
-            selectedScope: const ItemScope.personal(),
+            selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
             onSelected: (scope) => selected = scope,
           ),
         ),
       ),
     );
 
-    expect(find.text('내 물품'), findsOneWidget);
+    expect(find.text('내 물품'), findsNothing);
     expect(find.text('우리 가족'), findsOneWidget);
     expect(find.text('사무실'), findsOneWidget);
 


### PR DESCRIPTION
## 변경 사항
- 그룹 탭에서 그룹 전용 범위와 추가 액션 흐름을 개선했습니다.
- 상품 상세의 `AI 가격 비교`를 네이버 쇼핑 검색 + OpenAI 분석 기반 서비스로 분리했습니다.
- Web 실행 시 브라우저 CORS를 피하도록 Supabase Edge Function `price-comparison` 프록시를 추가했습니다.
- 가격 비교 서비스 단위 테스트와 그룹/스캔/추가 흐름 회귀 테스트를 보강했습니다.

## 변경 이유
- Chrome/Web 환경에서 네이버/OpenAI API 직접 호출이 CORS로 실패해 가격 비교가 비어 보이는 문제를 해결하기 위함입니다.
- 그룹 페이지에서 개인 범위와 그룹 범위가 섞이지 않도록 그룹 중심 UX를 명확히 하기 위함입니다.

## 테스트
- `flutter analyze`
- `flutter test`
- Supabase Edge Function 원격 호출 확인: `price-comparison` 응답 `200`, 가격 비교 결과 반환

## 참고 사항
- Supabase Dashboard에 `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`, `OPENAI_API_KEY` Edge Function secret을 등록했습니다.
- `gh` CLI는 로컬에 없어 GitHub 커넥터로 PR을 생성했습니다.