### PR TITLE
그룹 페이지 설정과 그룹 전용 흐름 개선

### DIFF
--- a/docs/superpowers/plans/2026-05-28-add-item-scope-toggle.md
+++ b/docs/superpowers/plans/2026-05-28-add-item-scope-toggle.md
@@ -1,0 +1,656 @@
+# Add Item Scope Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 제품 추가 화면에서 개인/그룹 저장 위치를 토글할 수 있게 만들고, 일반 페이지 진입은 개인 추가를, 그룹 페이지 진입은 그룹 추가를 기본값으로 사용한다.
+
+**Architecture:** `MainNavigation._currentAddScope()`는 기존처럼 진입 기본 스코프만 결정한다. `AddItemScreen`은 새 아이템 등록 모드에서만 내부 `_selectedScope` 상태와 `GroupStore`의 그룹 목록을 사용해 개인/그룹 토글을 표시하고, 저장/중복검사/OCR 검수 저장은 선택된 스코프를 사용한다. 편집 모드는 기존 아이템의 스코프를 유지하고 토글을 숨겨서 제품 이동 기능으로 범위를 넓히지 않는다.
+
+**Tech Stack:** Flutter, Dart, `ValueNotifier`, existing `ItemScope`/`GroupStore`/`ItemStore`, `flutter_test`.
+
+---
+
+## Current Context
+
+- `lib/main.dart`의 `MainNavigation._currentAddScope()`는 현재 탭이 그룹 탭이면 `GroupStore.instance.value.selectedGroupScope`, 그 외에는 `ItemScope.personal()`을 `AddItemScreen`/`ScanScreen`에 전달한다.
+- `lib/screens/add_item_screen.dart`는 현재 `widget.targetScope`를 `_effectiveScope`로 읽기만 하므로, 화면 안에서 저장 위치를 바꿀 수 없다.
+- `lib/services/item_store.dart`와 `lib/services/supabase_service.dart`는 이미 `ItemScope`를 받아 개인 저장은 `user_id`, 그룹 저장은 `group_id`로 분기한다.
+- `lib/services/group_store.dart`는 `availableGroupScopes`와 `selectedGroupScope`를 제공한다.
+- 기존 `test/main_navigation_test.dart`는 일반/그룹 FAB 기본 스코프를 검증한다.
+- 기존 `test/screens/add_item_screen_test.dart`는 그룹 targetScope 저장을 검증하지만, 화면 내 토글은 아직 없다.
+
+## Scope
+
+In scope:
+
+- 새 제품 등록 화면에 개인/그룹 저장 위치 토글을 추가한다.
+- 일반 페이지에서 등록 버튼으로 진입하면 `내 물품`이 기본 선택된다.
+- 그룹 페이지에서 등록 버튼으로 진입하면 선택된 그룹이 기본 선택된다.
+- 사용자가 토글로 저장 위치를 바꾸면 중복 검사와 최종 저장 모두 바뀐 스코프를 사용한다.
+- OCR 검수로 진입한 `AddItemScreen`도 같은 토글과 기본 스코프 규칙을 사용한다.
+- 그룹이 없으면 개인 선택만 표시하거나 토글 UI를 생략해 기존 개인 추가 흐름을 유지한다.
+- 편집 모드에서는 토글을 표시하지 않고 기존 아이템 스코프를 유지한다.
+
+Out of scope:
+
+- 기존 아이템을 개인에서 그룹으로 이동하거나 그룹 간 이동하는 편집 기능.
+- 그룹 생성/초대 UX 변경.
+- DB schema/RLS 변경.
+
+## File Structure
+
+- Modify: `lib/screens/add_item_screen.dart`
+  - `_selectedScope` 상태를 추가한다.
+  - `_effectiveScope`가 새 등록 모드에서는 `_selectedScope`, 편집 모드에서는 기존 아이템 스코프를 반환하게 한다.
+  - `GroupStore`를 구독하는 scope toggle UI를 기본 정보 섹션 위에 추가한다.
+  - 토글 선택 시 중복 검사와 저장이 새 스코프를 사용하게 한다.
+- Modify: `test/screens/add_item_screen_test.dart`
+  - 개인 기본값, 그룹 기본값, 개인에서 그룹으로 전환, 그룹에서 개인으로 전환, 편집 모드 토글 숨김을 검증한다.
+- Modify: `test/main_navigation_test.dart`
+  - 기존 FAB 기본 스코프 테스트가 토글 추가 후에도 통과하도록 key 기반 등록 helper를 유지한다.
+
+---
+
+### Task 1: Add Scope Toggle Tests For AddItemScreen
+
+**Files:**
+- Modify: `test/screens/add_item_screen_test.dart`
+
+- [ ] **Step 1: Replace the existing test file with scope-toggle coverage**
+
+Replace `test/screens/add_item_screen_test.dart` with:
+
+```dart
+import 'package:buylog/models/group.dart';
+import 'package:buylog/models/item.dart';
+import 'package:buylog/models/item_scope.dart';
+import 'package:buylog/screens/add_item_screen.dart';
+import 'package:buylog/services/group_store.dart';
+import 'package:buylog/services/item_store.dart';
+import 'package:buylog/services/supabase_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late _RecordingItemDatabaseGateway gateway;
+
+  setUp(() {
+    gateway = _RecordingItemDatabaseGateway();
+    SupabaseService.debugItemDatabaseGateway = gateway;
+    GroupStore.instance.resetForTesting();
+    ItemStore.instance.value = [];
+  });
+
+  tearDown(() {
+    SupabaseService.debugItemDatabaseGateway = null;
+    GroupStore.instance.resetForTesting();
+    ItemStore.instance.value = [];
+  });
+
+  testWidgets('personal target scope is selected by default', (tester) async {
+    _seedGroups();
+
+    await tester.pumpWidget(_wrap(const AddItemScreen()));
+
+    expect(_scopeChip('personal'), findsOneWidget);
+    expect(
+      tester.widget<ChoiceChip>(_scopeChip('personal')).selected,
+      isTrue,
+    );
+    expect(
+      tester.widget<ChoiceChip>(_scopeChip('group:group-1')).selected,
+      isFalse,
+    );
+  });
+
+  testWidgets('group target scope is selected by default', (tester) async {
+    _seedGroups();
+
+    await tester.pumpWidget(
+      _wrap(
+        const AddItemScreen(
+          targetScope: ItemScope.group(id: 'group-1', label: 'Family'),
+        ),
+      ),
+    );
+
+    expect(
+      tester.widget<ChoiceChip>(_scopeChip('personal')).selected,
+      isFalse,
+    );
+    expect(
+      tester.widget<ChoiceChip>(_scopeChip('group:group-1')).selected,
+      isTrue,
+    );
+  });
+
+  testWidgets('switching from personal to group saves with group id', (
+    tester,
+  ) async {
+    _seedGroups();
+
+    await tester.pumpWidget(_wrap(const AddItemScreen()));
+    await tester.tap(_scopeChip('group:group-1'));
+    await tester.pump();
+    await _submitMinimalItem(tester);
+
+    expect(gateway.upsertedItemPayload?['user_id'], isNull);
+    expect(gateway.upsertedItemPayload?['group_id'], 'group-1');
+  });
+
+  testWidgets('switching from group to personal saves as personal item', (
+    tester,
+  ) async {
+    _seedGroups();
+
+    await tester.pumpWidget(
+      _wrap(
+        const AddItemScreen(
+          targetScope: ItemScope.group(id: 'group-1', label: 'Family'),
+        ),
+      ),
+    );
+    await tester.tap(_scopeChip('personal'));
+    await tester.pump();
+    await _submitMinimalItem(tester);
+
+    expect(gateway.upsertedItemPayload?['user_id'], SupabaseService.currentUserId);
+    expect(gateway.upsertedItemPayload?['group_id'], isNull);
+  });
+
+  testWidgets('edit mode hides scope toggle and preserves item group scope', (
+    tester,
+  ) async {
+    _seedGroups();
+
+    await tester.pumpWidget(
+      _wrap(
+        AddItemScreen(
+          editItem: ConsumableItem(
+            id: 'item-1',
+            name: 'filter',
+            brand: 'Coway',
+            category: '주방/세제',
+            icon: Icons.kitchen_outlined,
+            daysRemaining: 10,
+            cycleDays: 30,
+            progress: 0.2,
+            groupId: 'group-1',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('add_item_scope_toggle')), findsNothing);
+    await tester.tap(find.byType(FilledButton).last);
+    await tester.pumpAndSettle();
+
+    expect(gateway.upsertedItemPayload?['user_id'], isNull);
+    expect(gateway.upsertedItemPayload?['group_id'], 'group-1');
+  });
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(theme: AppTheme.lightTheme, home: child);
+}
+
+Finder _scopeChip(String storageKey) {
+  return find.byKey(ValueKey('add_item_scope_$storageKey'));
+}
+
+void _seedGroups() {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[
+      BuylogGroup(
+        id: 'group-1',
+        name: 'Family',
+        inviteCode: 'BUY-ABC123',
+        createdBy: SupabaseService.currentUserId,
+        createdAt: DateTime.parse('2026-05-26T00:00:00.000Z'),
+      ),
+    ],
+    selectedScope: const ItemScope.group(id: 'group-1', label: 'Family'),
+  );
+}
+
+Future<void> _submitMinimalItem(WidgetTester tester) async {
+  await tester.enterText(find.byType(TextFormField).at(0), 'filter');
+  await tester.enterText(find.byType(TextFormField).at(1), 'Coway');
+  await tester.enterText(find.byType(TextFormField).at(2), '30');
+  await tester.enterText(find.byType(TextFormField).at(3), '8900');
+  await tester.enterText(find.byType(TextFormField).at(4), 'Market');
+  await tester.tap(find.byType(FilledButton).last);
+  await tester.pumpAndSettle();
+}
+
+class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
+  Map<String, dynamic>? upsertedItemPayload;
+
+  @override
+  Future<List<Map<String, dynamic>>> loadItems({
+    required String? userId,
+    required String? groupId,
+  }) async {
+    return const [];
+  }
+
+  @override
+  Future<String> ensureCategory({
+    required String name,
+    required String? userId,
+    required String? groupId,
+  }) async {
+    return 'category-1';
+  }
+
+  @override
+  Future<void> upsertItem(Map<String, dynamic> payload) async {
+    upsertedItemPayload = Map<String, dynamic>.from(payload);
+  }
+
+  @override
+  Future<void> insertPurchase(Map<String, dynamic> payload) async {}
+}
+```
+
+- [ ] **Step 2: Run AddItemScreen tests and verify failure**
+
+Run:
+
+```powershell
+flutter test test/screens/add_item_screen_test.dart
+```
+
+Expected: FAIL because `add_item_scope_toggle` and `add_item_scope_*` keys do not exist.
+
+- [ ] **Step 3: Commit the failing tests**
+
+Do not commit if your team avoids red commits. If following this plan literally with checkpoint commits, run:
+
+```powershell
+git add test/screens/add_item_screen_test.dart
+git commit -m "test: specify add item scope toggle"
+```
+
+---
+
+### Task 2: Add Mutable Scope State To AddItemScreen
+
+**Files:**
+- Modify: `lib/screens/add_item_screen.dart`
+
+- [ ] **Step 1: Add GroupStore import and selected scope state**
+
+In `lib/screens/add_item_screen.dart`, add this import:
+
+```dart
+import '../services/group_store.dart';
+```
+
+Inside `_AddItemScreenState`, after `_selectedCategory`, add:
+
+```dart
+late ItemScope _selectedScope;
+```
+
+- [ ] **Step 2: Replace `_effectiveScope` with edit-aware selected scope logic**
+
+Replace the current `_effectiveScope` getter with:
+
+```dart
+bool get _canChangeScope => !_isEditing;
+
+ItemScope get _initialScope {
+  final explicit = widget.targetScope;
+  if (explicit != null) return explicit;
+
+  final editGroupId = widget.editItem?.groupId;
+  if (editGroupId != null && editGroupId.isNotEmpty) {
+    return ItemScope.group(id: editGroupId, label: '그룹');
+  }
+
+  return const ItemScope.personal();
+}
+
+ItemScope get _effectiveScope {
+  if (_isEditing) return _initialScope;
+  return _selectedScope;
+}
+```
+
+- [ ] **Step 3: Initialize selected scope**
+
+In `initState()`, immediately after:
+
+```dart
+super.initState();
+```
+
+add:
+
+```dart
+_selectedScope = _initialScope;
+```
+
+- [ ] **Step 4: Run AddItemScreen tests and verify partial failure**
+
+Run:
+
+```powershell
+flutter test test/screens/add_item_screen_test.dart
+```
+
+Expected: still FAIL because the UI toggle is not rendered yet, but compile errors for `_selectedScope` are gone.
+
+---
+
+### Task 3: Render Personal/Group Scope Toggle
+
+**Files:**
+- Modify: `lib/screens/add_item_screen.dart`
+
+- [ ] **Step 1: Add scope option helper**
+
+Inside `_AddItemScreenState`, add this method before `_submit()`:
+
+```dart
+List<ItemScope> _scopeOptions(GroupState state) {
+  final options = <ItemScope>[
+    const ItemScope.personal(),
+    ...state.availableGroupScopes,
+  ];
+
+  final selectedAlreadyIncluded = options.any(
+    (scope) => scope.storageKey == _selectedScope.storageKey,
+  );
+  if (!selectedAlreadyIncluded && _selectedScope.isGroup) {
+    options.add(_selectedScope);
+  }
+
+  return options;
+}
+```
+
+- [ ] **Step 2: Add scope toggle widget**
+
+Inside `_AddItemScreenState`, add this widget method before `_buildBasicInfoSection()`:
+
+```dart
+Widget _buildScopeToggle() {
+  if (!_canChangeScope) return const SizedBox.shrink();
+
+  return ValueListenableBuilder<GroupState>(
+    valueListenable: GroupStore.instance,
+    builder: (context, state, _) {
+      final options = _scopeOptions(state);
+      if (options.length <= 1) {
+        return const SizedBox.shrink();
+      }
+
+      return Column(
+        key: const ValueKey('add_item_scope_toggle'),
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            '등록 위치',
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: AppColors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final scope in options)
+                ChoiceChip(
+                  key: ValueKey('add_item_scope_${scope.storageKey}'),
+                  label: Text(scope.label),
+                  selected: scope.storageKey == _selectedScope.storageKey,
+                  onSelected: (_) {
+                    setState(() {
+                      _selectedScope = scope;
+                    });
+                  },
+                  selectedColor: AppColors.primary,
+                  backgroundColor: AppColors.surface,
+                  labelStyle: TextStyle(
+                    color: scope.storageKey == _selectedScope.storageKey
+                        ? Colors.white
+                        : AppColors.textSecondary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(999),
+                    side: BorderSide(
+                      color: scope.storageKey == _selectedScope.storageKey
+                          ? AppColors.primary
+                          : AppColors.border,
+                      width: 0.5,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      );
+    },
+  );
+}
+```
+
+- [ ] **Step 3: Insert toggle into the form**
+
+In `build()`, inside the main `Column` and immediately before:
+
+```dart
+_sectionTitle('기본 정보'),
+```
+
+insert:
+
+```dart
+_buildScopeToggle(),
+if (_canChangeScope && _scopeOptions(GroupStore.instance.value).length > 1)
+  const SizedBox(height: 24),
+```
+
+If the file still contains garbled Korean strings from prior encoding, keep the existing `_sectionTitle(...)` call unchanged and insert the toggle immediately above it.
+
+- [ ] **Step 4: Run AddItemScreen tests**
+
+Run:
+
+```powershell
+flutter test test/screens/add_item_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2-3 implementation**
+
+Run:
+
+```powershell
+git add lib/screens/add_item_screen.dart test/screens/add_item_screen_test.dart
+git commit -m "feat: add item scope toggle"
+```
+
+---
+
+### Task 4: Lock FAB Defaults With Toggle Present
+
+**Files:**
+- Modify: `test/main_navigation_test.dart`
+
+- [ ] **Step 1: Add assertions that the opened form default is correct**
+
+In `test/main_navigation_test.dart`, update `_addManualItem` so it accepts an expected selected scope key:
+
+```dart
+Future<void> _addManualItem(
+  WidgetTester tester, {
+  required String expectedSelectedScopeKey,
+}) async {
+  await tester.tap(find.byType(FloatingActionButton));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byIcon(Icons.edit_outlined));
+  await tester.pumpAndSettle();
+
+  final chip = tester.widget<ChoiceChip>(
+    find.byKey(ValueKey('add_item_scope_$expectedSelectedScopeKey')),
+  );
+  expect(chip.selected, isTrue);
+
+  await tester.enterText(find.byType(TextFormField).first, 'filter');
+  await tester.tap(find.byType(FilledButton).last);
+  await tester.pumpAndSettle();
+}
+```
+
+Update the group test call:
+
+```dart
+await _addManualItem(
+  tester,
+  expectedSelectedScopeKey: 'group:group-1',
+);
+```
+
+Update the home test call:
+
+```dart
+await _addManualItem(
+  tester,
+  expectedSelectedScopeKey: 'personal',
+);
+```
+
+- [ ] **Step 2: Run main navigation tests**
+
+Run:
+
+```powershell
+flutter test test/main_navigation_test.dart
+```
+
+Expected: PASS. This proves 일반 페이지 진입 defaults to personal and 그룹 페이지 진입 defaults to group while the new toggle is visible.
+
+- [ ] **Step 3: Commit Task 4**
+
+Run:
+
+```powershell
+git add test/main_navigation_test.dart
+git commit -m "test: lock add form default scope from fab"
+```
+
+---
+
+### Task 5: Regression And Verification
+
+**Files:**
+- No file edits.
+
+- [ ] **Step 1: Format changed files**
+
+Run:
+
+```powershell
+dart format lib/screens/add_item_screen.dart test/screens/add_item_screen_test.dart test/main_navigation_test.dart
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Run analyzer**
+
+Run:
+
+```powershell
+flutter analyze --no-fatal-infos
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```powershell
+flutter test test/screens/add_item_screen_test.dart
+flutter test test/main_navigation_test.dart
+```
+
+Expected: both focused test files pass.
+
+- [ ] **Step 4: Run related store/service tests**
+
+Run:
+
+```powershell
+flutter test test/services/item_store_test.dart test/services/supabase_service_test.dart test/screens/group_screen_test.dart
+```
+
+Expected: all related tests pass, proving the changed screen still saves through existing scope-aware services.
+
+- [ ] **Step 5: Run full test suite**
+
+Run:
+
+```powershell
+flutter test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Optional manual smoke check**
+
+Run:
+
+```powershell
+flutter run -d windows
+```
+
+Manual checks:
+
+1. 홈 또는 모든 제품 탭에서 `+` → `직접 등록`을 연다.
+2. 등록 위치가 개인으로 기본 선택되어 있는지 확인한다.
+3. 그룹 토글로 바꾼 뒤 저장하면 그룹 목록에 나타나는지 확인한다.
+4. 그룹 탭에서 `+` → `직접 등록`을 연다.
+5. 등록 위치가 현재 그룹으로 기본 선택되어 있는지 확인한다.
+6. 개인 토글로 바꾼 뒤 저장하면 개인 목록에 저장되는지 확인한다.
+7. OCR 등록 흐름에서도 같은 토글이 보이고 저장 위치가 반영되는지 확인한다.
+
+- [ ] **Step 7: Inspect final diff**
+
+Run:
+
+```powershell
+git status --short
+git diff --stat
+```
+
+Expected: only these files changed for this feature:
+
+```text
+lib/screens/add_item_screen.dart
+test/screens/add_item_screen_test.dart
+test/main_navigation_test.dart
+docs/superpowers/plans/2026-05-28-add-item-scope-toggle.md
+```
+
+If earlier uncommitted work exists in the same branch, verify the diff manually and do not revert unrelated files.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan adds the requested personal/group toggle on product add, preserves personal default from general pages, preserves group default from group pages, and lets users override the default before saving.
+- Business logic boundary: Scope persistence stays in `ItemStore`/`SupabaseService`; `AddItemScreen` only owns the user's current selection.
+- Type consistency: The plan uses existing `ItemScope`, `GroupState`, `GroupStore`, `ItemStore`, and `ChoiceChip` APIs consistently.
+- Test coverage: Add form defaults, toggling in both directions, edit-mode preservation, and FAB default behavior are covered.
+- Placeholder scan: No unresolved implementation placeholders remain.

--- a/docs/superpowers/plans/2026-05-28-group-exclusive-dashboard.md
+++ b/docs/superpowers/plans/2026-05-28-group-exclusive-dashboard.md
@@ -1,0 +1,939 @@
+# Group Exclusive Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 그룹 탭에서 `내 물품` 전환을 제거하고, 가입한 그룹의 물품 현황과 그룹 액션에 집중하는 전용 대시보드로 바꾼다.
+
+**Architecture:** 개인 물품 데이터 흐름은 `홈`과 `모든 제품` 탭에 그대로 두고, 그룹 탭은 `GroupStore`가 제공하는 그룹 전용 scope만 사용한다. 그룹 선택 fallback, 그룹 물품 로딩, 요약/필터 계산은 서비스와 store helper에 두고 `GroupScreen`은 상태 조합과 화면 배치만 담당한다.
+
+**Tech Stack:** Flutter, Dart, `ValueNotifier`, existing Supabase gateway seams, `flutter_test`.
+
+---
+
+## Current Context
+
+- 현재 `GroupScreen`은 `ItemScopeTabs`에 `내 물품`과 그룹 scope를 함께 전달한다.
+- `GroupStore.availableScopes`는 항상 `ItemScope.personal()`을 첫 항목으로 포함한다.
+- `MainNavigation._currentAddScope()`는 그룹 탭에서 `GroupStore.instance.value.selectedScope`가 그룹이면 해당 그룹에 제품을 추가하고, 아니면 개인 물품에 추가한다.
+- 그룹 물품 요약과 필터는 이미 `GroupDashboardSummaryBuilder`, `GroupItemFilterChips`, `GroupStatusSummary`, `GroupItemsStore.selectedFilter`로 분리되어 있다.
+- 루트 `AGENTS.md` 기준상 새 비즈니스 로직에는 테스트가 필요하고, Flutter 위젯 내부에 비즈니스 로직을 넣으면 안 된다.
+
+## Scope
+
+In scope:
+
+- 그룹 탭에서 `내 물품` 탭과 `내 물품 목록` 렌더링을 제거한다.
+- 가입한 그룹이 있으면 첫 그룹을 기본 선택으로 사용한다.
+- 여러 그룹이 있으면 그룹 이름 칩으로 그룹만 전환한다.
+- 그룹이 없으면 그룹 생성 empty state만 보여주고 물품 목록/요약은 보여주지 않는다.
+- 그룹 탭의 FAB/스캔/직접 등록은 현재 선택된 그룹, 또는 선택값이 개인으로 남아 있어도 첫 가입 그룹을 target scope로 사용한다.
+
+Out of scope:
+
+- 초대 코드로 그룹 참여, 담당자, 활동 로그, 멤버별 권한 변경, DB/RLS 변경.
+- `모든 제품` 탭의 개인 물품 목록 UX 변경.
+
+## File Structure
+
+- Modify: `lib/services/group_store.dart`
+  - `availableGroupScopes`, `selectedGroupScope`, `selectedGroup`를 추가한다.
+  - `leaveGroup` 후 남은 그룹이 있으면 첫 그룹 scope를 선택하고, 없으면 개인 scope로 fallback한다.
+- Modify: `lib/main.dart`
+  - 그룹 탭 FAB target scope를 `selectedGroupScope` 기준으로 결정한다.
+- Modify: `lib/screens/group_screen.dart`
+  - `ItemScopeTabs`에 개인 scope를 전달하지 않는다.
+  - 그룹이 없을 때는 empty state만 렌더링한다.
+  - `GroupStore` listener로 그룹 선택 변경과 그룹 생성 후 item load를 동기화한다.
+  - 저장 이벤트 reload 비교를 `selectedGroupScope` 기준으로 바꾼다.
+- Modify: `test/services/group_store_test.dart`
+  - 그룹 전용 scope 파생값과 leave fallback을 검증한다.
+- Modify: `test/screens/group_screen_test.dart`
+  - 개인 탭/개인 목록 제거, 첫 그룹 자동 로딩, 그룹 전환 로딩, empty state를 검증한다.
+- Create: `test/main_navigation_test.dart`
+  - 그룹 탭에서 추가 FAB가 첫 그룹 scope를 사용하는지 확인한다.
+- Modify: `test/widgets/group/item_scope_tabs_test.dart`
+  - `ItemScopeTabs` 자체는 generic widget으로 유지하면서 group-only 사용 케이스를 검증한다.
+
+---
+
+### Task 1: Add Group-Only Scope Derivations
+
+**Files:**
+- Modify: `lib/services/group_store.dart`
+- Modify: `test/services/group_store_test.dart`
+
+- [ ] **Step 1: Write failing tests for group-only scopes**
+
+Add these tests inside the existing `group('GroupStore', () { ... })` block in `test/services/group_store_test.dart`:
+
+```dart
+test('exposes group-only scopes without the personal scope', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+
+  await GroupStore.instance.initialize();
+
+  final scopes = GroupStore.instance.value.availableGroupScopes;
+  expect(scopes.map((scope) => scope.label), ['우리 가족', '사무실']);
+  expect(scopes.every((scope) => scope.isGroup), isTrue);
+});
+
+test('uses the first joined group as selectedGroupScope fallback', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+
+  await GroupStore.instance.initialize();
+
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.personal(),
+  );
+  expect(
+    GroupStore.instance.value.selectedGroupScope,
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+  expect(GroupStore.instance.value.selectedGroup?.id, 'group-1');
+});
+
+test('keeps the selected joined group as selectedGroupScope', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+  await GroupStore.instance.initialize();
+
+  GroupStore.instance.selectScope(
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+
+  expect(
+    GroupStore.instance.value.selectedGroupScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+  expect(GroupStore.instance.value.selectedGroup?.id, 'group-2');
+});
+```
+
+- [ ] **Step 2: Run focused store tests and verify failure**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart --plain-name "group-only scopes"
+flutter test test/services/group_store_test.dart --plain-name "selectedGroupScope"
+```
+
+Expected: FAIL because `availableGroupScopes`, `selectedGroupScope`, and `selectedGroup` are not defined.
+
+- [ ] **Step 3: Implement group-only scope helpers**
+
+In `lib/services/group_store.dart`, add these getters to `GroupState` after `availableScopes`:
+
+```dart
+List<ItemScope> get availableGroupScopes {
+  return <ItemScope>[
+    for (final group in visibleGroups)
+      ItemScope.group(id: group.id, label: group.name),
+  ];
+}
+
+ItemScope? get selectedGroupScope {
+  if (selectedScope.isGroup &&
+      availableGroupScopes.any((scope) => scope == selectedScope)) {
+    return selectedScope;
+  }
+  return availableGroupScopes.isEmpty ? null : availableGroupScopes.first;
+}
+
+BuylogGroup? get selectedGroup {
+  final scope = selectedGroupScope;
+  return scope == null ? null : groupForScope(scope);
+}
+```
+
+- [ ] **Step 4: Run focused store tests and verify pass**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart --plain-name "group-only scopes"
+flutter test test/services/group_store_test.dart --plain-name "selectedGroupScope"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```powershell
+git add lib/services/group_store.dart test/services/group_store_test.dart
+git commit -m "feat: expose group-only scopes"
+```
+
+---
+
+### Task 2: Keep Group Selection After Leaving Groups
+
+**Files:**
+- Modify: `lib/services/group_store.dart`
+- Modify: `test/services/group_store_test.dart`
+
+- [ ] **Step 1: Write failing leave fallback test**
+
+Add this test inside `group('GroupStore', () { ... })` in `test/services/group_store_test.dart`:
+
+```dart
+test('selects the next group after leaving the selected group', () async {
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-1', name: '우리 가족'),
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+  await GroupStore.instance.initialize();
+  GroupStore.instance.selectScope(
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+  gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+    _groupRow(id: 'group-2', name: '사무실'),
+  ];
+
+  await GroupStore.instance.leaveGroup(groupId: 'group-1');
+
+  expect(
+    GroupStore.instance.value.selectedScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+  expect(
+    GroupStore.instance.value.selectedGroupScope,
+    const ItemScope.group(id: 'group-2', label: '사무실'),
+  );
+});
+```
+
+- [ ] **Step 2: Run focused leave test and verify failure**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart --plain-name "selects the next group"
+```
+
+Expected: FAIL because current `leaveGroup` selects `ItemScope.personal()` after leaving the selected group.
+
+- [ ] **Step 3: Update `leaveGroup` selected scope calculation**
+
+In `lib/services/group_store.dart`, replace the selected scope block inside `leaveGroup` after `final groups = await SupabaseService.loadGroupsForUser();` with:
+
+```dart
+final remainingScopes = <ItemScope>[
+  for (final group in groups) ItemScope.group(id: group.id, label: group.name),
+];
+final previousSelectedStillExists = remainingScopes.any(
+  (scope) => scope == previousState.selectedScope,
+);
+final selectedScope = previousSelectedStillExists
+    ? previousState.selectedScope
+    : remainingScopes.isEmpty
+    ? const ItemScope.personal()
+    : remainingScopes.first;
+
+value = GroupState(
+  group: groups.isEmpty ? null : groups.first,
+  groups: groups,
+  selectedScope: selectedScope,
+);
+```
+
+Remove the old local `availableScopes` calculation from the same method.
+
+- [ ] **Step 4: Update old expectation that now conflicts**
+
+In the existing test named `leaves the selected group and reloads joined groups`, change this expectation:
+
+```dart
+expect(
+  GroupStore.instance.value.selectedScope,
+  const ItemScope.personal(),
+);
+```
+
+to:
+
+```dart
+expect(
+  GroupStore.instance.value.selectedScope,
+  const ItemScope.group(id: 'group-2', label: '사무실'),
+);
+```
+
+- [ ] **Step 5: Run GroupStore tests**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```powershell
+git add lib/services/group_store.dart test/services/group_store_test.dart
+git commit -m "fix: keep group scope after leaving group"
+```
+
+---
+
+### Task 3: Make Add Flow Use Group-Only Fallback
+
+**Files:**
+- Modify: `lib/main.dart`
+- Create: `test/main_navigation_test.dart`
+
+- [ ] **Step 1: Write failing navigation scope test**
+
+Create `test/main_navigation_test.dart`:
+
+```dart
+import 'package:buylog/main.dart';
+import 'package:buylog/models/group.dart';
+import 'package:buylog/models/item_scope.dart';
+import 'package:buylog/services/group_store.dart';
+import 'package:buylog/services/item_store.dart';
+import 'package:buylog/services/supabase_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    GroupStore.instance.resetForTesting();
+    ItemStore.instance.value = [];
+    SupabaseService.debugItemDatabaseGateway = _RecordingItemDatabaseGateway();
+  });
+
+  tearDown(() {
+    GroupStore.instance.resetForTesting();
+    ItemStore.instance.value = [];
+    SupabaseService.debugItemDatabaseGateway = null;
+  });
+
+  testWidgets('group tab add action targets the first group when selected scope is personal', (
+    tester,
+  ) async {
+    final gateway = _RecordingItemDatabaseGateway();
+    SupabaseService.debugItemDatabaseGateway = gateway;
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.personal(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: const MainNavigation(),
+      ),
+    );
+
+    await tester.tap(find.text('그룹'));
+    await tester.pump();
+    await tester.tap(find.byTooltip('제품 추가'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('직접 등록'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextFormField).first, '정수기 필터');
+    await tester.tap(find.text('등록 완료'));
+    await tester.pumpAndSettle();
+
+    expect(gateway.ensureCategoryUserId, isNull);
+    expect(gateway.ensureCategoryGroupId, 'group-1');
+    expect(gateway.upsertPayload?['group_id'], 'group-1');
+    expect(gateway.upsertPayload?['user_id'], isNull);
+  });
+}
+
+BuylogGroup _group() {
+  return BuylogGroup(
+    id: 'group-1',
+    name: '우리 가족',
+    inviteCode: 'BUY-ABC123',
+    createdBy: SupabaseService.currentUserId,
+    createdAt: DateTime.parse('2026-05-26T00:00:00.000Z'),
+    members: <BuylogGroupMember>[],
+  );
+}
+
+class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
+  String? ensureCategoryUserId;
+  String? ensureCategoryGroupId;
+  Map<String, dynamic>? upsertPayload;
+
+  @override
+  Future<List<Map<String, dynamic>>> loadItems({
+    required String? userId,
+    required String? groupId,
+  }) async {
+    return const <Map<String, dynamic>>[];
+  }
+
+  @override
+  Future<String> ensureCategory({
+    required String name,
+    required String? userId,
+    required String? groupId,
+  }) async {
+    ensureCategoryUserId = userId;
+    ensureCategoryGroupId = groupId;
+    return 'category-1';
+  }
+
+  @override
+  Future<void> upsertItem(Map<String, dynamic> payload) async {
+    upsertPayload = Map<String, dynamic>.from(payload);
+  }
+
+  @override
+  Future<void> insertPurchase(Map<String, dynamic> payload) async {}
+}
+```
+
+- [ ] **Step 2: Run navigation test and verify failure**
+
+Run:
+
+```powershell
+flutter test test/main_navigation_test.dart
+```
+
+Expected: FAIL before `MainNavigation._currentAddScope()` uses `selectedGroupScope`, because `ensureCategoryGroupId` is null and the payload is saved as a personal item.
+
+- [ ] **Step 3: Update group tab add target selection**
+
+In `lib/main.dart`, replace `_currentAddScope()` with:
+
+```dart
+ItemScope _currentAddScope() {
+  if (_currentIndex != 1) {
+    return const ItemScope.personal();
+  }
+
+  return GroupStore.instance.value.selectedGroupScope ??
+      const ItemScope.personal();
+}
+```
+
+- [ ] **Step 4: Run navigation test**
+
+Run:
+
+```powershell
+flutter test test/main_navigation_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```powershell
+git add lib/main.dart test/main_navigation_test.dart
+git commit -m "fix: target group scope from group tab add action"
+```
+
+---
+
+### Task 4: Remove Personal Scope From GroupScreen
+
+**Files:**
+- Modify: `lib/screens/group_screen.dart`
+- Modify: `test/screens/group_screen_test.dart`
+
+- [ ] **Step 1: Write failing screen tests for group-only rendering**
+
+Add these tests to `test/screens/group_screen_test.dart`:
+
+```dart
+testWidgets('group screen hides personal item tab and personal item list', (
+  tester,
+) async {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group(id: 'group-1', name: '우리 가족')],
+    selectedScope: const ItemScope.personal(),
+  );
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+
+  expect(find.text('내 물품'), findsNothing);
+  expect(find.text('내 물품 목록'), findsNothing);
+  expect(find.text('우리 가족'), findsAtLeastNWidgets(1));
+  expect(find.text('우리 가족 목록'), findsOneWidget);
+});
+
+testWidgets('group screen loads first group items when selected scope is personal', (
+  tester,
+) async {
+  final itemGateway = _RecordingItemDatabaseGateway()
+    ..loadItemsResult = <Map<String, dynamic>>[
+      _itemRow(id: 'group-item-1', groupId: 'group-1'),
+    ];
+  SupabaseService.debugItemDatabaseGateway = itemGateway;
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group(id: 'group-1', name: '우리 가족')],
+    selectedScope: const ItemScope.personal(),
+  );
+
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+
+  expect(itemGateway.lastUserId, isNull);
+  expect(itemGateway.lastGroupId, 'group-1');
+  expect(find.text('group-item-1'), findsOneWidget);
+});
+
+testWidgets('empty group state does not render item dashboard or list heading', (
+  tester,
+) async {
+  await tester.pumpWidget(_wrap());
+  await tester.pump();
+
+  expect(find.text('그룹'), findsOneWidget);
+  expect(find.text('아직 연결된 그룹이 없습니다.'), findsOneWidget);
+  expect(find.text('전체'), findsNothing);
+  expect(find.textContaining('목록'), findsNothing);
+});
+```
+
+Update `_RecordingItemDatabaseGateway` in the same file to record the last query:
+
+```dart
+String? lastUserId;
+String? lastGroupId;
+
+@override
+Future<List<Map<String, dynamic>>> loadItems({
+  required String? userId,
+  required String? groupId,
+}) async {
+  loadItemsCalls += 1;
+  lastUserId = userId;
+  lastGroupId = groupId;
+  return loadItemsResult;
+}
+```
+
+- [ ] **Step 2: Run focused screen tests and verify failure**
+
+Run:
+
+```powershell
+flutter test test/screens/group_screen_test.dart --plain-name "group screen hides personal"
+flutter test test/screens/group_screen_test.dart --plain-name "loads first group items"
+flutter test test/screens/group_screen_test.dart --plain-name "empty group state"
+```
+
+Expected: FAIL because `GroupScreen` still renders personal scope tabs and can load personal scope.
+
+- [ ] **Step 3: Add group-store listener and group-scope loader**
+
+In `lib/screens/group_screen.dart`, replace the current `initState`, `dispose`, `_selectScope`, and `_reloadAfterScopedSave` methods in `_GroupScreenState` with:
+
+```dart
+@override
+void initState() {
+  super.initState();
+  _itemsStore = GroupItemsStore();
+  GroupStore.instance.addListener(_reloadForSelectedGroup);
+  ItemStore.instance.lastSaveEvent.addListener(_reloadAfterScopedSave);
+  _reloadForSelectedGroup();
+}
+
+@override
+void dispose() {
+  GroupStore.instance.removeListener(_reloadForSelectedGroup);
+  ItemStore.instance.lastSaveEvent.removeListener(_reloadAfterScopedSave);
+  _itemsStore.dispose();
+  super.dispose();
+}
+
+void _selectScope(ItemScope scope) {
+  if (!scope.isGroup) return;
+  GroupStore.instance.selectScope(scope);
+}
+
+void _reloadForSelectedGroup() {
+  final scope = GroupStore.instance.value.selectedGroupScope;
+  if (scope == null) return;
+  if (_itemsStore.value.scope.storageKey == scope.storageKey &&
+      !_itemsStore.value.isLoading) {
+    return;
+  }
+  _itemsStore.load(scope);
+}
+
+void _reloadAfterScopedSave() {
+  final event = ItemStore.instance.lastSaveEvent.value;
+  final selectedScope = GroupStore.instance.value.selectedGroupScope;
+  if (event == null ||
+      selectedScope == null ||
+      event.scope.storageKey != selectedScope.storageKey) {
+    return;
+  }
+  _itemsStore.load(selectedScope);
+}
+```
+
+- [ ] **Step 4: Render only group scopes**
+
+In `GroupScreen.build`, replace:
+
+```dart
+final selectedGroup = state.groupForScope(state.selectedScope);
+```
+
+with:
+
+```dart
+final selectedScope = state.selectedGroupScope;
+final selectedGroup = state.selectedGroup;
+```
+
+Replace the `ItemScopeTabs` block:
+
+```dart
+ItemScopeTabs(
+  scopes: state.availableScopes,
+  selectedScope: state.selectedScope,
+  onSelected: _selectScope,
+),
+const SizedBox(height: 16),
+```
+
+with:
+
+```dart
+if (state.availableGroupScopes.length > 1) ...[
+  ItemScopeTabs(
+    scopes: state.availableGroupScopes,
+    selectedScope: selectedScope ?? state.availableGroupScopes.first,
+    onSelected: _selectScope,
+  ),
+  const SizedBox(height: 16),
+],
+```
+
+Replace the group card and empty state branch:
+
+```dart
+if (selectedGroup != null)
+  Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 20),
+    child: _GroupCard(
+      group: selectedGroup,
+      isRefreshingMembers: state.isRefreshingMembers,
+      isLeavingGroup: state.isLeavingGroup,
+      onRefreshMembers: () => GroupStore.instance
+          .refreshMembers(groupId: selectedGroup.id),
+      onCopyInviteCode: _copyInviteCode,
+    ),
+  )
+else if (state.visibleGroups.isEmpty)
+  Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 20),
+    child: _EmptyGroupState(errorMessage: state.errorMessage),
+  ),
+const SizedBox(height: 16),
+```
+
+with:
+
+```dart
+if (selectedGroup != null)
+  Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 20),
+    child: _GroupCard(
+      group: selectedGroup,
+      isRefreshingMembers: state.isRefreshingMembers,
+      isLeavingGroup: state.isLeavingGroup,
+      onRefreshMembers: () => GroupStore.instance
+          .refreshMembers(groupId: selectedGroup.id),
+      onCopyInviteCode: _copyInviteCode,
+    ),
+  )
+else
+  Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 20),
+    child: _EmptyGroupState(errorMessage: state.errorMessage),
+  ),
+```
+
+- [ ] **Step 5: Render dashboard only when a group is selected**
+
+Wrap the existing list heading and `ValueListenableBuilder<GroupItemsState>` block with:
+
+```dart
+if (selectedScope != null && selectedGroup != null) ...[
+  const SizedBox(height: 16),
+  Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 20),
+    child: Text(
+      '${selectedScope.label} 목록',
+      style: Theme.of(context).textTheme.titleLarge,
+    ),
+  ),
+  ValueListenableBuilder<GroupItemsState>(
+    valueListenable: _itemsStore,
+    builder: (context, itemState, _) {
+      final summary = GroupDashboardSummaryBuilder.build(
+        scope: itemState.scope,
+        items: itemState.items,
+        selectedFilter: itemState.selectedFilter,
+      );
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+            child: GroupStatusSummary(summary: summary),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: GroupItemFilterChips(
+              summary: summary,
+              onSelected: _itemsStore.selectFilter,
+            ),
+          ),
+          GroupScopedItemList(
+            items: summary.filteredItems,
+            isLoading: itemState.isLoading,
+            errorMessage: itemState.errorMessage,
+            emptyMessage: '아직 이 그룹에 등록된 물품이 없습니다.',
+            emptyActionLabel: '그룹에 제품 추가',
+            onEmptyAction: () => _openScopedAdd(selectedScope),
+          ),
+        ],
+      );
+    },
+  ),
+],
+```
+
+Delete the old unconditional heading:
+
+```dart
+Padding(
+  padding: const EdgeInsets.symmetric(horizontal: 20),
+  child: Text(
+    '${state.selectedScope.label} 목록',
+    style: Theme.of(context).textTheme.titleLarge,
+  ),
+),
+```
+
+Delete the personal empty message branches:
+
+```dart
+emptyMessage: summary.scope.isGroup
+    ? '아직 이 그룹에 등록된 물품이 없습니다.'
+    : '표시할 내 물품이 없습니다.',
+emptyActionLabel: summary.scope.isGroup
+    ? '그룹에 제품 추가'
+    : '내 물품 추가',
+```
+
+- [ ] **Step 6: Update old scope tab test expectations**
+
+In `test/screens/group_screen_test.dart`, rename the existing test:
+
+```dart
+testWidgets('renders scope tabs and switches selected group tab', (
+```
+
+to:
+
+```dart
+testWidgets('renders group scope tabs and switches selected group tab', (
+```
+
+Change the personal tab expectation:
+
+```dart
+expect(find.text('내 물품'), findsOneWidget);
+```
+
+to:
+
+```dart
+expect(find.text('내 물품'), findsNothing);
+```
+
+- [ ] **Step 7: Run screen tests**
+
+Run:
+
+```powershell
+flutter test test/screens/group_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 4**
+
+Run:
+
+```powershell
+git add lib/screens/group_screen.dart test/screens/group_screen_test.dart
+git commit -m "feat: make group screen group-only"
+```
+
+---
+
+### Task 5: Keep Widget Tests Aligned With Generic Scope Tabs
+
+**Files:**
+- Modify: `test/widgets/group/item_scope_tabs_test.dart`
+
+- [ ] **Step 1: Add group-only usage coverage**
+
+Add this test to `test/widgets/group/item_scope_tabs_test.dart`:
+
+```dart
+testWidgets('renders group-only tabs when personal scope is not provided', (
+  tester,
+) async {
+  ItemScope? selected;
+
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: AppTheme.lightTheme,
+      home: Scaffold(
+        body: ItemScopeTabs(
+          scopes: const <ItemScope>[
+            ItemScope.group(id: 'group-1', label: '우리 가족'),
+            ItemScope.group(id: 'group-2', label: '사무실'),
+          ],
+          selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+          onSelected: (scope) => selected = scope,
+        ),
+      ),
+    ),
+  );
+
+  expect(find.text('내 물품'), findsNothing);
+  expect(find.text('우리 가족'), findsOneWidget);
+  expect(find.text('사무실'), findsOneWidget);
+
+  await tester.tap(find.text('사무실'));
+  expect(selected, const ItemScope.group(id: 'group-2', label: '사무실'));
+});
+```
+
+- [ ] **Step 2: Run scope tab widget tests**
+
+Run:
+
+```powershell
+flutter test test/widgets/group/item_scope_tabs_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit Task 5**
+
+Run:
+
+```powershell
+git add test/widgets/group/item_scope_tabs_test.dart
+git commit -m "test: cover group-only scope tabs"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- No file edits.
+
+- [ ] **Step 1: Run formatter**
+
+Run:
+
+```powershell
+dart format lib/services/group_store.dart lib/main.dart lib/screens/group_screen.dart test/services/group_store_test.dart test/screens/group_screen_test.dart test/widgets/group/item_scope_tabs_test.dart test/main_navigation_test.dart
+```
+
+Expected: command exits 0 and only planned files are formatted.
+
+- [ ] **Step 2: Run analyzer**
+
+Run:
+
+```powershell
+flutter analyze --no-fatal-infos
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart
+flutter test test/screens/group_screen_test.dart
+flutter test test/widgets/group/item_scope_tabs_test.dart
+flutter test test/main_navigation_test.dart
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```powershell
+flutter test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Inspect git diff**
+
+Run:
+
+```powershell
+git status --short
+git diff --stat
+```
+
+Expected: only these files changed:
+
+```text
+lib/services/group_store.dart
+lib/main.dart
+lib/screens/group_screen.dart
+test/services/group_store_test.dart
+test/screens/group_screen_test.dart
+test/widgets/group/item_scope_tabs_test.dart
+test/main_navigation_test.dart
+```
+
+The plan document itself is already tracked separately if this plan has been committed before implementation.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan removes `내 물품` from `GroupScreen`, keeps personal items in `모든 제품`, and strengthens group-only selection, dashboard, and add flow.
+- Business logic boundary: Group fallback selection lives in `GroupState`; item loading stays in `GroupItemsStore`; summary/filter logic stays in `GroupDashboardSummaryBuilder`.
+- Type consistency: The plan uses existing `ItemScope`, `GroupState`, `GroupItemsStore`, `GroupDashboardSummaryBuilder`, `ItemScopeTabs`, and `GroupScopedItemList` names consistently.
+- Test coverage: Store fallback, screen rendering, group item loading, widget behavior, and navigation add-scope behavior are covered.
+- Placeholder scan: No unresolved implementation placeholders are present.

--- a/docs/superpowers/plans/2026-05-28-group-fab-add-registrant.md
+++ b/docs/superpowers/plans/2026-05-28-group-fab-add-registrant.md
@@ -1,0 +1,716 @@
+# Group FAB Add Registrant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 그룹 페이지의 우측 하단 `+` 버튼이 선택된 그룹에 제품을 추가하고, 그룹 아이템에서 누가 추가했는지 식별 가능한 정보를 사용할 수 있게 만든다.
+
+**Architecture:** 기존 `ItemScope` 흐름을 유지해서 `MainNavigation`이 현재 탭과 `GroupStore.selectedGroupScope`로 추가 대상 스코프를 결정한다. 저장은 계속 `SupabaseService.saveItem()`에서 `user_id`, `group_id`, `registered_by`를 결정하게 두고, 조회 projection과 `ConsumableItem` 모델을 확장해 등록자 표시명을 UI에서 사용할 수 있게 한다.
+
+**Tech Stack:** Flutter, Dart, `ValueNotifier`, Supabase PostgREST joins, `flutter_test`.
+
+---
+
+## Current Context
+
+- `lib/main.dart`에는 루트 `FloatingActionButton`과 `_openAddSheet()`가 있고, 수동 등록은 `AddItemScreen(targetScope: targetScope)`, OCR 등록은 `ScanScreen(targetScope: targetScope)`로 이동한다.
+- `lib/models/item_scope.dart`는 개인/그룹 저장 위치를 `ItemScope.personal()`과 `ItemScope.group(...)`로 표현한다.
+- `lib/screens/add_item_screen.dart`는 `targetScope`를 받아 `ItemStore.instance.add(item, scope: _effectiveScope)`로 저장한다.
+- `lib/services/supabase_service.dart`는 그룹 저장 시 `product_items.user_id = null`, `group_id = scope.id`, `registered_by = currentUserId`를 upsert payload에 넣는다.
+- `lib/models/item.dart`에는 `registeredBy` ID 필드가 있지만, 등록자 표시명/email fallback은 아직 모델과 UI에서 직접 쓰기 어렵다.
+- `lib/widgets/group/group_scoped_item_list.dart`는 그룹 아이템을 `ItemRow`로 렌더링한다.
+
+## Scope
+
+In scope:
+
+- 그룹 탭에서 우측 하단 `+` 버튼을 누르면 선택된 그룹, 또는 선택값이 개인으로 남아 있으면 첫 번째 그룹에 제품이 저장되도록 회귀 테스트를 고정한다.
+- 개인 탭/모든 제품 탭의 `+` 버튼은 계속 개인 아이템 추가로 동작한다.
+- 그룹 아이템 저장 시 `registered_by`가 현재 사용자 ID로 저장되는 것을 테스트로 고정한다.
+- 그룹 아이템 조회 시 `registered_by` 사용자의 표시명/email을 함께 가져오고 `ConsumableItem`에서 `registeredByLabel`로 사용할 수 있게 한다.
+- 그룹 아이템 목록과 상세 화면에서 등록자 정보를 작게 표시한다.
+
+Out of scope:
+
+- 그룹 초대/가입, 멤버 권한 변경, RLS 정책 변경.
+- 기존 DB 컬럼 추가. `product_items.registered_by`는 이미 존재하므로 migration은 만들지 않는다.
+- 구매 이력별 `purchased_by` 표시. 이번 범위는 "아이템을 추가한 사람"인 `product_items.registered_by`만 다룬다.
+
+## File Structure
+
+- Modify: `lib/main.dart`
+  - `_currentAddScope()`가 그룹 탭에서 `GroupStore.instance.value.selectedGroupScope`를 우선 반환하도록 유지/보강한다.
+- Modify: `lib/services/supabase_service.dart`
+  - `product_items` projection에 등록자 user join alias를 추가한다.
+  - `_itemFromJoinedRow()`/`ConsumableItem.fromSupabase()`가 등록자 표시 정보를 받을 수 있게 한다.
+- Modify: `lib/models/item.dart`
+  - `registeredByDisplayName`, `registeredByEmail`, `registeredByLabel`을 추가한다.
+- Modify: `lib/screens/items_screen.dart`
+  - `ItemRow` subtitle에 그룹 아이템 등록자 label을 표시한다.
+- Modify: `lib/screens/item_detail_screen.dart`
+  - 그룹 아이템 상세 header에 등록자 metadata row를 표시한다.
+- Modify: `test/main_navigation_test.dart`
+  - 그룹 탭 `+` 수동 등록이 `group_id`, null `user_id`, `registered_by`를 저장하는지 검증한다.
+- Modify: `test/services/supabase_service_test.dart`
+  - 그룹 아이템 조회가 등록자 표시명을 모델로 매핑하는지 검증한다.
+- Create: `test/widgets/item_row_test.dart`
+  - 그룹 아이템 row에서 등록자 label이 보이고, 개인 아이템 row에서는 보이지 않는지 검증한다.
+- Create: `test/screens/item_detail_screen_test.dart`
+  - 그룹 아이템 상세 화면에서 등록자 metadata가 보이는지 검증한다.
+
+---
+
+### Task 1: Lock Group FAB Add Target
+
+**Files:**
+- Modify: `lib/main.dart`
+- Modify: `test/main_navigation_test.dart`
+
+- [ ] **Step 1: Extend the group FAB regression test**
+
+In `test/main_navigation_test.dart`, update the existing test named `group tab add action targets the first group when selected scope is personal` so the final expectations include `registered_by`:
+
+```dart
+expect(gateway.ensureCategoryUserId, isNull);
+expect(gateway.ensureCategoryGroupId, 'group-1');
+expect(gateway.upsertPayload?['group_id'], 'group-1');
+expect(gateway.upsertPayload?['user_id'], isNull);
+expect(
+  gateway.upsertPayload?['registered_by'],
+  SupabaseService.currentUserId,
+);
+```
+
+Add this second test in the same file to protect the personal-tab behavior:
+
+```dart
+testWidgets('home tab add action still targets personal items', (
+  tester,
+) async {
+  final gateway = _RecordingItemDatabaseGateway();
+  SupabaseService.debugItemDatabaseGateway = gateway;
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[_group()],
+    selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(theme: AppTheme.lightTheme, home: const MainNavigation()),
+  );
+
+  await tester.tap(find.byTooltip('제품 추가'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('직접 등록'));
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextFormField).first, '정수기 필터');
+  await tester.tap(find.text('등록 완료'));
+  await tester.pumpAndSettle();
+
+  expect(gateway.ensureCategoryUserId, SupabaseService.currentUserId);
+  expect(gateway.ensureCategoryGroupId, isNull);
+  expect(gateway.upsertPayload?['user_id'], SupabaseService.currentUserId);
+  expect(gateway.upsertPayload?['group_id'], isNull);
+  expect(
+    gateway.upsertPayload?['registered_by'],
+    SupabaseService.currentUserId,
+  );
+});
+```
+
+- [ ] **Step 2: Run the navigation tests**
+
+Run:
+
+```powershell
+flutter test test/main_navigation_test.dart
+```
+
+Expected: the new personal-tab test passes if `_currentAddScope()` already handles tab context correctly; otherwise it fails with `group_id` set on a personal add.
+
+- [ ] **Step 3: Keep `_currentAddScope()` scoped by current tab**
+
+In `lib/main.dart`, make `_currentAddScope()` exactly:
+
+```dart
+ItemScope _currentAddScope() {
+  if (_currentIndex != 1) {
+    return const ItemScope.personal();
+  }
+
+  return GroupStore.instance.value.selectedGroupScope ??
+      const ItemScope.personal();
+}
+```
+
+This keeps the default `+` behavior personal outside the group page, and makes the group page `+` use the selected group or the first available group fallback.
+
+- [ ] **Step 4: Re-run the navigation tests**
+
+Run:
+
+```powershell
+flutter test test/main_navigation_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```powershell
+git add lib/main.dart test/main_navigation_test.dart
+git commit -m "test: lock grouped add action from fab"
+```
+
+---
+
+### Task 2: Expose Registrant Data In Item Model
+
+**Files:**
+- Modify: `lib/models/item.dart`
+- Modify: `lib/services/supabase_service.dart`
+- Modify: `test/services/supabase_service_test.dart`
+
+- [ ] **Step 1: Add failing mapping test for registered user display data**
+
+In `test/services/supabase_service_test.dart`, add this test inside `group('SupabaseService.loadItemsForScope', () { ... })`:
+
+```dart
+test('maps registered user display data for group items', () async {
+  final gateway = _RecordingItemDatabaseGateway()
+    ..loadItemsResult = <Map<String, dynamic>>[
+      _itemRow(id: 'group-item-1', groupId: 'group-1')
+        ..['registered_by_user'] = <String, dynamic>{
+          'id': SupabaseService.currentUserId,
+          'display_name': '민서',
+          'email': 'minseo@example.com',
+        },
+    ];
+  SupabaseService.debugItemDatabaseGateway = gateway;
+
+  final items = await SupabaseService.loadItemsForScope(
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+
+  expect(items.single.registeredBy, SupabaseService.currentUserId);
+  expect(items.single.registeredByDisplayName, '민서');
+  expect(items.single.registeredByEmail, 'minseo@example.com');
+  expect(items.single.registeredByLabel, '민서');
+});
+```
+
+Also add this fallback test:
+
+```dart
+test('uses registered user email as label when display name is blank', () async {
+  final gateway = _RecordingItemDatabaseGateway()
+    ..loadItemsResult = <Map<String, dynamic>>[
+      _itemRow(id: 'group-item-1', groupId: 'group-1')
+        ..['registered_by_user'] = <String, dynamic>{
+          'id': SupabaseService.currentUserId,
+          'display_name': '   ',
+          'email': 'minseo@example.com',
+        },
+    ];
+  SupabaseService.debugItemDatabaseGateway = gateway;
+
+  final items = await SupabaseService.loadItemsForScope(
+    const ItemScope.group(id: 'group-1', label: '우리 가족'),
+  );
+
+  expect(items.single.registeredByLabel, 'minseo@example.com');
+});
+```
+
+- [ ] **Step 2: Run the focused Supabase mapping tests and verify failure**
+
+Run:
+
+```powershell
+flutter test test/services/supabase_service_test.dart --plain-name "registered user"
+```
+
+Expected: FAIL because `registeredByDisplayName`, `registeredByEmail`, and `registeredByLabel` do not exist yet.
+
+- [ ] **Step 3: Extend `ConsumableItem`**
+
+In `lib/models/item.dart`, add fields after `registeredBy`:
+
+```dart
+final String? registeredByDisplayName;
+final String? registeredByEmail;
+```
+
+Update the constructor parameters:
+
+```dart
+this.registeredBy,
+this.registeredByDisplayName,
+this.registeredByEmail,
+```
+
+Add this getter to `ConsumableItem`:
+
+```dart
+String? get registeredByLabel {
+  final displayName = registeredByDisplayName?.trim();
+  if (displayName != null && displayName.isNotEmpty) {
+    return displayName;
+  }
+
+  final email = registeredByEmail?.trim();
+  if (email != null && email.isNotEmpty) {
+    return email;
+  }
+
+  final id = registeredBy?.trim();
+  return id == null || id.isEmpty ? null : id;
+}
+```
+
+- [ ] **Step 4: Parse registered user data in `fromSupabase`**
+
+In `lib/models/item.dart`, inside `ConsumableItem.fromSupabase`, add this before `return ConsumableItem(`:
+
+```dart
+final registeredUser = data['registered_by_user'] as Map<String, dynamic>?;
+final registeredDisplayName =
+    (registeredUser?['display_name'] as String?)?.trim();
+final registeredEmail = (registeredUser?['email'] as String?)?.trim();
+```
+
+Then update the returned `ConsumableItem`:
+
+```dart
+registeredBy: data['registered_by'] as String?,
+registeredByDisplayName: registeredDisplayName?.isNotEmpty == true
+    ? registeredDisplayName
+    : null,
+registeredByEmail: registeredEmail?.isNotEmpty == true
+    ? registeredEmail
+    : null,
+```
+
+- [ ] **Step 5: Add registered user join to item projection**
+
+In `lib/services/supabase_service.dart`, update `_itemProjection` in `SupabaseItemDatabaseGateway` so it includes the registered user relation immediately after `registered_by`:
+
+```dart
+registered_by,
+registered_by_user:users!product_items_registered_by_fkey (
+  id,
+  display_name,
+  email
+),
+```
+
+Keep the existing scalar `registered_by` field because it is the stable ID used for comparisons and fallback labels.
+
+- [ ] **Step 6: Run Supabase service tests**
+
+Run:
+
+```powershell
+flutter test test/services/supabase_service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+Run:
+
+```powershell
+git add lib/models/item.dart lib/services/supabase_service.dart test/services/supabase_service_test.dart
+git commit -m "feat: expose item registrant metadata"
+```
+
+---
+
+### Task 3: Show Registrant In Group Item Rows
+
+**Files:**
+- Modify: `lib/screens/items_screen.dart`
+- Create: `test/widgets/item_row_test.dart`
+
+- [ ] **Step 1: Create failing ItemRow widget tests**
+
+Create `test/widgets/item_row_test.dart`:
+
+```dart
+import 'package:buylog/models/item.dart';
+import 'package:buylog/screens/items_screen.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('group item row shows the registrant label', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: ItemRow(
+            item: _item(
+              groupId: 'group-1',
+              registeredByDisplayName: '민서',
+              registeredByEmail: 'minseo@example.com',
+            ),
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('추가: 민서'), findsOneWidget);
+  });
+
+  testWidgets('personal item row does not show registrant metadata', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: ItemRow(
+            item: _item(
+              registeredByDisplayName: '민서',
+              registeredByEmail: 'minseo@example.com',
+            ),
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('추가:'), findsNothing);
+  });
+}
+
+ConsumableItem _item({
+  String? groupId,
+  String? registeredByDisplayName,
+  String? registeredByEmail,
+}) {
+  return ConsumableItem(
+    id: 'item-1',
+    name: '정수기 필터',
+    brand: '코웨이',
+    category: '필터',
+    icon: Icons.filter_alt_outlined,
+    daysRemaining: 20,
+    cycleDays: 30,
+    progress: 0.3,
+    groupId: groupId,
+    registeredBy: 'user-1',
+    registeredByDisplayName: registeredByDisplayName,
+    registeredByEmail: registeredByEmail,
+  );
+}
+```
+
+- [ ] **Step 2: Run the row tests and verify failure**
+
+Run:
+
+```powershell
+flutter test test/widgets/item_row_test.dart
+```
+
+Expected: FAIL because `ItemRow` does not render `registeredByLabel`.
+
+- [ ] **Step 3: Update `ItemRow` subtitle composition**
+
+In `lib/screens/items_screen.dart`, inside `ItemRow.build`, add this after `final cyclePart = item.aiPredictedDays ?? item.cycleDays;`:
+
+```dart
+final registeredByLabel = item.groupId == null ? null : item.registeredByLabel;
+final subtitleParts = <String>[
+  if (item.brand.trim().isNotEmpty) item.brand.trim(),
+  '주기 $cyclePart일',
+  if (registeredByLabel != null) '추가: $registeredByLabel',
+];
+```
+
+Replace the existing subtitle `Text` widget content:
+
+```dart
+'${item.brand} · 주기 $cyclePart일',
+```
+
+with:
+
+```dart
+subtitleParts.join(' · '),
+```
+
+The full subtitle `Text` block should be:
+
+```dart
+Text(
+  subtitleParts.join(' · '),
+  maxLines: 1,
+  overflow: TextOverflow.ellipsis,
+  style: const TextStyle(
+    fontSize: 11.5,
+    color: AppColors.textMuted,
+  ),
+),
+```
+
+- [ ] **Step 4: Run the row tests**
+
+Run:
+
+```powershell
+flutter test test/widgets/item_row_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```powershell
+git add lib/screens/items_screen.dart test/widgets/item_row_test.dart
+git commit -m "feat: show registrant on group item rows"
+```
+
+---
+
+### Task 4: Show Registrant In Item Detail
+
+**Files:**
+- Modify: `lib/screens/item_detail_screen.dart`
+- Create: `test/screens/item_detail_screen_test.dart`
+
+- [ ] **Step 1: Create failing detail screen test**
+
+Create `test/screens/item_detail_screen_test.dart`:
+
+```dart
+import 'package:buylog/models/item.dart';
+import 'package:buylog/screens/item_detail_screen.dart';
+import 'package:buylog/services/item_store.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    ItemStore.instance.value = [];
+  });
+
+  tearDown(() {
+    ItemStore.instance.value = [];
+  });
+
+  testWidgets('group item detail shows the registrant label', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: ItemDetailScreen(
+          item: ConsumableItem(
+            id: 'item-1',
+            name: '정수기 필터',
+            brand: '코웨이',
+            category: '필터',
+            icon: Icons.filter_alt_outlined,
+            daysRemaining: 20,
+            cycleDays: 30,
+            progress: 0.3,
+            groupId: 'group-1',
+            registeredBy: 'user-1',
+            registeredByDisplayName: '민서',
+            registeredByEmail: 'minseo@example.com',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('추가한 사람'), findsOneWidget);
+    expect(find.text('민서'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run the detail test and verify failure**
+
+Run:
+
+```powershell
+flutter test test/screens/item_detail_screen_test.dart
+```
+
+Expected: FAIL because the detail screen does not render registrant metadata.
+
+- [ ] **Step 3: Add a detail metadata widget**
+
+In `lib/screens/item_detail_screen.dart`, add this method inside `_ItemDetailScreenState`:
+
+```dart
+Widget _buildRegistrantMeta() {
+  final registeredByLabel = _item.groupId == null ? null : _item.registeredByLabel;
+  if (registeredByLabel == null) {
+    return const SizedBox.shrink();
+  }
+
+  return Padding(
+    padding: const EdgeInsets.only(top: 10),
+    child: Row(
+      children: [
+        const Icon(
+          Icons.person_add_alt_1_outlined,
+          size: 15,
+          color: AppColors.textMuted,
+        ),
+        const SizedBox(width: 6),
+        const Text(
+          '추가한 사람',
+          style: TextStyle(fontSize: 12, color: AppColors.textMuted),
+        ),
+        const SizedBox(width: 6),
+        Flexible(
+          child: Text(
+            registeredByLabel,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              fontSize: 12,
+              color: AppColors.textSecondary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+```
+
+- [ ] **Step 4: Render the metadata below brand**
+
+In `_buildProductHeader()`, inside the `Column` that currently renders category, item name, and brand, add `_buildRegistrantMeta()` immediately after the brand `Text`:
+
+```dart
+const SizedBox(height: 2),
+Text(
+  _item.brand,
+  style: const TextStyle(
+    fontSize: 14,
+    color: AppColors.textMuted,
+  ),
+),
+_buildRegistrantMeta(),
+```
+
+If the existing brand `Text` already has the same structure, only add the final `_buildRegistrantMeta()` call after it.
+
+- [ ] **Step 5: Run the detail test**
+
+Run:
+
+```powershell
+flutter test test/screens/item_detail_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```powershell
+git add lib/screens/item_detail_screen.dart test/screens/item_detail_screen_test.dart
+git commit -m "feat: show registrant on item detail"
+```
+
+---
+
+### Task 5: Final Verification
+
+**Files:**
+- No file edits.
+
+- [ ] **Step 1: Format changed files**
+
+Run:
+
+```powershell
+dart format lib/main.dart lib/models/item.dart lib/services/supabase_service.dart lib/screens/items_screen.dart lib/screens/item_detail_screen.dart test/main_navigation_test.dart test/services/supabase_service_test.dart test/widgets/item_row_test.dart test/screens/item_detail_screen_test.dart
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Run analyzer**
+
+Run:
+
+```powershell
+flutter analyze --no-fatal-infos
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```powershell
+flutter test test/main_navigation_test.dart
+flutter test test/services/supabase_service_test.dart
+flutter test test/widgets/item_row_test.dart
+flutter test test/screens/item_detail_screen_test.dart
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```powershell
+flutter test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run:
+
+```powershell
+flutter run -d windows
+```
+
+Manual checks:
+
+1. 그룹 탭으로 이동한다.
+2. 우측 하단 `+` 버튼을 누르고 `직접 등록`을 선택한다.
+3. 제품을 저장한다.
+4. Supabase `product_items` row가 `user_id = null`, `group_id = 선택된 그룹 id`, `registered_by = 현재 사용자 id`인지 확인한다.
+5. 그룹 목록에 저장한 제품이 나타나고 subtitle에 `추가: <표시명>`이 보이는지 확인한다.
+6. 제품 상세 화면에서 `추가한 사람 <표시명>`이 보이는지 확인한다.
+7. 홈 탭 또는 모든 제품 탭의 `+` 버튼으로 저장한 제품은 `user_id = 현재 사용자 id`, `group_id = null`로 저장되는지 확인한다.
+
+- [ ] **Step 6: Inspect final diff**
+
+Run:
+
+```powershell
+git status --short
+git diff --stat
+```
+
+Expected: only the planned source/test files and this plan document changed.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers group-page FAB add, default personal FAB behavior outside the group page, `registered_by` persistence, registered user lookup, model exposure, list UI, and detail UI.
+- Business logic boundary: Scope ownership stays in `SupabaseService.saveItem()` and `GroupStore`; widgets only receive model data and render it.
+- Test coverage: Navigation scope, Supabase mapping, row rendering, and detail rendering are covered with focused tests.
+- Null safety: Registrant fields are nullable, and UI only renders labels when `registeredByLabel` is non-null.
+- Placeholder scan: No unresolved implementation placeholders remain.

--- a/docs/superpowers/plans/2026-05-28-group-settings-dialog.md
+++ b/docs/superpowers/plans/2026-05-28-group-settings-dialog.md
@@ -1,0 +1,1070 @@
+# Group Settings Dialog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 그룹 카드에 바로 노출된 `그룹 탈퇴` 액션을 설정 버튼 뒤의 팝업으로 옮기고, 같은 설정 팝업에서 그룹 이름 변경과 관련 액션을 처리할 수 있게 만든다.
+
+**Architecture:** 그룹 이름 변경은 `SupabaseService`와 `GroupStore`에 추가하고, 위젯은 입력, 확인, 상태 표시만 담당한다. `GroupSettingsDialog`는 독립 위젯으로 분리해 설정 액션이 늘어나도 `GroupScreen`이 더 비대해지지 않게 한다.
+
+**Tech Stack:** Flutter, Dart, `ValueNotifier`, `supabase_flutter`, Supabase RLS, `flutter_test`.
+
+---
+
+## Current Repo Context
+
+- 그룹 화면은 `lib/screens/group_screen.dart`에 있다. `_GroupCard` 안에서 현재 `OutlinedButton.icon(label: Text('그룹 탈퇴'))`가 바로 보이고, 버튼이 `_LeaveGroupDialog`를 연다.
+- 그룹 상태와 비즈니스 로직은 `lib/services/group_store.dart`의 `GroupStore`가 관리한다.
+- Supabase 접근 계약은 `lib/services/supabase_service.dart`의 `GroupDatabaseGateway`와 `SupabaseGroupDatabaseGateway`에 있다.
+- `supabase/migrations/20260526193000_add_group_rls_policies.sql`에 이미 `"Group owners can update groups"` 정책이 있어서, owner의 `groups.name` 수정에는 새 migration이 필요하지 않다.
+- `ItemScope` equality는 `type`, `id`, `label`을 모두 비교한다. 그룹 이름 변경 후 선택된 scope label을 같이 갱신하지 않으면 선택 상태가 fallback될 수 있다.
+- AGENTS.md 기준상 새 비즈니스 로직에 테스트가 없으면 `[P1]`이다. 서비스, store, widget 테스트를 먼저 작성한다.
+
+## File Structure
+
+- Modify: `lib/services/supabase_service.dart`
+  - `SupabaseService.renameGroup()`을 추가한다.
+  - `GroupDatabaseGateway.renameGroup()` 계약과 Supabase update 구현을 추가한다.
+- Modify: `lib/services/group_store.dart`
+  - `GroupState.isUpdatingGroup`을 추가한다.
+  - `GroupStore.renameGroup()`에서 trim, blank validation, local state update, selected scope label 갱신, 실패 복구를 처리한다.
+- Create: `lib/widgets/group/group_settings_dialog.dart`
+  - 설정 팝업 UI를 담당한다.
+  - 그룹 이름 편집, 초대 코드 복사, 멤버 새로고침, 그룹 탈퇴 액션을 한 팝업 안에 둔다.
+- Modify: `lib/screens/group_screen.dart`
+  - `_GroupCard`의 직접 탈퇴 버튼을 설정 아이콘 버튼으로 교체한다.
+  - `_openGroupSettings()`를 추가해 settings dialog와 기존 `_LeaveGroupDialog`를 연결한다.
+- Modify: `test/services/supabase_service_test.dart`
+  - rename service trim, blank validation, gateway 호출을 검증한다.
+- Modify: `test/services/group_store_test.dart`
+  - rename 성공 시 그룹 목록과 selected scope label이 같이 바뀌는지 검증한다.
+  - rename 실패 시 이전 상태 복구와 한국어 오류 메시지를 검증한다.
+- Modify: `test/screens/group_screen_test.dart`
+  - `그룹 탈퇴`가 카드에 바로 보이지 않고 설정 팝업 안에서만 보이는지 검증한다.
+  - 설정 팝업에서 탈퇴 dialog로 이어지는 흐름과 그룹 이름 변경 UI를 검증한다.
+
+---
+
+### Task 1: Add Rename Contract to SupabaseService
+
+**Files:**
+- Modify: `test/services/supabase_service_test.dart`
+- Modify: `lib/services/supabase_service.dart`
+- Touch fakes as needed: `test/services/group_store_test.dart`, `test/screens/group_screen_test.dart`
+
+- [ ] **Step 1: Write failing service tests**
+
+Add these fields to `_RecordingGroupDatabaseGateway` in `test/services/supabase_service_test.dart`:
+
+```dart
+  int renameGroupCalls = 0;
+  String? renameGroupGroupId;
+  String? renameGroupName;
+```
+
+Add this method to the same fake gateway:
+
+```dart
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    renameGroupCalls += 1;
+    renameGroupGroupId = groupId;
+    renameGroupName = name;
+    return <String, dynamic>{
+      'id': groupId,
+      'name': name,
+      'invite_code': 'BUY-ABC123',
+      'created_by': SupabaseService.currentUserId,
+      'created_at': '2026-05-26T00:00:00.000Z',
+      'group_members': <Map<String, dynamic>>[],
+    };
+  }
+```
+
+Add this test group after `SupabaseService.createGroup`:
+
+```dart
+  group('SupabaseService.renameGroup', () {
+    tearDown(() {
+      SupabaseService.debugGroupDatabaseGateway = null;
+    });
+
+    test('trims group id and name before gateway update', () async {
+      final gateway = _RecordingGroupDatabaseGateway();
+      SupabaseService.debugGroupDatabaseGateway = gateway;
+
+      final group = await SupabaseService.renameGroup(
+        groupId: ' group-1 ',
+        name: '  새 가족  ',
+      );
+
+      expect(gateway.renameGroupCalls, 1);
+      expect(gateway.renameGroupGroupId, 'group-1');
+      expect(gateway.renameGroupName, '새 가족');
+      expect(group.id, 'group-1');
+      expect(group.name, '새 가족');
+    });
+
+    test('rejects blank group ids without calling gateway', () async {
+      final gateway = _RecordingGroupDatabaseGateway();
+      SupabaseService.debugGroupDatabaseGateway = gateway;
+
+      await expectLater(
+        SupabaseService.renameGroup(groupId: '   ', name: '새 가족'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            'Group id is required.',
+          ),
+        ),
+      );
+
+      expect(gateway.renameGroupCalls, 0);
+    });
+
+    test('rejects blank names without calling gateway', () async {
+      final gateway = _RecordingGroupDatabaseGateway();
+      SupabaseService.debugGroupDatabaseGateway = gateway;
+
+      await expectLater(
+        SupabaseService.renameGroup(groupId: 'group-1', name: '   '),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            'Group name is required.',
+          ),
+        ),
+      );
+
+      expect(gateway.renameGroupCalls, 0);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the service test and verify it fails**
+
+Run:
+
+```powershell
+flutter test test/services/supabase_service_test.dart
+```
+
+Expected: FAIL with compile errors for `renameGroup`.
+
+- [ ] **Step 3: Add `SupabaseService.renameGroup()`**
+
+Add this method after `createGroup()` in `lib/services/supabase_service.dart`:
+
+```dart
+  static Future<BuylogGroup> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    final trimmedGroupId = groupId.trim();
+    if (trimmedGroupId.isEmpty) {
+      throw ArgumentError.value(groupId, 'groupId', 'Group id is required.');
+    }
+
+    final trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'Group name is required.');
+    }
+
+    final updatedGroup = await _groupDatabaseGateway.renameGroup(
+      groupId: trimmedGroupId,
+      name: trimmedName,
+    );
+    return BuylogGroup.fromSupabase(updatedGroup);
+  }
+```
+
+- [ ] **Step 4: Extend the group gateway contract**
+
+Add this method to `abstract class GroupDatabaseGateway`:
+
+```dart
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  });
+```
+
+Add this method to `SupabaseGroupDatabaseGateway`:
+
+```dart
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    final row = await _client
+        .from('groups')
+        .update({'name': name})
+        .eq('id', groupId)
+        .select(_groupProjection)
+        .single();
+    return Map<String, dynamic>.from(row);
+  }
+```
+
+- [ ] **Step 5: Update other fake gateways for the new interface**
+
+Add this method to `_RecordingGroupDatabaseGateway` in `test/services/group_store_test.dart`:
+
+```dart
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    return _groupRow(id: groupId, name: name);
+  }
+```
+
+Add this method to `_FakeGroupDatabaseGateway` in `test/screens/group_screen_test.dart`:
+
+```dart
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    return _groupRow(id: groupId, name: name);
+  }
+```
+
+- [ ] **Step 6: Run focused service tests**
+
+Run:
+
+```powershell
+flutter test test/services/supabase_service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```powershell
+git add lib/services/supabase_service.dart test/services/supabase_service_test.dart test/services/group_store_test.dart test/screens/group_screen_test.dart
+git commit -m "feat: add group rename service"
+```
+
+Expected: commit succeeds with the service contract and fake updates.
+
+---
+
+### Task 2: Add Rename State and Behavior to GroupStore
+
+**Files:**
+- Modify: `test/services/group_store_test.dart`
+- Modify: `lib/services/group_store.dart`
+
+- [ ] **Step 1: Write failing store tests**
+
+Extend `_RecordingGroupDatabaseGateway` in `test/services/group_store_test.dart`:
+
+```dart
+  int renameGroupCalls = 0;
+  String? renameGroupGroupId;
+  String? renameGroupName;
+  Object? renameGroupError;
+```
+
+Replace the temporary `renameGroup` fake method from Task 1 with:
+
+```dart
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    renameGroupCalls += 1;
+    renameGroupGroupId = groupId;
+    renameGroupName = name;
+    if (renameGroupError != null) {
+      throw renameGroupError!;
+    }
+    return _groupRow(id: groupId, name: name);
+  }
+```
+
+Add these tests inside the existing `GroupStore` group:
+
+```dart
+    test('renames selected group and updates selected scope label', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+      await GroupStore.instance.initialize();
+      GroupStore.instance.selectScope(
+        const ItemScope.group(id: 'group-1', label: '우리 가족'),
+      );
+
+      await GroupStore.instance.renameGroup(
+        groupId: ' group-1 ',
+        name: '  새 가족  ',
+      );
+
+      expect(gateway.renameGroupCalls, 1);
+      expect(gateway.renameGroupGroupId, 'group-1');
+      expect(gateway.renameGroupName, '새 가족');
+      expect(GroupStore.instance.value.groups.first.name, '새 가족');
+      expect(
+        GroupStore.instance.value.selectedScope,
+        const ItemScope.group(id: 'group-1', label: '새 가족'),
+      );
+      expect(GroupStore.instance.value.isUpdatingGroup, isFalse);
+      expect(GroupStore.instance.value.errorMessage, isNull);
+    });
+
+    test('keeps previous group state when rename fails', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+      ];
+      await GroupStore.instance.initialize();
+      gateway.renameGroupError = StateError('rename failed');
+
+      await expectLater(
+        GroupStore.instance.renameGroup(groupId: 'group-1', name: '새 가족'),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'rename failed',
+          ),
+        ),
+      );
+
+      expect(GroupStore.instance.value.groups.single.name, '우리 가족');
+      expect(GroupStore.instance.value.isUpdatingGroup, isFalse);
+      expect(
+        GroupStore.instance.value.errorMessage,
+        '그룹 이름을 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+    });
+
+    test('rejects blank rename values before gateway call', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+      ];
+      await GroupStore.instance.initialize();
+
+      await expectLater(
+        GroupStore.instance.renameGroup(groupId: 'group-1', name: '   '),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(gateway.renameGroupCalls, 0);
+      expect(GroupStore.instance.value.groups.single.name, '우리 가족');
+    });
+```
+
+- [ ] **Step 2: Run store tests and verify they fail**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart
+```
+
+Expected: FAIL with compile errors for `isUpdatingGroup` and `renameGroup`.
+
+- [ ] **Step 3: Add `isUpdatingGroup` to `GroupState`**
+
+Update `GroupState` in `lib/services/group_store.dart`:
+
+```dart
+  const GroupState({
+    this.group,
+    this.groups = const [],
+    this.selectedScope = const ItemScope.personal(),
+    this.isLoading = false,
+    this.isSaving = false,
+    this.isRefreshingMembers = false,
+    this.isLeavingGroup = false,
+    this.isUpdatingGroup = false,
+    this.errorMessage,
+  });
+```
+
+Add the field:
+
+```dart
+  final bool isUpdatingGroup;
+```
+
+Add the `copyWith` parameter:
+
+```dart
+    bool? isUpdatingGroup,
+```
+
+Set it in the returned `GroupState`:
+
+```dart
+      isUpdatingGroup: isUpdatingGroup ?? this.isUpdatingGroup,
+```
+
+- [ ] **Step 4: Add `GroupStore.renameGroup()`**
+
+Add this method after `createGroup()` in `lib/services/group_store.dart`:
+
+```dart
+  Future<void> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    final trimmedGroupId = groupId.trim();
+    if (trimmedGroupId.isEmpty) {
+      throw ArgumentError.value(groupId, 'groupId', 'Group id is required.');
+    }
+
+    final trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'Group name is required.');
+    }
+
+    final previousState = value;
+    final currentGroup = previousState.groupForScope(
+      ItemScope.group(id: trimmedGroupId, label: ''),
+    );
+    if (currentGroup?.name == trimmedName || value.isUpdatingGroup) {
+      return;
+    }
+
+    value = previousState.copyWith(isUpdatingGroup: true, errorMessage: null);
+
+    try {
+      final updatedGroup = await SupabaseService.renameGroup(
+        groupId: trimmedGroupId,
+        name: trimmedName,
+      );
+      final updatedGroups = previousState.visibleGroups
+          .map((group) => group.id == updatedGroup.id ? updatedGroup : group)
+          .toList(growable: false);
+      final selectedScope =
+          previousState.selectedScope.isGroup &&
+              previousState.selectedScope.id == updatedGroup.id
+          ? ItemScope.group(id: updatedGroup.id, label: updatedGroup.name)
+          : previousState.selectedScope;
+
+      value = GroupState(
+        group: updatedGroups.isEmpty ? null : updatedGroups.first,
+        groups: updatedGroups,
+        selectedScope: selectedScope,
+      );
+    } catch (_) {
+      value = previousState.copyWith(
+        isUpdatingGroup: false,
+        errorMessage: '그룹 이름을 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+      rethrow;
+    }
+  }
+```
+
+- [ ] **Step 5: Run store tests**
+
+Run:
+
+```powershell
+flutter test test/services/group_store_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```powershell
+git add lib/services/group_store.dart test/services/group_store_test.dart
+git commit -m "feat: rename group from store"
+```
+
+Expected: commit succeeds with store behavior and tests.
+
+---
+
+### Task 3: Create the Group Settings Dialog Widget
+
+**Files:**
+- Create: `lib/widgets/group/group_settings_dialog.dart`
+
+- [ ] **Step 1: Create the settings dialog widget**
+
+Create `lib/widgets/group/group_settings_dialog.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+
+import '../../models/group.dart';
+import '../../theme/app_theme.dart';
+
+class GroupSettingsDialog extends StatefulWidget {
+  const GroupSettingsDialog({
+    super.key,
+    required this.group,
+    required this.canRenameGroup,
+    required this.isUpdatingGroup,
+    required this.isRefreshingMembers,
+    required this.isLeavingGroup,
+    required this.errorMessage,
+    required this.onRenameGroup,
+    required this.onCopyInviteCode,
+    required this.onRefreshMembers,
+    required this.onLeaveGroup,
+  });
+
+  final BuylogGroup group;
+  final bool canRenameGroup;
+  final bool isUpdatingGroup;
+  final bool isRefreshingMembers;
+  final bool isLeavingGroup;
+  final String? errorMessage;
+  final Future<void> Function(String name) onRenameGroup;
+  final VoidCallback onCopyInviteCode;
+  final VoidCallback onRefreshMembers;
+  final VoidCallback onLeaveGroup;
+
+  @override
+  State<GroupSettingsDialog> createState() => _GroupSettingsDialogState();
+}
+
+class _GroupSettingsDialogState extends State<GroupSettingsDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.group.name);
+  }
+
+  @override
+  void didUpdateWidget(covariant GroupSettingsDialog oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.group.name != widget.group.name &&
+        _nameController.text != widget.group.name) {
+      _nameController.text = widget.group.name;
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitName() async {
+    if (!widget.canRenameGroup || widget.isUpdatingGroup) return;
+    if (!_formKey.currentState!.validate()) return;
+
+    final nextName = _nameController.text.trim();
+    if (nextName == widget.group.name) {
+      Navigator.of(context).pop();
+      return;
+    }
+
+    try {
+      await widget.onRenameGroup(nextName);
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {});
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final errorMessage = widget.errorMessage;
+
+    return AlertDialog(
+      title: const Text('그룹 설정'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Form(
+              key: _formKey,
+              child: TextFormField(
+                key: const Key('group-settings-name-field'),
+                controller: _nameController,
+                readOnly: !widget.canRenameGroup || widget.isUpdatingGroup,
+                textInputAction: TextInputAction.done,
+                decoration: InputDecoration(
+                  labelText: '그룹 이름',
+                  helperText: widget.canRenameGroup
+                      ? '그룹 목록과 물품 목록 제목에 표시됩니다.'
+                      : '관리자만 그룹 이름을 변경할 수 있습니다.',
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '그룹 이름을 입력해 주세요.';
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (_) => _submitName(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            _SettingsActionButton(
+              icon: Icons.copy,
+              label: '초대 코드 복사',
+              value: widget.group.inviteCode,
+              onPressed: widget.onCopyInviteCode,
+            ),
+            const SizedBox(height: 8),
+            _SettingsActionButton(
+              icon: Icons.refresh,
+              label: '멤버 새로고침',
+              value: '최신 멤버 목록을 다시 불러옵니다.',
+              onPressed:
+                  widget.isRefreshingMembers ? null : widget.onRefreshMembers,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              onPressed: widget.isLeavingGroup ? null : widget.onLeaveGroup,
+              icon: widget.isLeavingGroup
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.logout, size: 18),
+              label: const Text('그룹 탈퇴'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.danger,
+              ),
+            ),
+            if (errorMessage?.isNotEmpty == true) ...[
+              const SizedBox(height: 12),
+              Text(
+                errorMessage!,
+                style: const TextStyle(color: AppColors.danger),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: widget.isUpdatingGroup
+              ? null
+              : () => Navigator.of(context).pop(),
+          child: const Text('닫기'),
+        ),
+        FilledButton(
+          onPressed:
+              widget.canRenameGroup && !widget.isUpdatingGroup ? _submitName : null,
+          child: widget.isUpdatingGroup
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('저장'),
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsActionButton extends StatelessWidget {
+  const _SettingsActionButton({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onPressed,
+        icon: Icon(icon, size: 18),
+        label: Align(
+          alignment: Alignment.centerLeft,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(label),
+              Text(
+                value,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: AppColors.textMuted,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Format the new widget**
+
+Run:
+
+```powershell
+dart format lib\widgets\group\group_settings_dialog.dart
+```
+
+Expected: formatter completes without parse errors.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```powershell
+git add lib/widgets/group/group_settings_dialog.dart
+git commit -m "feat: add group settings dialog"
+```
+
+Expected: commit succeeds with only the new widget.
+
+---
+
+### Task 4: Wire Settings Dialog into GroupScreen
+
+**Files:**
+- Modify: `test/screens/group_screen_test.dart`
+- Modify: `lib/screens/group_screen.dart`
+
+- [ ] **Step 1: Update widget tests for settings entry**
+
+In `test/screens/group_screen_test.dart`, update existing leave tests so they open settings first:
+
+```dart
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('그룹 탈퇴'));
+    await tester.pumpAndSettle();
+```
+
+Add this widget test near the current group card tests:
+
+```dart
+  testWidgets('group leave action is only shown inside settings dialog', (
+    tester,
+  ) async {
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+
+    expect(find.text('그룹 탈퇴'), findsNothing);
+    expect(find.byTooltip('그룹 설정'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('그룹 설정'), findsOneWidget);
+    expect(find.text('그룹 탈퇴'), findsOneWidget);
+  });
+```
+
+Add this widget test for rename:
+
+```dart
+  testWidgets('owner renames group from settings dialog', (tester) async {
+    final gateway = _FakeGroupDatabaseGateway();
+    SupabaseService.debugGroupDatabaseGateway = gateway;
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('group-settings-name-field')),
+      '새 가족',
+    );
+    await tester.tap(find.text('저장'));
+    await tester.pumpAndSettle();
+
+    expect(gateway.renameGroupCalls, 1);
+    expect(gateway.renameGroupGroupId, 'group-1');
+    expect(gateway.renameGroupName, '새 가족');
+    expect(GroupStore.instance.value.selectedScope.label, '새 가족');
+    expect(find.text('새 가족'), findsAtLeastNWidgets(1));
+  });
+```
+
+Extend `_FakeGroupDatabaseGateway`:
+
+```dart
+  int renameGroupCalls = 0;
+  String? renameGroupGroupId;
+  String? renameGroupName;
+```
+
+Replace the temporary `renameGroup` fake method with:
+
+```dart
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    renameGroupCalls += 1;
+    renameGroupGroupId = groupId;
+    renameGroupName = name;
+    final group = _groupRow(id: groupId, name: name);
+    _currentGroup = group;
+    return group;
+  }
+```
+
+- [ ] **Step 2: Run widget tests and verify they fail**
+
+Run:
+
+```powershell
+flutter test test/screens/group_screen_test.dart
+```
+
+Expected: FAIL because the settings tooltip and dialog are not wired yet.
+
+- [ ] **Step 3: Import the settings dialog**
+
+Add this import to `lib/screens/group_screen.dart`:
+
+```dart
+import '../widgets/group/group_settings_dialog.dart';
+```
+
+- [ ] **Step 4: Add `_openGroupSettings()` to `_GroupScreenState`**
+
+Add this method after `_openScopedAdd()`:
+
+```dart
+  void _openGroupSettings(BuylogGroup group) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return ValueListenableBuilder<GroupState>(
+          valueListenable: GroupStore.instance,
+          builder: (context, state, _) {
+            var currentGroup = group;
+            for (final candidate in state.visibleGroups) {
+              if (candidate.id == group.id) {
+                currentGroup = candidate;
+                break;
+              }
+            }
+
+            return GroupSettingsDialog(
+              group: currentGroup,
+              canRenameGroup: currentGroup.isOwner(
+                SupabaseService.currentUserId,
+              ),
+              isUpdatingGroup: state.isUpdatingGroup,
+              isRefreshingMembers: state.isRefreshingMembers,
+              isLeavingGroup: state.isLeavingGroup,
+              errorMessage: state.errorMessage,
+              onRenameGroup: (name) => GroupStore.instance.renameGroup(
+                groupId: currentGroup.id,
+                name: name,
+              ),
+              onCopyInviteCode: () => _copyInviteCode(currentGroup.inviteCode),
+              onRefreshMembers: () => GroupStore.instance.refreshMembers(
+                groupId: currentGroup.id,
+              ),
+              onLeaveGroup: () {
+                Navigator.of(dialogContext).pop();
+                showDialog<void>(
+                  context: this.context,
+                  builder: (_) => _LeaveGroupDialog(group: currentGroup),
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+```
+
+- [ ] **Step 5: Pass settings state into `_GroupCard`**
+
+Update the `_GroupCard` construction:
+
+```dart
+                    child: _GroupCard(
+                      group: selectedGroup,
+                      isRefreshingMembers: state.isRefreshingMembers,
+                      isLeavingGroup: state.isLeavingGroup,
+                      isUpdatingGroup: state.isUpdatingGroup,
+                      onRefreshMembers: () => GroupStore.instance
+                          .refreshMembers(groupId: selectedGroup.id),
+                      onCopyInviteCode: _copyInviteCode,
+                      onOpenSettings: () => _openGroupSettings(selectedGroup),
+                    ),
+```
+
+Update `_GroupCard` constructor and fields:
+
+```dart
+  const _GroupCard({
+    required this.group,
+    required this.isRefreshingMembers,
+    required this.isLeavingGroup,
+    required this.isUpdatingGroup,
+    required this.onRefreshMembers,
+    required this.onCopyInviteCode,
+    required this.onOpenSettings,
+  });
+
+  final BuylogGroup group;
+  final bool isRefreshingMembers;
+  final bool isLeavingGroup;
+  final bool isUpdatingGroup;
+  final VoidCallback onRefreshMembers;
+  final ValueChanged<String> onCopyInviteCode;
+  final VoidCallback onOpenSettings;
+```
+
+- [ ] **Step 6: Replace the direct leave button with a settings icon**
+
+In `_GroupCard.build()`, update the title row by adding the icon button after the expanded group name:
+
+```dart
+              IconButton(
+                tooltip: '그룹 설정',
+                onPressed:
+                    isLeavingGroup || isUpdatingGroup ? null : onOpenSettings,
+                icon: const Icon(Icons.settings_outlined),
+              ),
+```
+
+Remove the existing `Align` block that renders:
+
+```dart
+              label: const Text('그룹 탈퇴'),
+```
+
+Keep `_LeaveGroupDialog` unchanged except for any test-driven wording changes already present.
+
+- [ ] **Step 7: Run widget tests**
+
+Run:
+
+```powershell
+flutter test test/screens/group_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```powershell
+git add lib/screens/group_screen.dart lib/widgets/group/group_settings_dialog.dart test/screens/group_screen_test.dart
+git commit -m "feat: move group actions into settings"
+```
+
+Expected: commit succeeds with UI wiring and widget tests.
+
+---
+
+### Task 5: Verify the Whole Change
+
+**Files:**
+- Verify: `lib/services/supabase_service.dart`
+- Verify: `lib/services/group_store.dart`
+- Verify: `lib/screens/group_screen.dart`
+- Verify: `lib/widgets/group/group_settings_dialog.dart`
+- Verify: `test/services/supabase_service_test.dart`
+- Verify: `test/services/group_store_test.dart`
+- Verify: `test/screens/group_screen_test.dart`
+
+- [ ] **Step 1: Format changed Dart files**
+
+Run:
+
+```powershell
+dart format lib\services\supabase_service.dart lib\services\group_store.dart lib\screens\group_screen.dart lib\widgets\group\group_settings_dialog.dart test\services\supabase_service_test.dart test\services\group_store_test.dart test\screens\group_screen_test.dart
+```
+
+Expected: formatter completes without parse errors.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```powershell
+flutter test test/services/supabase_service_test.dart test/services/group_store_test.dart test/screens/group_screen_test.dart
+```
+
+Expected: PASS for service, store, and group screen tests.
+
+- [ ] **Step 3: Run analyzer**
+
+Run:
+
+```powershell
+flutter analyze --no-fatal-infos
+```
+
+Expected: exits 0.
+
+- [ ] **Step 4: Run full test suite**
+
+Run:
+
+```powershell
+flutter test
+```
+
+Expected: PASS for the full Flutter test suite.
+
+- [ ] **Step 5: Review final diff**
+
+Run:
+
+```powershell
+git diff -- lib\services\supabase_service.dart lib\services\group_store.dart lib\screens\group_screen.dart lib\widgets\group\group_settings_dialog.dart test\services\supabase_service_test.dart test\services\group_store_test.dart test\screens\group_screen_test.dart
+```
+
+Expected: diff only contains group rename service/store logic, settings dialog UI, direct leave button removal, updated widget flows, and tests.
+
+---
+
+## Self-Review
+
+- Spec coverage: 직접 노출된 `그룹 탈퇴`는 설정 아이콘 뒤로 이동한다. 설정 팝업에서 그룹 이름 변경, 초대 코드 복사, 멤버 새로고침, 그룹 탈퇴를 처리한다.
+- Placeholder scan: 파일 경로, 테스트 코드, 구현 코드, 실행 명령, expected result가 구체적으로 들어 있다.
+- Type consistency: `renameGroup`, `isUpdatingGroup`, `GroupSettingsDialog`, `onRenameGroup`, `onOpenSettings` 이름을 테스트와 구현에서 동일하게 사용한다.
+- Boundary check: Supabase update와 로컬 상태 갱신은 service/store에 있고, widget은 입력 검증과 콜백 호출만 맡는다.
+- Migration check: 기존 RLS의 `"Group owners can update groups"` 정책을 사용하므로 새 SQL migration은 계획하지 않는다.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -117,13 +117,8 @@ class MainNavigationState extends State<MainNavigation> {
       return const ItemScope.personal();
     }
 
-    final state = GroupStore.instance.value;
-    final scope = state.selectedScope;
-    if (scope.isGroup) {
-      return scope;
-    }
-
-    return const ItemScope.personal();
+    return GroupStore.instance.value.selectedGroupScope ??
+        const ItemScope.personal();
   }
 
   Widget _screenAt(int index) => switch (index) {

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -15,6 +15,8 @@ class ConsumableItem {
   final String? imageUrl;
   final String? groupId;
   final String? registeredBy;
+  final String? registeredByDisplayName;
+  final String? registeredByEmail;
 
   const ConsumableItem({
     required this.id,
@@ -31,7 +33,24 @@ class ConsumableItem {
     this.imageUrl,
     this.groupId,
     this.registeredBy,
+    this.registeredByDisplayName,
+    this.registeredByEmail,
   });
+
+  String? get registeredByLabel {
+    final displayName = registeredByDisplayName?.trim();
+    if (displayName != null && displayName.isNotEmpty) {
+      return displayName;
+    }
+
+    final email = registeredByEmail?.trim();
+    if (email != null && email.isNotEmpty) {
+      return email;
+    }
+
+    final id = registeredBy?.trim();
+    return id == null || id.isEmpty ? null : id;
+  }
 
   /// Supabase product_items 행 + 관련 데이터로 ConsumableItem 생성
   ///
@@ -62,6 +81,10 @@ class ConsumableItem {
     final daysSince = lastDate != null
         ? DateTime.now().difference(lastDate).inDays
         : cycleDays;
+    final registeredUser = data['registered_by_user'] as Map<String, dynamic>?;
+    final registeredDisplayName = (registeredUser?['display_name'] as String?)
+        ?.trim();
+    final registeredEmail = (registeredUser?['email'] as String?)?.trim();
 
     return ConsumableItem(
       id: data['id'] as String,
@@ -75,6 +98,12 @@ class ConsumableItem {
       imageUrl: data['image_url'] as String?,
       groupId: data['group_id'] as String?,
       registeredBy: data['registered_by'] as String?,
+      registeredByDisplayName: registeredDisplayName?.isNotEmpty == true
+          ? registeredDisplayName
+          : null,
+      registeredByEmail: registeredEmail?.isNotEmpty == true
+          ? registeredEmail
+          : null,
       aiPredictedDays: aiPrediction?['predicted_cycle_days'] as int?,
       aiConfidence: (aiPrediction?['confidence'] as num?)?.toDouble(),
       purchaseHistory: sorted

--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -4,6 +4,7 @@ import 'package:image_picker/image_picker.dart';
 import '../models/item.dart';
 import '../models/item_scope.dart';
 import '../services/ai/category_defaults.dart';
+import '../services/group_store.dart';
 import '../services/supabase_service.dart';
 import '../services/item_store.dart';
 import '../theme/app_theme.dart';
@@ -56,6 +57,7 @@ class _AddItemScreenState extends State<AddItemScreen> {
   late final TextEditingController _brandCtrl;
   late final TextEditingController _cycleDaysCtrl;
   String _selectedCategory = categoryDefaultDays.keys.first;
+  late ItemScope _selectedScope;
 
   // 구매 이력 목록
   final List<_PurchaseEntry> _purchases = [];
@@ -69,7 +71,9 @@ class _AddItemScreenState extends State<AddItemScreen> {
 
   bool get _isEditing => widget.editItem != null;
 
-  ItemScope get _effectiveScope {
+  bool get _canChangeScope => !_isEditing;
+
+  ItemScope get _initialScope {
     final explicit = widget.targetScope;
     if (explicit != null) return explicit;
 
@@ -81,9 +85,15 @@ class _AddItemScreenState extends State<AddItemScreen> {
     return const ItemScope.personal();
   }
 
+  ItemScope get _effectiveScope {
+    if (_isEditing) return _initialScope;
+    return _selectedScope;
+  }
+
   @override
   void initState() {
     super.initState();
+    _selectedScope = _initialScope;
     final edit = widget.editItem;
     final p = widget.prefillData;
 
@@ -212,6 +222,22 @@ class _AddItemScreenState extends State<AddItemScreen> {
     if (xFile == null) return;
     final bytes = await xFile.readAsBytes();
     setState(() => _imageBytes = bytes);
+  }
+
+  List<ItemScope> _scopeOptions(GroupState state) {
+    final options = <ItemScope>[
+      const ItemScope.personal(),
+      ...state.availableGroupScopes,
+    ];
+
+    final selectedAlreadyIncluded = options.any(
+      (scope) => scope.storageKey == _selectedScope.storageKey,
+    );
+    if (!selectedAlreadyIncluded && _selectedScope.isGroup) {
+      options.add(_selectedScope);
+    }
+
+    return options;
   }
 
   // ---------------------------------------------------------------------------
@@ -427,6 +453,7 @@ class _AddItemScreenState extends State<AddItemScreen> {
               const SizedBox(height: 12),
               _buildImagePicker(),
               const SizedBox(height: 24),
+              _buildScopeToggle(),
               _sectionTitle('기본 정보'),
               const SizedBox(height: 12),
               _buildBasicInfoSection(),
@@ -590,6 +617,72 @@ class _AddItemScreenState extends State<AddItemScreen> {
                 ],
               ),
       ),
+    );
+  }
+
+  Widget _buildScopeToggle() {
+    if (!_canChangeScope) return const SizedBox.shrink();
+
+    return ValueListenableBuilder<GroupState>(
+      valueListenable: GroupStore.instance,
+      builder: (context, state, _) {
+        final options = _scopeOptions(state);
+        if (options.length <= 1) {
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          key: const ValueKey('add_item_scope_toggle'),
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              '등록 위치',
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final scope in options)
+                  ChoiceChip(
+                    key: ValueKey('add_item_scope_${scope.storageKey}'),
+                    label: Text(scope.label),
+                    selected: scope.storageKey == _selectedScope.storageKey,
+                    onSelected: (_) {
+                      setState(() {
+                        _selectedScope = scope;
+                      });
+                    },
+                    selectedColor: AppColors.primary,
+                    backgroundColor: AppColors.surface,
+                    labelStyle: TextStyle(
+                      color: scope.storageKey == _selectedScope.storageKey
+                          ? Colors.white
+                          : AppColors.textSecondary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(999),
+                      side: BorderSide(
+                        color: scope.storageKey == _selectedScope.storageKey
+                            ? AppColors.primary
+                            : AppColors.border,
+                        width: 0.5,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 24),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/screens/group_screen.dart
+++ b/lib/screens/group_screen.dart
@@ -29,29 +29,43 @@ class _GroupScreenState extends State<GroupScreen> {
   void initState() {
     super.initState();
     _itemsStore = GroupItemsStore();
-    _itemsStore.load(GroupStore.instance.value.selectedScope);
+    GroupStore.instance.addListener(_reloadForSelectedGroup);
     ItemStore.instance.lastSaveEvent.addListener(_reloadAfterScopedSave);
+    _reloadForSelectedGroup();
   }
 
   @override
   void dispose() {
+    GroupStore.instance.removeListener(_reloadForSelectedGroup);
     ItemStore.instance.lastSaveEvent.removeListener(_reloadAfterScopedSave);
     _itemsStore.dispose();
     super.dispose();
   }
 
   void _selectScope(ItemScope scope) {
+    if (!scope.isGroup) return;
     GroupStore.instance.selectScope(scope);
+  }
+
+  void _reloadForSelectedGroup() {
+    final scope = GroupStore.instance.value.selectedGroupScope;
+    if (scope == null) return;
+    if (_itemsStore.value.scope.storageKey == scope.storageKey &&
+        !_itemsStore.value.isLoading) {
+      return;
+    }
     _itemsStore.load(scope);
   }
 
   void _reloadAfterScopedSave() {
     final event = ItemStore.instance.lastSaveEvent.value;
-    final selectedScope = GroupStore.instance.value.selectedScope;
-    if (event == null || event.scope.storageKey != selectedScope.storageKey) {
+    final selectedScope = GroupStore.instance.value.selectedGroupScope;
+    if (event == null ||
+        selectedScope == null ||
+        event.scope.storageKey != selectedScope.storageKey) {
       return;
     }
-    _itemsStore.load(event.scope);
+    _itemsStore.load(selectedScope);
   }
 
   Future<void> _copyInviteCode(String inviteCode) async {
@@ -78,7 +92,8 @@ class _GroupScreenState extends State<GroupScreen> {
             return const Center(child: CircularProgressIndicator());
           }
 
-          final selectedGroup = state.groupForScope(state.selectedScope);
+          final selectedScope = state.selectedGroupScope;
+          final selectedGroup = state.selectedGroup;
 
           return SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(0, 20, 0, 24),
@@ -93,12 +108,15 @@ class _GroupScreenState extends State<GroupScreen> {
                   ),
                 ),
                 const SizedBox(height: 16),
-                ItemScopeTabs(
-                  scopes: state.availableScopes,
-                  selectedScope: state.selectedScope,
-                  onSelected: _selectScope,
-                ),
-                const SizedBox(height: 16),
+                if (state.availableGroupScopes.length > 1) ...[
+                  ItemScopeTabs(
+                    scopes: state.availableGroupScopes,
+                    selectedScope:
+                        selectedScope ?? state.availableGroupScopes.first,
+                    onSelected: _selectScope,
+                  ),
+                  const SizedBox(height: 16),
+                ],
                 if (selectedGroup != null)
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -111,57 +129,55 @@ class _GroupScreenState extends State<GroupScreen> {
                       onCopyInviteCode: _copyInviteCode,
                     ),
                   )
-                else if (state.visibleGroups.isEmpty)
+                else
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 20),
                     child: _EmptyGroupState(errorMessage: state.errorMessage),
                   ),
-                const SizedBox(height: 16),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 20),
-                  child: Text(
-                    '${state.selectedScope.label} 목록',
-                    style: Theme.of(context).textTheme.titleLarge,
+                if (selectedScope != null && selectedGroup != null) ...[
+                  const SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    child: Text(
+                      '${selectedScope.label} 목록',
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
                   ),
-                ),
-                ValueListenableBuilder<GroupItemsState>(
-                  valueListenable: _itemsStore,
-                  builder: (context, itemState, _) {
-                    final summary = GroupDashboardSummaryBuilder.build(
-                      scope: itemState.scope,
-                      items: itemState.items,
-                      selectedFilter: itemState.selectedFilter,
-                    );
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
-                          child: GroupStatusSummary(summary: summary),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 20),
-                          child: GroupItemFilterChips(
-                            summary: summary,
-                            onSelected: _itemsStore.selectFilter,
+                  ValueListenableBuilder<GroupItemsState>(
+                    valueListenable: _itemsStore,
+                    builder: (context, itemState, _) {
+                      final summary = GroupDashboardSummaryBuilder.build(
+                        scope: itemState.scope,
+                        items: itemState.items,
+                        selectedFilter: itemState.selectedFilter,
+                      );
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+                            child: GroupStatusSummary(summary: summary),
                           ),
-                        ),
-                        GroupScopedItemList(
-                          items: summary.filteredItems,
-                          isLoading: itemState.isLoading,
-                          errorMessage: itemState.errorMessage,
-                          emptyMessage: summary.scope.isGroup
-                              ? '아직 이 그룹에 등록된 물품이 없습니다.'
-                              : '표시할 내 물품이 없습니다.',
-                          emptyActionLabel: summary.scope.isGroup
-                              ? '그룹에 제품 추가'
-                              : '내 물품 추가',
-                          onEmptyAction: () => _openScopedAdd(summary.scope),
-                        ),
-                      ],
-                    );
-                  },
-                ),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 20),
+                            child: GroupItemFilterChips(
+                              summary: summary,
+                              onSelected: _itemsStore.selectFilter,
+                            ),
+                          ),
+                          GroupScopedItemList(
+                            items: summary.filteredItems,
+                            isLoading: itemState.isLoading,
+                            errorMessage: itemState.errorMessage,
+                            emptyMessage: '아직 이 그룹에 등록된 물품이 없습니다.',
+                            emptyActionLabel: '그룹에 제품 추가',
+                            onEmptyAction: () => _openScopedAdd(selectedScope),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                ],
               ],
             ),
           );

--- a/lib/screens/group_screen.dart
+++ b/lib/screens/group_screen.dart
@@ -11,6 +11,7 @@ import '../services/supabase_service.dart';
 import '../theme/app_theme.dart';
 import '../widgets/group/group_item_filter_chips.dart';
 import '../widgets/group/group_scoped_item_list.dart';
+import '../widgets/group/group_settings_dialog.dart';
 import '../widgets/group/group_status_summary.dart';
 import '../widgets/group/item_scope_tabs.dart';
 import 'add_item_screen.dart';
@@ -82,6 +83,52 @@ class _GroupScreenState extends State<GroupScreen> {
     );
   }
 
+  void _openGroupSettings(BuylogGroup group) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return ValueListenableBuilder<GroupState>(
+          valueListenable: GroupStore.instance,
+          builder: (context, state, _) {
+            var currentGroup = group;
+            for (final candidate in state.visibleGroups) {
+              if (candidate.id == group.id) {
+                currentGroup = candidate;
+                break;
+              }
+            }
+
+            return GroupSettingsDialog(
+              group: currentGroup,
+              canRenameGroup: currentGroup.isOwner(
+                SupabaseService.currentUserId,
+              ),
+              isUpdatingGroup: state.isUpdatingGroup,
+              isRefreshingMembers: state.isRefreshingMembers,
+              isLeavingGroup: state.isLeavingGroup,
+              errorMessage: state.errorMessage,
+              onRenameGroup: (name) => GroupStore.instance.renameGroup(
+                groupId: currentGroup.id,
+                name: name,
+              ),
+              onCopyInviteCode: () => _copyInviteCode(currentGroup.inviteCode),
+              onRefreshMembers: () =>
+                  GroupStore.instance.refreshMembers(groupId: currentGroup.id),
+              onLeaveGroup: () {
+                Navigator.of(dialogContext).pop();
+                if (!mounted) return;
+                showDialog<void>(
+                  context: this.context,
+                  builder: (_) => _LeaveGroupDialog(group: currentGroup),
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -124,9 +171,11 @@ class _GroupScreenState extends State<GroupScreen> {
                       group: selectedGroup,
                       isRefreshingMembers: state.isRefreshingMembers,
                       isLeavingGroup: state.isLeavingGroup,
+                      isUpdatingGroup: state.isUpdatingGroup,
                       onRefreshMembers: () => GroupStore.instance
                           .refreshMembers(groupId: selectedGroup.id),
                       onCopyInviteCode: _copyInviteCode,
+                      onOpenSettings: () => _openGroupSettings(selectedGroup),
                     ),
                   )
                 else
@@ -273,15 +322,19 @@ class _GroupCard extends StatelessWidget {
     required this.group,
     required this.isRefreshingMembers,
     required this.isLeavingGroup,
+    required this.isUpdatingGroup,
     required this.onRefreshMembers,
     required this.onCopyInviteCode,
+    required this.onOpenSettings,
   });
 
   final BuylogGroup group;
   final bool isRefreshingMembers;
   final bool isLeavingGroup;
+  final bool isUpdatingGroup;
   final VoidCallback onRefreshMembers;
   final ValueChanged<String> onCopyInviteCode;
+  final VoidCallback onOpenSettings;
 
   @override
   Widget build(BuildContext context) {
@@ -319,6 +372,13 @@ class _GroupCard extends StatelessWidget {
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
               ),
+              IconButton(
+                tooltip: '그룹 설정',
+                onPressed: isLeavingGroup || isUpdatingGroup
+                    ? null
+                    : onOpenSettings,
+                icon: const Icon(Icons.settings_outlined),
+              ),
             ],
           ),
           const SizedBox(height: 20),
@@ -345,26 +405,6 @@ class _GroupCard extends StatelessWidget {
                   icon: const Icon(Icons.copy, size: 18),
                 ),
               ],
-            ),
-          ),
-          const SizedBox(height: 12),
-          Align(
-            alignment: Alignment.centerRight,
-            child: OutlinedButton.icon(
-              onPressed: isLeavingGroup
-                  ? null
-                  : () => showDialog<void>(
-                      context: context,
-                      builder: (_) => _LeaveGroupDialog(group: group),
-                    ),
-              icon: isLeavingGroup
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.logout, size: 18),
-              label: const Text('그룹 탈퇴'),
             ),
           ),
           const SizedBox(height: 20),

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -396,6 +396,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                           color: AppColors.textMuted,
                         ),
                       ),
+                      _buildRegistrantMeta(),
                     ],
                   ),
                 ),
@@ -405,6 +406,46 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                   size: 100,
                 ),
               ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRegistrantMeta() {
+    final registeredByLabel = _item.groupId == null
+        ? null
+        : _item.registeredByLabel;
+    if (registeredByLabel == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 10),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.person_add_alt_1_outlined,
+            size: 15,
+            color: AppColors.textMuted,
+          ),
+          const SizedBox(width: 6),
+          const Text(
+            '추가한 사람',
+            style: TextStyle(fontSize: 12, color: AppColors.textMuted),
+          ),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              registeredByLabel,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                fontSize: 12,
+                color: AppColors.textSecondary,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
         ],

--- a/lib/screens/items_screen.dart
+++ b/lib/screens/items_screen.dart
@@ -216,6 +216,9 @@ class ItemRow extends StatelessWidget {
     final tile = dense ? 36.0 : 40.0;
     final iconSize = dense ? 18.0 : 20.0;
     final cyclePart = item.aiPredictedDays ?? item.cycleDays;
+    final registeredByLabel = item.groupId == null
+        ? null
+        : item.registeredByLabel;
 
     return Material(
       color: Colors.transparent,
@@ -275,6 +278,18 @@ class ItemRow extends StatelessWidget {
                         color: AppColors.textMuted,
                       ),
                     ),
+                    if (registeredByLabel != null) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        '추가: $registeredByLabel',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          fontSize: 11.5,
+                          color: AppColors.textMuted,
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/lib/services/group_store.dart
+++ b/lib/services/group_store.dart
@@ -13,6 +13,7 @@ class GroupState {
     this.isSaving = false,
     this.isRefreshingMembers = false,
     this.isLeavingGroup = false,
+    this.isUpdatingGroup = false,
     this.errorMessage,
   });
 
@@ -25,6 +26,7 @@ class GroupState {
   final bool isSaving;
   final bool isRefreshingMembers;
   final bool isLeavingGroup;
+  final bool isUpdatingGroup;
   final String? errorMessage;
 
   List<BuylogGroup> get visibleGroups {
@@ -78,6 +80,7 @@ class GroupState {
     bool? isSaving,
     bool? isRefreshingMembers,
     bool? isLeavingGroup,
+    bool? isUpdatingGroup,
     Object? errorMessage = _unset,
   }) {
     final nextGroups = groups ?? this.groups;
@@ -93,6 +96,7 @@ class GroupState {
       isSaving: isSaving ?? this.isSaving,
       isRefreshingMembers: isRefreshingMembers ?? this.isRefreshingMembers,
       isLeavingGroup: isLeavingGroup ?? this.isLeavingGroup,
+      isUpdatingGroup: isUpdatingGroup ?? this.isUpdatingGroup,
       errorMessage: identical(errorMessage, _unset)
           ? this.errorMessage
           : errorMessage as String?,
@@ -152,6 +156,58 @@ class GroupStore extends ValueNotifier<GroupState> {
         selectedScope: previousState.selectedScope,
         isLoading: previousState.isLoading,
         errorMessage: '그룹을 만들지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+      rethrow;
+    }
+  }
+
+  Future<void> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    final trimmedGroupId = groupId.trim();
+    if (trimmedGroupId.isEmpty) {
+      throw ArgumentError.value(groupId, 'groupId', 'Group id is required.');
+    }
+
+    final trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'Group name is required.');
+    }
+
+    final previousState = value;
+    final currentGroup = previousState.groupForScope(
+      ItemScope.group(id: trimmedGroupId, label: ''),
+    );
+    if (currentGroup?.name == trimmedName || value.isUpdatingGroup) {
+      return;
+    }
+
+    value = previousState.copyWith(isUpdatingGroup: true, errorMessage: null);
+
+    try {
+      final updatedGroup = await SupabaseService.renameGroup(
+        groupId: trimmedGroupId,
+        name: trimmedName,
+      );
+      final updatedGroups = previousState.visibleGroups
+          .map((group) => group.id == updatedGroup.id ? updatedGroup : group)
+          .toList(growable: false);
+      final selectedScope =
+          previousState.selectedScope.isGroup &&
+              previousState.selectedScope.id == updatedGroup.id
+          ? ItemScope.group(id: updatedGroup.id, label: updatedGroup.name)
+          : previousState.selectedScope;
+
+      value = GroupState(
+        group: updatedGroups.isEmpty ? null : updatedGroups.first,
+        groups: updatedGroups,
+        selectedScope: selectedScope,
+      );
+    } catch (_) {
+      value = previousState.copyWith(
+        isUpdatingGroup: false,
+        errorMessage: '그룹 이름을 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.',
       );
       rethrow;
     }

--- a/lib/services/group_store.dart
+++ b/lib/services/group_store.dart
@@ -42,6 +42,26 @@ class GroupState {
     ];
   }
 
+  List<ItemScope> get availableGroupScopes {
+    return <ItemScope>[
+      for (final group in visibleGroups)
+        ItemScope.group(id: group.id, label: group.name),
+    ];
+  }
+
+  ItemScope? get selectedGroupScope {
+    if (selectedScope.isGroup &&
+        availableGroupScopes.any((scope) => scope == selectedScope)) {
+      return selectedScope;
+    }
+    return availableGroupScopes.isEmpty ? null : availableGroupScopes.first;
+  }
+
+  BuylogGroup? get selectedGroup {
+    final scope = selectedGroupScope;
+    return scope == null ? null : groupForScope(scope);
+  }
+
   BuylogGroup? groupForScope(ItemScope scope) {
     if (!scope.isGroup) return null;
     for (final group in visibleGroups) {
@@ -200,23 +220,23 @@ class GroupStore extends ValueNotifier<GroupState> {
         newOwnerUserId: newOwnerUserId,
       );
       final groups = await SupabaseService.loadGroupsForUser();
-      final selectedScope =
-          previousState.selectedScope.isGroup &&
-              previousState.selectedScope.id == trimmedGroupId
-          ? const ItemScope.personal()
-          : previousState.selectedScope;
-      final availableScopes = <ItemScope>[
-        const ItemScope.personal(),
+      final remainingScopes = <ItemScope>[
         for (final group in groups)
           ItemScope.group(id: group.id, label: group.name),
       ];
+      final previousSelectedStillExists = remainingScopes.any(
+        (scope) => scope == previousState.selectedScope,
+      );
+      final selectedScope = previousSelectedStillExists
+          ? previousState.selectedScope
+          : remainingScopes.isEmpty
+          ? const ItemScope.personal()
+          : remainingScopes.first;
 
       value = GroupState(
         group: groups.isEmpty ? null : groups.first,
         groups: groups,
-        selectedScope: availableScopes.contains(selectedScope)
-            ? selectedScope
-            : const ItemScope.personal(),
+        selectedScope: selectedScope,
       );
     } catch (_) {
       value = previousState.copyWith(

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -509,6 +509,11 @@ class SupabaseItemDatabaseGateway implements ItemDatabaseGateway {
           user_id,
           group_id,
           registered_by,
+          registered_by_user:users!product_items_registered_by_fkey (
+            id,
+            display_name,
+            email
+          ),
           name,
           brand,
           image_url,

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -121,6 +121,27 @@ class SupabaseService {
     return BuylogGroup.fromSupabase(createdGroup);
   }
 
+  static Future<BuylogGroup> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    final trimmedGroupId = groupId.trim();
+    if (trimmedGroupId.isEmpty) {
+      throw ArgumentError.value(groupId, 'groupId', 'Group id is required.');
+    }
+
+    final trimmedName = name.trim();
+    if (trimmedName.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'Group name is required.');
+    }
+
+    final updatedGroup = await _groupDatabaseGateway.renameGroup(
+      groupId: trimmedGroupId,
+      name: trimmedName,
+    );
+    return BuylogGroup.fromSupabase(updatedGroup);
+  }
+
   static Future<List<BuylogGroupMember>> loadGroupMembers({
     required String groupId,
   }) async {
@@ -370,6 +391,11 @@ abstract class GroupDatabaseGateway {
     required String inviteCode,
   });
 
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  });
+
   Future<List<Map<String, dynamic>>> loadGroupMembers({
     required String groupId,
   });
@@ -453,6 +479,20 @@ class SupabaseGroupDatabaseGateway implements GroupDatabaseGateway {
           'create_group_with_owner',
           params: {'group_name': name, 'group_invite_code': inviteCode},
         )
+        .select(_groupProjection)
+        .single();
+    return Map<String, dynamic>.from(row);
+  }
+
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    final row = await _client
+        .from('groups')
+        .update({'name': name})
+        .eq('id', groupId)
         .select(_groupProjection)
         .single();
     return Map<String, dynamic>.from(row);

--- a/lib/widgets/group/group_settings_dialog.dart
+++ b/lib/widgets/group/group_settings_dialog.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+
+import '../../models/group.dart';
+import '../../theme/app_theme.dart';
+
+class GroupSettingsDialog extends StatefulWidget {
+  const GroupSettingsDialog({
+    super.key,
+    required this.group,
+    required this.canRenameGroup,
+    required this.isUpdatingGroup,
+    required this.isRefreshingMembers,
+    required this.isLeavingGroup,
+    required this.errorMessage,
+    required this.onRenameGroup,
+    required this.onCopyInviteCode,
+    required this.onRefreshMembers,
+    required this.onLeaveGroup,
+  });
+
+  final BuylogGroup group;
+  final bool canRenameGroup;
+  final bool isUpdatingGroup;
+  final bool isRefreshingMembers;
+  final bool isLeavingGroup;
+  final String? errorMessage;
+  final Future<void> Function(String name) onRenameGroup;
+  final VoidCallback onCopyInviteCode;
+  final VoidCallback onRefreshMembers;
+  final VoidCallback onLeaveGroup;
+
+  @override
+  State<GroupSettingsDialog> createState() => _GroupSettingsDialogState();
+}
+
+class _GroupSettingsDialogState extends State<GroupSettingsDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.group.name);
+  }
+
+  @override
+  void didUpdateWidget(covariant GroupSettingsDialog oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.group.name != widget.group.name &&
+        _nameController.text != widget.group.name) {
+      _nameController.text = widget.group.name;
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitName() async {
+    if (!widget.canRenameGroup || widget.isUpdatingGroup) return;
+    if (!_formKey.currentState!.validate()) return;
+
+    final nextName = _nameController.text.trim();
+    if (nextName == widget.group.name) {
+      Navigator.of(context).pop();
+      return;
+    }
+
+    try {
+      await widget.onRenameGroup(nextName);
+      if (mounted) {
+        Navigator.of(context).pop();
+      }
+    } catch (_) {
+      if (mounted) {
+        setState(() {});
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final errorMessage = widget.errorMessage;
+
+    return AlertDialog(
+      title: const Text('그룹 설정'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Form(
+              key: _formKey,
+              child: TextFormField(
+                key: const Key('group-settings-name-field'),
+                controller: _nameController,
+                readOnly: !widget.canRenameGroup || widget.isUpdatingGroup,
+                textInputAction: TextInputAction.done,
+                decoration: const InputDecoration(labelText: '그룹 이름'),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '그룹 이름을 입력해 주세요.';
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (_) => _submitName(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            _SettingsActionButton(
+              icon: Icons.copy,
+              label: '초대 코드 복사',
+              value: widget.group.inviteCode,
+              onPressed: widget.onCopyInviteCode,
+            ),
+            const SizedBox(height: 8),
+            _SettingsActionButton(
+              icon: Icons.refresh,
+              label: '멤버 새로고침',
+              value: '최신 멤버 목록',
+              onPressed: widget.isRefreshingMembers
+                  ? null
+                  : widget.onRefreshMembers,
+            ),
+            const SizedBox(height: 16),
+            OutlinedButton.icon(
+              onPressed: widget.isLeavingGroup ? null : widget.onLeaveGroup,
+              icon: widget.isLeavingGroup
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.logout, size: 18),
+              label: const Text('그룹 탈퇴'),
+              style: OutlinedButton.styleFrom(
+                foregroundColor: AppColors.danger,
+              ),
+            ),
+            if (errorMessage?.isNotEmpty == true) ...[
+              const SizedBox(height: 12),
+              Text(
+                errorMessage!,
+                style: const TextStyle(color: AppColors.danger),
+              ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: widget.isUpdatingGroup
+              ? null
+              : () => Navigator.of(context).pop(),
+          child: const Text('닫기'),
+        ),
+        FilledButton(
+          onPressed: widget.canRenameGroup && !widget.isUpdatingGroup
+              ? _submitName
+              : null,
+          child: widget.isUpdatingGroup
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('저장'),
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsActionButton extends StatelessWidget {
+  const _SettingsActionButton({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onPressed,
+        icon: Icon(icon, size: 18),
+        label: Align(
+          alignment: Alignment.centerLeft,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(label),
+              Text(
+                value,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: AppColors.textMuted),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/main_navigation_test.dart
+++ b/test/main_navigation_test.dart
@@ -1,0 +1,98 @@
+import 'package:buylog/main.dart';
+import 'package:buylog/models/group.dart';
+import 'package:buylog/models/item_scope.dart';
+import 'package:buylog/services/group_store.dart';
+import 'package:buylog/services/item_store.dart';
+import 'package:buylog/services/supabase_service.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    GroupStore.instance.resetForTesting();
+    ItemStore.instance.value = [];
+    SupabaseService.debugItemDatabaseGateway = _RecordingItemDatabaseGateway();
+  });
+
+  tearDown(() {
+    GroupStore.instance.resetForTesting();
+    ItemStore.instance.value = [];
+    SupabaseService.debugItemDatabaseGateway = null;
+  });
+
+  testWidgets(
+    'group tab add action targets the first group when selected scope is personal',
+    (tester) async {
+      final gateway = _RecordingItemDatabaseGateway();
+      SupabaseService.debugItemDatabaseGateway = gateway;
+      GroupStore.instance.value = GroupState(
+        groups: <BuylogGroup>[_group()],
+        selectedScope: const ItemScope.personal(),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(theme: AppTheme.lightTheme, home: const MainNavigation()),
+      );
+
+      await tester.tap(find.text('그룹').last);
+      await tester.pump();
+      await tester.tap(find.byTooltip('제품 추가'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('직접 등록'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextFormField).first, '정수기 필터');
+      await tester.tap(find.text('등록 완료'));
+      await tester.pumpAndSettle();
+
+      expect(gateway.ensureCategoryUserId, isNull);
+      expect(gateway.ensureCategoryGroupId, 'group-1');
+      expect(gateway.upsertPayload?['group_id'], 'group-1');
+      expect(gateway.upsertPayload?['user_id'], isNull);
+    },
+  );
+}
+
+BuylogGroup _group() {
+  return BuylogGroup(
+    id: 'group-1',
+    name: '우리 가족',
+    inviteCode: 'BUY-ABC123',
+    createdBy: SupabaseService.currentUserId,
+    createdAt: DateTime.parse('2026-05-26T00:00:00.000Z'),
+    members: <BuylogGroupMember>[],
+  );
+}
+
+class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
+  String? ensureCategoryUserId;
+  String? ensureCategoryGroupId;
+  Map<String, dynamic>? upsertPayload;
+
+  @override
+  Future<List<Map<String, dynamic>>> loadItems({
+    required String? userId,
+    required String? groupId,
+  }) async {
+    return const <Map<String, dynamic>>[];
+  }
+
+  @override
+  Future<String> ensureCategory({
+    required String name,
+    required String? userId,
+    required String? groupId,
+  }) async {
+    ensureCategoryUserId = userId;
+    ensureCategoryGroupId = groupId;
+    return 'category-1';
+  }
+
+  @override
+  Future<void> upsertItem(Map<String, dynamic> payload) async {
+    upsertPayload = Map<String, dynamic>.from(payload);
+  }
+
+  @override
+  Future<void> insertPurchase(Map<String, dynamic> payload) async {}
+}

--- a/test/main_navigation_test.dart
+++ b/test/main_navigation_test.dart
@@ -35,28 +35,62 @@ void main() {
         MaterialApp(theme: AppTheme.lightTheme, home: const MainNavigation()),
       );
 
-      await tester.tap(find.text('그룹').last);
+      await tester.tap(find.byIcon(Icons.group_outlined));
       await tester.pump();
-      await tester.tap(find.byTooltip('제품 추가'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('직접 등록'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.byType(TextFormField).first, '정수기 필터');
-      await tester.tap(find.text('등록 완료'));
-      await tester.pumpAndSettle();
+      await _addManualItem(tester);
 
       expect(gateway.ensureCategoryUserId, isNull);
       expect(gateway.ensureCategoryGroupId, 'group-1');
       expect(gateway.upsertPayload?['group_id'], 'group-1');
       expect(gateway.upsertPayload?['user_id'], isNull);
+      expect(
+        gateway.upsertPayload?['registered_by'],
+        SupabaseService.currentUserId,
+      );
     },
   );
+
+  testWidgets('home tab add action still targets personal items', (
+    tester,
+  ) async {
+    final gateway = _RecordingItemDatabaseGateway();
+    SupabaseService.debugItemDatabaseGateway = gateway;
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: 'Family'),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(theme: AppTheme.lightTheme, home: const MainNavigation()),
+    );
+
+    await _addManualItem(tester);
+
+    expect(gateway.ensureCategoryUserId, SupabaseService.currentUserId);
+    expect(gateway.ensureCategoryGroupId, isNull);
+    expect(gateway.upsertPayload?['user_id'], SupabaseService.currentUserId);
+    expect(gateway.upsertPayload?['group_id'], isNull);
+    expect(
+      gateway.upsertPayload?['registered_by'],
+      SupabaseService.currentUserId,
+    );
+  });
+}
+
+Future<void> _addManualItem(WidgetTester tester) async {
+  await tester.tap(find.byType(FloatingActionButton));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byIcon(Icons.edit_outlined));
+  await tester.pumpAndSettle();
+  await tester.enterText(find.byType(TextFormField).first, 'filter');
+  await tester.tap(find.byType(FilledButton).last);
+  await tester.pumpAndSettle();
 }
 
 BuylogGroup _group() {
   return BuylogGroup(
     id: 'group-1',
-    name: '우리 가족',
+    name: 'Family',
     inviteCode: 'BUY-ABC123',
     createdBy: SupabaseService.currentUserId,
     createdAt: DateTime.parse('2026-05-26T00:00:00.000Z'),

--- a/test/main_navigation_test.dart
+++ b/test/main_navigation_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       await tester.tap(find.byIcon(Icons.group_outlined));
       await tester.pump();
-      await _addManualItem(tester);
+      await _addManualItem(tester, expectedSelectedScopeKey: 'group:group-1');
 
       expect(gateway.ensureCategoryUserId, isNull);
       expect(gateway.ensureCategoryGroupId, 'group-1');
@@ -64,7 +64,7 @@ void main() {
       MaterialApp(theme: AppTheme.lightTheme, home: const MainNavigation()),
     );
 
-    await _addManualItem(tester);
+    await _addManualItem(tester, expectedSelectedScopeKey: 'personal');
 
     expect(gateway.ensureCategoryUserId, SupabaseService.currentUserId);
     expect(gateway.ensureCategoryGroupId, isNull);
@@ -77,11 +77,20 @@ void main() {
   });
 }
 
-Future<void> _addManualItem(WidgetTester tester) async {
+Future<void> _addManualItem(
+  WidgetTester tester, {
+  required String expectedSelectedScopeKey,
+}) async {
   await tester.tap(find.byType(FloatingActionButton));
   await tester.pumpAndSettle();
   await tester.tap(find.byIcon(Icons.edit_outlined));
   await tester.pumpAndSettle();
+
+  final chip = tester.widget<ChoiceChip>(
+    find.byKey(ValueKey('add_item_scope_$expectedSelectedScopeKey')),
+  );
+  expect(chip.selected, isTrue);
+
   await tester.enterText(find.byType(TextFormField).first, 'filter');
   await tester.tap(find.byType(FilledButton).last);
   await tester.pumpAndSettle();

--- a/test/screens/add_item_screen_test.dart
+++ b/test/screens/add_item_screen_test.dart
@@ -1,5 +1,8 @@
+import 'package:buylog/models/group.dart';
+import 'package:buylog/models/item.dart';
 import 'package:buylog/models/item_scope.dart';
 import 'package:buylog/screens/add_item_screen.dart';
+import 'package:buylog/services/group_store.dart';
 import 'package:buylog/services/item_store.dart';
 import 'package:buylog/services/supabase_service.dart';
 import 'package:buylog/theme/app_theme.dart';
@@ -12,37 +15,147 @@ void main() {
   setUp(() {
     gateway = _RecordingItemDatabaseGateway();
     SupabaseService.debugItemDatabaseGateway = gateway;
+    GroupStore.instance.resetForTesting();
     ItemStore.instance.value = [];
   });
 
   tearDown(() {
     SupabaseService.debugItemDatabaseGateway = null;
+    GroupStore.instance.resetForTesting();
+    ItemStore.instance.value = [];
   });
 
-  testWidgets('manual group registration saves with selected group id', (
-    tester,
-  ) async {
+  testWidgets('personal target scope is selected by default', (tester) async {
+    _seedGroups();
+
+    await tester.pumpWidget(_wrap(const AddItemScreen()));
+
+    expect(_scopeChip('personal'), findsOneWidget);
+    expect(tester.widget<ChoiceChip>(_scopeChip('personal')).selected, isTrue);
+    expect(
+      tester.widget<ChoiceChip>(_scopeChip('group:group-1')).selected,
+      isFalse,
+    );
+  });
+
+  testWidgets('group target scope is selected by default', (tester) async {
+    _seedGroups();
+
     await tester.pumpWidget(
-      MaterialApp(
-        theme: AppTheme.lightTheme,
-        home: const AddItemScreen(
-          targetScope: ItemScope.group(id: 'group-1', label: '우리 가족'),
+      _wrap(
+        const AddItemScreen(
+          targetScope: ItemScope.group(id: 'group-1', label: 'Family'),
         ),
       ),
     );
 
-    await tester.enterText(find.byType(TextFormField).at(0), '세제');
-    await tester.enterText(find.byType(TextFormField).at(1), '브랜드');
-    await tester.enterText(find.byType(TextFormField).at(2), '30');
-    await tester.enterText(find.byType(TextFormField).at(3), '8900');
-    await tester.enterText(find.byType(TextFormField).at(4), '마트');
+    expect(tester.widget<ChoiceChip>(_scopeChip('personal')).selected, isFalse);
+    expect(
+      tester.widget<ChoiceChip>(_scopeChip('group:group-1')).selected,
+      isTrue,
+    );
+  });
 
-    await tester.tap(find.text('등록 완료'));
+  testWidgets('switching from personal to group saves with group id', (
+    tester,
+  ) async {
+    _seedGroups();
+
+    await tester.pumpWidget(_wrap(const AddItemScreen()));
+    await tester.tap(_scopeChip('group:group-1'));
+    await tester.pump();
+    await _submitMinimalItem(tester);
+
+    expect(gateway.upsertedItemPayload?['user_id'], isNull);
+    expect(gateway.upsertedItemPayload?['group_id'], 'group-1');
+  });
+
+  testWidgets('switching from group to personal saves as personal item', (
+    tester,
+  ) async {
+    _seedGroups();
+
+    await tester.pumpWidget(
+      _wrap(
+        const AddItemScreen(
+          targetScope: ItemScope.group(id: 'group-1', label: 'Family'),
+        ),
+      ),
+    );
+    await tester.tap(_scopeChip('personal'));
+    await tester.pump();
+    await _submitMinimalItem(tester);
+
+    expect(
+      gateway.upsertedItemPayload?['user_id'],
+      SupabaseService.currentUserId,
+    );
+    expect(gateway.upsertedItemPayload?['group_id'], isNull);
+  });
+
+  testWidgets('edit mode hides scope toggle and preserves item group scope', (
+    tester,
+  ) async {
+    _seedGroups();
+
+    await tester.pumpWidget(
+      _wrap(
+        AddItemScreen(
+          editItem: ConsumableItem(
+            id: 'item-1',
+            name: 'filter',
+            brand: 'Coway',
+            category: 'Kitchen',
+            icon: Icons.kitchen_outlined,
+            daysRemaining: 10,
+            cycleDays: 30,
+            progress: 0.2,
+            groupId: 'group-1',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('add_item_scope_toggle')), findsNothing);
+    await tester.tap(find.byType(FilledButton).last);
     await tester.pumpAndSettle();
 
-    expect(gateway.upsertedItemPayload?['group_id'], 'group-1');
     expect(gateway.upsertedItemPayload?['user_id'], isNull);
+    expect(gateway.upsertedItemPayload?['group_id'], 'group-1');
   });
+}
+
+Widget _wrap(Widget child) {
+  return MaterialApp(theme: AppTheme.lightTheme, home: child);
+}
+
+Finder _scopeChip(String storageKey) {
+  return find.byKey(ValueKey('add_item_scope_$storageKey'));
+}
+
+void _seedGroups() {
+  GroupStore.instance.value = GroupState(
+    groups: <BuylogGroup>[
+      BuylogGroup(
+        id: 'group-1',
+        name: 'Family',
+        inviteCode: 'BUY-ABC123',
+        createdBy: SupabaseService.currentUserId,
+        createdAt: DateTime.parse('2026-05-26T00:00:00.000Z'),
+      ),
+    ],
+    selectedScope: const ItemScope.group(id: 'group-1', label: 'Family'),
+  );
+}
+
+Future<void> _submitMinimalItem(WidgetTester tester) async {
+  await tester.enterText(find.byType(TextFormField).at(0), 'filter');
+  await tester.enterText(find.byType(TextFormField).at(1), 'Coway');
+  await tester.enterText(find.byType(TextFormField).at(2), '30');
+  await tester.enterText(find.byType(TextFormField).at(3), '8900');
+  await tester.enterText(find.byType(TextFormField).at(4), 'Market');
+  await tester.tap(find.byType(FilledButton).last);
+  await tester.pumpAndSettle();
 }
 
 class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
@@ -53,7 +166,7 @@ class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
     required String? userId,
     required String? groupId,
   }) async {
-    return const [];
+    return const <Map<String, dynamic>>[];
   }
 
   @override

--- a/test/screens/group_screen_test.dart
+++ b/test/screens/group_screen_test.dart
@@ -232,6 +232,52 @@ void main() {
     expect(find.text('멤버 1명'), findsOneWidget);
   });
 
+  testWidgets('group leave action is only shown inside settings dialog', (
+    tester,
+  ) async {
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+
+    expect(find.text('그룹 탈퇴'), findsNothing);
+    expect(find.byTooltip('그룹 설정'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('그룹 설정'), findsOneWidget);
+    expect(find.text('그룹 탈퇴'), findsOneWidget);
+  });
+
+  testWidgets('owner renames group from settings dialog', (tester) async {
+    final gateway = _FakeGroupDatabaseGateway();
+    SupabaseService.debugGroupDatabaseGateway = gateway;
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group()],
+      selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const Key('group-settings-name-field')),
+      '새 가족',
+    );
+    await tester.tap(find.text('저장'));
+    await tester.pumpAndSettle();
+
+    expect(gateway.renameGroupCalls, 1);
+    expect(gateway.renameGroupGroupId, 'group-1');
+    expect(gateway.renameGroupName, '새 가족');
+    expect(GroupStore.instance.value.selectedScope.label, '새 가족');
+    expect(find.text('새 가족'), findsAtLeastNWidgets(1));
+  });
+
   testWidgets('member can confirm leaving a group', (tester) async {
     final gateway = _FakeGroupDatabaseGateway();
     SupabaseService.debugGroupDatabaseGateway = gateway;
@@ -253,6 +299,8 @@ void main() {
     );
 
     await tester.pumpWidget(_wrap());
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('그룹 탈퇴'));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -274,6 +322,8 @@ void main() {
     );
 
     await tester.pumpWidget(_wrap());
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('그룹 탈퇴'));
     await tester.pumpAndSettle();
     await tester.tap(find.byType(DropdownButtonFormField<String>));
@@ -301,6 +351,8 @@ void main() {
     );
 
     await tester.pumpWidget(_wrap());
+    await tester.tap(find.byTooltip('그룹 설정'));
+    await tester.pumpAndSettle();
     await tester.tap(find.text('그룹 탈퇴'));
     await tester.pumpAndSettle();
     await tester.tap(
@@ -485,11 +537,14 @@ class _FakeGroupDatabaseGateway implements GroupDatabaseGateway {
   int createGroupWithOwnerCalls = 0;
   int loadGroupMembersCalls = 0;
   int leaveGroupCalls = 0;
+  int renameGroupCalls = 0;
   Map<String, dynamic>? createdGroupValues;
   Object? createGroupWithOwnerError;
   List<Map<String, dynamic>> loadGroupMembersResult = const [];
   String? leaveGroupGroupId;
   String? leaveGroupNewOwnerUserId;
+  String? renameGroupGroupId;
+  String? renameGroupName;
   Map<String, dynamic>? _currentGroup;
 
   @override
@@ -522,6 +577,19 @@ class _FakeGroupDatabaseGateway implements GroupDatabaseGateway {
       'invite_code': inviteCode,
     };
     final group = _groupRow(name: name, inviteCode: inviteCode);
+    _currentGroup = group;
+    return group;
+  }
+
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    renameGroupCalls += 1;
+    renameGroupGroupId = groupId;
+    renameGroupName = name;
+    final group = _groupRow(id: groupId, name: name);
     _currentGroup = group;
     return group;
   }

--- a/test/screens/group_screen_test.dart
+++ b/test/screens/group_screen_test.dart
@@ -123,7 +123,7 @@ void main() {
     expect(find.text('관리자'), findsOneWidget);
   });
 
-  testWidgets('renders scope tabs and switches selected group tab', (
+  testWidgets('renders group scope tabs and switches selected group tab', (
     WidgetTester tester,
   ) async {
     GroupStore.instance.value = GroupState(
@@ -135,8 +135,8 @@ void main() {
 
     await tester.pumpWidget(_wrap());
 
-    expect(find.text('내 물품'), findsOneWidget);
-    expect(find.text('우리 가족'), findsOneWidget);
+    expect(find.text('내 물품'), findsNothing);
+    expect(find.text('우리 가족'), findsAtLeastNWidgets(1));
     expect(find.text('사무실'), findsOneWidget);
 
     await tester.tap(find.text('사무실'));
@@ -147,6 +147,58 @@ void main() {
       const ItemScope.group(id: 'group-2', label: '사무실'),
     );
   });
+
+  testWidgets('group screen hides personal item tab and personal item list', (
+    tester,
+  ) async {
+    GroupStore.instance.value = GroupState(
+      groups: <BuylogGroup>[_group(id: 'group-1', name: '우리 가족')],
+      selectedScope: const ItemScope.personal(),
+    );
+
+    await tester.pumpWidget(_wrap());
+    await tester.pump();
+
+    expect(find.text('내 물품'), findsNothing);
+    expect(find.text('내 물품 목록'), findsNothing);
+    expect(find.text('우리 가족'), findsAtLeastNWidgets(1));
+    expect(find.text('우리 가족 목록'), findsOneWidget);
+  });
+
+  testWidgets(
+    'group screen loads first group items when selected scope is personal',
+    (tester) async {
+      final itemGateway = _RecordingItemDatabaseGateway()
+        ..loadItemsResult = <Map<String, dynamic>>[
+          _itemRow(id: 'group-item-1', groupId: 'group-1'),
+        ];
+      SupabaseService.debugItemDatabaseGateway = itemGateway;
+      GroupStore.instance.value = GroupState(
+        groups: <BuylogGroup>[_group(id: 'group-1', name: '우리 가족')],
+        selectedScope: const ItemScope.personal(),
+      );
+
+      await tester.pumpWidget(_wrap());
+      await tester.pump();
+
+      expect(itemGateway.lastUserId, isNull);
+      expect(itemGateway.lastGroupId, 'group-1');
+      expect(find.text('group-item-1'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'empty group state does not render item dashboard or list heading',
+    (tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.pump();
+
+      expect(find.text('그룹'), findsOneWidget);
+      expect(find.text('아직 연결된 그룹이 없습니다.'), findsOneWidget);
+      expect(find.text('전체'), findsNothing);
+      expect(find.textContaining('목록'), findsNothing);
+    },
+  );
 
   testWidgets('member refresh button reloads and renders latest members', (
     WidgetTester tester,
@@ -575,6 +627,8 @@ Map<String, dynamic> _itemRow({
 
 class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
   int loadItemsCalls = 0;
+  String? lastUserId;
+  String? lastGroupId;
   List<Map<String, dynamic>> loadItemsResult = const [];
 
   @override
@@ -583,6 +637,8 @@ class _RecordingItemDatabaseGateway implements ItemDatabaseGateway {
     required String? groupId,
   }) async {
     loadItemsCalls += 1;
+    lastUserId = userId;
+    lastGroupId = groupId;
     return loadItemsResult;
   }
 

--- a/test/screens/item_detail_screen_test.dart
+++ b/test/screens/item_detail_screen_test.dart
@@ -1,0 +1,45 @@
+import 'package:buylog/models/item.dart';
+import 'package:buylog/screens/item_detail_screen.dart';
+import 'package:buylog/services/item_store.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  setUp(() {
+    dotenv.loadFromString(envString: '', isOptional: true);
+    ItemStore.instance.value = [];
+  });
+
+  tearDown(() {
+    ItemStore.instance.value = [];
+  });
+
+  testWidgets('group item detail shows the registrant label', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: ItemDetailScreen(
+          item: ConsumableItem(
+            id: 'item-1',
+            name: 'filter',
+            brand: 'Coway',
+            category: 'filter',
+            icon: Icons.filter_alt_outlined,
+            daysRemaining: 20,
+            cycleDays: 30,
+            progress: 0.3,
+            groupId: 'group-1',
+            registeredBy: 'user-1',
+            registeredByDisplayName: 'Minseo',
+            registeredByEmail: 'minseo@example.com',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('추가한 사람'), findsOneWidget);
+    expect(find.text('Minseo'), findsOneWidget);
+  });
+}

--- a/test/services/group_store_test.dart
+++ b/test/services/group_store_test.dart
@@ -313,6 +313,74 @@ void main() {
       expect(GroupStore.instance.value.selectedGroup?.id, 'group-2');
     });
 
+    test('renames selected group and updates selected scope label', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+      await GroupStore.instance.initialize();
+      GroupStore.instance.selectScope(
+        const ItemScope.group(id: 'group-1', label: '우리 가족'),
+      );
+
+      await GroupStore.instance.renameGroup(
+        groupId: ' group-1 ',
+        name: '  새 가족  ',
+      );
+
+      expect(gateway.renameGroupCalls, 1);
+      expect(gateway.renameGroupGroupId, 'group-1');
+      expect(gateway.renameGroupName, '새 가족');
+      expect(GroupStore.instance.value.groups.first.name, '새 가족');
+      expect(
+        GroupStore.instance.value.selectedScope,
+        const ItemScope.group(id: 'group-1', label: '새 가족'),
+      );
+      expect(GroupStore.instance.value.isUpdatingGroup, isFalse);
+      expect(GroupStore.instance.value.errorMessage, isNull);
+    });
+
+    test('keeps previous group state when rename fails', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+      ];
+      await GroupStore.instance.initialize();
+      gateway.renameGroupError = StateError('rename failed');
+
+      await expectLater(
+        GroupStore.instance.renameGroup(groupId: 'group-1', name: '새 가족'),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            'rename failed',
+          ),
+        ),
+      );
+
+      expect(GroupStore.instance.value.groups.single.name, '우리 가족');
+      expect(GroupStore.instance.value.isUpdatingGroup, isFalse);
+      expect(
+        GroupStore.instance.value.errorMessage,
+        '그룹 이름을 변경하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      );
+    });
+
+    test('rejects blank rename values before gateway call', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+      ];
+      await GroupStore.instance.initialize();
+
+      await expectLater(
+        GroupStore.instance.renameGroup(groupId: 'group-1', name: '   '),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      expect(gateway.renameGroupCalls, 0);
+      expect(GroupStore.instance.value.groups.single.name, '우리 가족');
+    });
+
     test(
       'restores previous state and sets Korean error message when creation fails',
       () async {
@@ -566,13 +634,17 @@ class _RecordingGroupDatabaseGateway implements GroupDatabaseGateway {
   int loadGroupsForUserCalls = 0;
   int loadGroupMembersCalls = 0;
   int leaveGroupCalls = 0;
+  int renameGroupCalls = 0;
   Object? loadDefaultGroupError;
   Object? loadGroupsForUserError;
   Object? loadGroupMembersError;
   Object? leaveGroupError;
+  Object? renameGroupError;
   String? loadGroupMembersGroupId;
   String? leaveGroupGroupId;
   String? leaveGroupNewOwnerUserId;
+  String? renameGroupGroupId;
+  String? renameGroupName;
   Map<String, dynamic>? loadDefaultGroupResult;
   List<Map<String, dynamic>> loadGroupsForUserResult = const [];
   Map<String, dynamic>? createdGroupValues;
@@ -623,6 +695,20 @@ class _RecordingGroupDatabaseGateway implements GroupDatabaseGateway {
       'created_at': '2026-05-26T00:00:00.000Z',
       'group_members': <Map<String, dynamic>>[],
     };
+  }
+
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    renameGroupCalls += 1;
+    renameGroupGroupId = groupId;
+    renameGroupName = name;
+    if (renameGroupError != null) {
+      throw renameGroupError!;
+    }
+    return _groupRow(id: groupId, name: name);
   }
 
   @override

--- a/test/services/group_store_test.dart
+++ b/test/services/group_store_test.dart
@@ -260,6 +260,59 @@ void main() {
       expect(GroupStore.instance.value.selectedScope.label, '우리 가족');
     });
 
+    test('exposes group-only scopes without the personal scope', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+
+      await GroupStore.instance.initialize();
+
+      final scopes = GroupStore.instance.value.availableGroupScopes;
+      expect(scopes.map((scope) => scope.label), ['우리 가족', '사무실']);
+      expect(scopes.every((scope) => scope.isGroup), isTrue);
+    });
+
+    test(
+      'uses the first joined group as selectedGroupScope fallback',
+      () async {
+        gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+          _groupRow(id: 'group-1', name: '우리 가족'),
+          _groupRow(id: 'group-2', name: '사무실'),
+        ];
+
+        await GroupStore.instance.initialize();
+
+        expect(
+          GroupStore.instance.value.selectedScope,
+          const ItemScope.personal(),
+        );
+        expect(
+          GroupStore.instance.value.selectedGroupScope,
+          const ItemScope.group(id: 'group-1', label: '우리 가족'),
+        );
+        expect(GroupStore.instance.value.selectedGroup?.id, 'group-1');
+      },
+    );
+
+    test('keeps the selected joined group as selectedGroupScope', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+      await GroupStore.instance.initialize();
+
+      GroupStore.instance.selectScope(
+        const ItemScope.group(id: 'group-2', label: '사무실'),
+      );
+
+      expect(
+        GroupStore.instance.value.selectedGroupScope,
+        const ItemScope.group(id: 'group-2', label: '사무실'),
+      );
+      expect(GroupStore.instance.value.selectedGroup?.id, 'group-2');
+    });
+
     test(
       'restores previous state and sets Korean error message when creation fails',
       () async {
@@ -376,10 +429,35 @@ void main() {
       ]);
       expect(
         GroupStore.instance.value.selectedScope,
-        const ItemScope.personal(),
+        const ItemScope.group(id: 'group-2', label: '사무실'),
       );
       expect(GroupStore.instance.value.isLeavingGroup, isFalse);
       expect(GroupStore.instance.value.errorMessage, isNull);
+    });
+
+    test('selects the next group after leaving the selected group', () async {
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-1', name: '우리 가족'),
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+      await GroupStore.instance.initialize();
+      GroupStore.instance.selectScope(
+        const ItemScope.group(id: 'group-1', label: '우리 가족'),
+      );
+      gateway.loadGroupsForUserResult = <Map<String, dynamic>>[
+        _groupRow(id: 'group-2', name: '사무실'),
+      ];
+
+      await GroupStore.instance.leaveGroup(groupId: 'group-1');
+
+      expect(
+        GroupStore.instance.value.selectedScope,
+        const ItemScope.group(id: 'group-2', label: '사무실'),
+      );
+      expect(
+        GroupStore.instance.value.selectedGroupScope,
+        const ItemScope.group(id: 'group-2', label: '사무실'),
+      );
     });
 
     test('passes owner delegation user id when leaving as owner', () async {

--- a/test/services/supabase_service_test.dart
+++ b/test/services/supabase_service_test.dart
@@ -443,6 +443,50 @@ void main() {
       expect(gateway.lastUserId, isNull);
       expect(gateway.lastGroupId, 'group-1');
     });
+
+    test('maps registered user display data for group items', () async {
+      final gateway = _RecordingItemDatabaseGateway()
+        ..loadItemsResult = <Map<String, dynamic>>[
+          _itemRow(id: 'group-item-1', groupId: 'group-1')
+            ..['registered_by_user'] = <String, dynamic>{
+              'id': SupabaseService.currentUserId,
+              'display_name': 'Minseo',
+              'email': 'minseo@example.com',
+            },
+        ];
+      SupabaseService.debugItemDatabaseGateway = gateway;
+
+      final items = await SupabaseService.loadItemsForScope(
+        const ItemScope.group(id: 'group-1', label: 'Family'),
+      );
+
+      expect(items.single.registeredBy, SupabaseService.currentUserId);
+      expect(items.single.registeredByDisplayName, 'Minseo');
+      expect(items.single.registeredByEmail, 'minseo@example.com');
+      expect(items.single.registeredByLabel, 'Minseo');
+    });
+
+    test(
+      'uses registered user email as label when display name is blank',
+      () async {
+        final gateway = _RecordingItemDatabaseGateway()
+          ..loadItemsResult = <Map<String, dynamic>>[
+            _itemRow(id: 'group-item-1', groupId: 'group-1')
+              ..['registered_by_user'] = <String, dynamic>{
+                'id': SupabaseService.currentUserId,
+                'display_name': '   ',
+                'email': 'minseo@example.com',
+              },
+          ];
+        SupabaseService.debugItemDatabaseGateway = gateway;
+
+        final items = await SupabaseService.loadItemsForScope(
+          const ItemScope.group(id: 'group-1', label: 'Family'),
+        );
+
+        expect(items.single.registeredByLabel, 'minseo@example.com');
+      },
+    );
   });
 
   group('SupabaseService.saveItem scoped ownership', () {

--- a/test/services/supabase_service_test.dart
+++ b/test/services/supabase_service_test.dart
@@ -14,11 +14,14 @@ class _RecordingGroupDatabaseGateway implements GroupDatabaseGateway {
   int createGroupWithOwnerCalls = 0;
   int loadGroupMembersCalls = 0;
   int leaveGroupCalls = 0;
+  int renameGroupCalls = 0;
   String? createGroupWithOwnerName;
   String? createGroupWithOwnerInviteCode;
   String? loadGroupMembersGroupId;
   String? leaveGroupGroupId;
   String? leaveGroupNewOwnerUserId;
+  String? renameGroupGroupId;
+  String? renameGroupName;
   Map<String, dynamic>? loadDefaultGroupResult;
   List<Map<String, dynamic>> loadGroupsForUserResult = const [];
   Map<String, dynamic>? createGroupWithOwnerResult;
@@ -70,6 +73,24 @@ class _RecordingGroupDatabaseGateway implements GroupDatabaseGateway {
             },
           ],
         };
+  }
+
+  @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) async {
+    renameGroupCalls += 1;
+    renameGroupGroupId = groupId;
+    renameGroupName = name;
+    return <String, dynamic>{
+      'id': groupId,
+      'name': name,
+      'invite_code': 'BUY-ABC123',
+      'created_by': SupabaseService.currentUserId,
+      'created_at': '2026-05-26T00:00:00.000Z',
+      'group_members': <Map<String, dynamic>>[],
+    };
   }
 
   @override
@@ -291,6 +312,64 @@ void main() {
       expect(gateway.createGroupWithOwnerCalls, 1);
       expect(gateway.createGroupWithOwnerName, 'Group Name');
       expect(gateway.loadDefaultGroupCalls, 0);
+    });
+  });
+
+  group('SupabaseService.renameGroup', () {
+    tearDown(() {
+      SupabaseService.debugGroupDatabaseGateway = null;
+    });
+
+    test('trims group id and name before gateway update', () async {
+      final gateway = _RecordingGroupDatabaseGateway();
+      SupabaseService.debugGroupDatabaseGateway = gateway;
+
+      final group = await SupabaseService.renameGroup(
+        groupId: ' group-1 ',
+        name: '  새 가족  ',
+      );
+
+      expect(gateway.renameGroupCalls, 1);
+      expect(gateway.renameGroupGroupId, 'group-1');
+      expect(gateway.renameGroupName, '새 가족');
+      expect(group.id, 'group-1');
+      expect(group.name, '새 가족');
+    });
+
+    test('rejects blank group ids without calling gateway', () async {
+      final gateway = _RecordingGroupDatabaseGateway();
+      SupabaseService.debugGroupDatabaseGateway = gateway;
+
+      await expectLater(
+        SupabaseService.renameGroup(groupId: '   ', name: '새 가족'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            'Group id is required.',
+          ),
+        ),
+      );
+
+      expect(gateway.renameGroupCalls, 0);
+    });
+
+    test('rejects blank names without calling gateway', () async {
+      final gateway = _RecordingGroupDatabaseGateway();
+      SupabaseService.debugGroupDatabaseGateway = gateway;
+
+      await expectLater(
+        SupabaseService.renameGroup(groupId: 'group-1', name: '   '),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            'Group name is required.',
+          ),
+        ),
+      );
+
+      expect(gateway.renameGroupCalls, 0);
     });
   });
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -102,6 +102,14 @@ class _ThrowingGroupDatabaseGateway implements GroupDatabaseGateway {
   }
 
   @override
+  Future<Map<String, dynamic>> renameGroup({
+    required String groupId,
+    required String name,
+  }) {
+    throw UnsupportedError('renameGroup is not used in this test');
+  }
+
+  @override
   Future<List<Map<String, dynamic>>> loadGroupMembers({
     required String groupId,
   }) {

--- a/test/widgets/group/item_scope_tabs_test.dart
+++ b/test/widgets/group/item_scope_tabs_test.dart
@@ -34,4 +34,33 @@ void main() {
     await tester.tap(find.text('사무실'));
     expect(selected, const ItemScope.group(id: 'group-2', label: '사무실'));
   });
+
+  testWidgets('renders group-only tabs when personal scope is not provided', (
+    tester,
+  ) async {
+    ItemScope? selected;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: ItemScopeTabs(
+            scopes: const <ItemScope>[
+              ItemScope.group(id: 'group-1', label: '우리 가족'),
+              ItemScope.group(id: 'group-2', label: '사무실'),
+            ],
+            selectedScope: const ItemScope.group(id: 'group-1', label: '우리 가족'),
+            onSelected: (scope) => selected = scope,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('내 물품'), findsNothing);
+    expect(find.text('우리 가족'), findsOneWidget);
+    expect(find.text('사무실'), findsOneWidget);
+
+    await tester.tap(find.text('사무실'));
+    expect(selected, const ItemScope.group(id: 'group-2', label: '사무실'));
+  });
 }

--- a/test/widgets/item_row_test.dart
+++ b/test/widgets/item_row_test.dart
@@ -1,0 +1,69 @@
+import 'package:buylog/models/item.dart';
+import 'package:buylog/screens/items_screen.dart';
+import 'package:buylog/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('group item row shows the registrant label', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: ItemRow(
+            item: _item(
+              groupId: 'group-1',
+              registeredByDisplayName: 'Minseo',
+              registeredByEmail: 'minseo@example.com',
+            ),
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('추가: Minseo'), findsOneWidget);
+  });
+
+  testWidgets('personal item row does not show registrant metadata', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: ItemRow(
+            item: _item(
+              registeredByDisplayName: 'Minseo',
+              registeredByEmail: 'minseo@example.com',
+            ),
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('추가:'), findsNothing);
+  });
+}
+
+ConsumableItem _item({
+  String? groupId,
+  String? registeredByDisplayName,
+  String? registeredByEmail,
+}) {
+  return ConsumableItem(
+    id: 'item-1',
+    name: 'filter',
+    brand: 'Coway',
+    category: 'filter',
+    icon: Icons.filter_alt_outlined,
+    daysRemaining: 20,
+    cycleDays: 30,
+    progress: 0.3,
+    groupId: groupId,
+    registeredBy: 'user-1',
+    registeredByDisplayName: registeredByDisplayName,
+    registeredByEmail: registeredByEmail,
+  );
+}


### PR DESCRIPTION
## 변경 사항
- 그룹 페이지를 그룹 전용 탭/목록 흐름으로 정리
- 그룹 페이지 내 빠른 추가/스캔/그룹 생성 액션 추가
- 그룹 물품 등록자 표시 및 그룹 추가 기본 스코프 보강
- 그룹 설정 팝업 추가
- 설정 팝업에서 그룹 이름 변경, 초대 코드 복사, 멤버 새로고침, 그룹 탈퇴 진입 지원
- `develop` 최신 변경분 병합 및 충돌 해결

## 변경 이유
- 그룹 탈퇴 액션을 카드에 직접 노출하지 않고 설정 팝업 안에서 처리하도록 UX를 정리하기 위해
- 그룹 페이지에서 개인 물품 흐름과 섞이지 않도록 그룹 전용 사용 흐름을 명확히 하기 위해
- 그룹 이름 변경 같은 추가 설정 액션을 확장 가능한 구조로 분리하기 위해

## 테스트
- `flutter analyze --no-fatal-infos`
- `flutter test test/services/group_store_test.dart test/screens/group_screen_test.dart test/main_navigation_test.dart test/screens/add_item_screen_test.dart`
- `flutter test`

## 리뷰 포인트
- 그룹 설정 팝업 내 액션 배치
- 그룹 이름 변경 후 선택된 그룹 scope label 동기화
- `develop` 병합 충돌 해결 결과