### PR TITLE
MIDAS 재고 수량 Supabase 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ app.*.map.json
 
 # env
 .env
+
+# MIDAS runtime artifacts
+hardware/MIDAS/uploads/
+hardware/MIDAS/results/

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ app.*.map.json
 
 # env
 .env
+supabase/.temp/
 
 # MIDAS runtime artifacts
 hardware/MIDAS/uploads/

--- a/hardware/MIDAS/inventory_sync.py
+++ b/hardware/MIDAS/inventory_sync.py
@@ -1,0 +1,272 @@
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any
+import os
+import re
+
+try:
+    from supabase import create_client
+except ImportError:
+    create_client = None
+
+
+@dataclass(frozen=True)
+class InventoryOwner:
+    user_id: str | None
+    group_id: str | None
+
+    def to_observation_owner(self) -> dict[str, str | None]:
+        if bool(self.user_id) == bool(self.group_id):
+            raise ValueError("Exactly one of user_id or group_id is required.")
+        return {"user_id": self.user_id, "group_id": self.group_id}
+
+
+@dataclass(frozen=True)
+class ItemMatch:
+    product_item_id: str | None
+    status: str
+    score: float | None
+
+
+def normalize_name(value: str) -> str:
+    normalized = re.sub(r"\s+", "", value.strip().lower())
+    return re.sub(r"[^0-9a-z가-힣]", "", normalized)
+
+
+def optional_float(value: str | None) -> float | None:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def make_client_from_env():
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        return None
+    if create_client is None:
+        raise RuntimeError("Install the supabase package before enabling inventory sync.")
+    return create_client(url, key)
+
+
+def owner_from_env() -> InventoryOwner | None:
+    user_id = (os.getenv("BUYLOG_CAPTURE_USER_ID") or "").strip() or None
+    group_id = (os.getenv("BUYLOG_CAPTURE_GROUP_ID") or "").strip() or None
+    if not user_id and not group_id:
+        return None
+    return InventoryOwner(user_id=user_id, group_id=group_id)
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_confidence(value: Any) -> float:
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    return max(0.0, min(confidence, 1.0))
+
+
+def _match_score(detected: str, candidate: str) -> float:
+    if not detected or not candidate:
+        return 0.0
+    if detected == candidate:
+        return 1.0
+    if detected in candidate or candidate in detected:
+        shorter = min(len(detected), len(candidate))
+        longer = max(len(detected), len(candidate))
+        return max(0.9, shorter / longer)
+    return SequenceMatcher(None, detected, candidate).ratio()
+
+
+def match_detected_item(
+    *,
+    detected_name: str,
+    catalog: list[dict[str, Any]],
+    confidence: float,
+    min_confidence: float,
+    min_match_score: float,
+) -> ItemMatch:
+    if confidence < min_confidence:
+        return ItemMatch(product_item_id=None, status="low_confidence", score=None)
+
+    detected = normalize_name(detected_name)
+    if not detected:
+        return ItemMatch(product_item_id=None, status="unmatched", score=None)
+
+    scored: list[tuple[float, dict[str, Any]]] = []
+    for product in catalog:
+        candidates = [
+            normalize_name(str(product.get("name") or "")),
+            normalize_name(f"{product.get('brand') or ''}{product.get('name') or ''}"),
+        ]
+        best_score = max((_match_score(detected, candidate) for candidate in candidates), default=0.0)
+        scored.append((best_score, product))
+
+    if not scored:
+        return ItemMatch(product_item_id=None, status="unmatched", score=None)
+
+    scored.sort(key=lambda entry: entry[0], reverse=True)
+    top_score, top_product = scored[0]
+    second_score = scored[1][0] if len(scored) > 1 else 0.0
+
+    if top_score < min_match_score:
+        return ItemMatch(product_item_id=None, status="unmatched", score=top_score)
+    if second_score >= min_match_score and (top_score - second_score) < 0.05:
+        return ItemMatch(product_item_id=None, status="ambiguous", score=top_score)
+
+    return ItemMatch(
+        product_item_id=str(top_product["id"]),
+        status="matched",
+        score=top_score,
+    )
+
+
+def build_detected_item_records(
+    *,
+    items: list[dict[str, Any]],
+    catalog: list[dict[str, Any]],
+    min_confidence: float,
+    min_match_score: float,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for item in items:
+        detected_name = str(item.get("item_name") or "").strip()
+        if not detected_name:
+            continue
+
+        quantity = max(_safe_int(item.get("quantity")), 0)
+        confidence = _safe_confidence(item.get("confidence"))
+        match = match_detected_item(
+            detected_name=detected_name,
+            catalog=catalog,
+            confidence=confidence,
+            min_confidence=min_confidence,
+            min_match_score=min_match_score,
+        )
+
+        records.append(
+            {
+                "product_item_id": match.product_item_id,
+                "detected_name": detected_name,
+                "normalized_name": normalize_name(detected_name),
+                "quantity": quantity,
+                "confidence": confidence,
+                "note": str(item.get("note") or "").strip() or None,
+                "match_status": match.status,
+                "match_score": match.score,
+            }
+        )
+    return records
+
+
+class InventorySync:
+    def __init__(
+        self,
+        *,
+        db,
+        owner: InventoryOwner,
+        min_confidence: float = 0.6,
+        min_match_score: float = 0.82,
+    ):
+        self.db = db
+        self.owner = owner
+        self.min_confidence = min_confidence
+        self.min_match_score = min_match_score
+
+    def load_catalog(self) -> list[dict[str, Any]]:
+        query = self.db.table("product_items").select("id,name,brand,user_id,group_id")
+        if self.owner.group_id:
+            query = query.eq("group_id", self.owner.group_id)
+        else:
+            query = query.eq("user_id", self.owner.user_id)
+        response = query.execute()
+        return list(response.data or [])
+
+    def persist_analysis(
+        self,
+        *,
+        device_id: str,
+        image_file: str,
+        txt_file: str,
+        gpt_ok: bool,
+        analysis_result: dict[str, Any],
+        sensor_id: str | None,
+        weight_g: float | None,
+        delta_g: float | None,
+    ) -> dict[str, Any]:
+        observation_payload = {
+            **self.owner.to_observation_owner(),
+            "device_id": device_id,
+            "image_file": image_file,
+            "txt_file": txt_file,
+            "summary": analysis_result.get("summary") or "",
+            "raw_result": analysis_result,
+            "gpt_ok": gpt_ok,
+            "sensor_id": sensor_id or None,
+            "weight_g": weight_g,
+            "delta_g": delta_g,
+        }
+
+        observation_rows = (
+            self.db.table("inventory_observations")
+            .insert(observation_payload)
+            .select("id,observed_at")
+            .execute()
+        ).data
+        observation = observation_rows[0]
+
+        item_records = build_detected_item_records(
+            items=list(analysis_result.get("items") or []),
+            catalog=self.load_catalog(),
+            min_confidence=self.min_confidence,
+            min_match_score=self.min_match_score,
+        )
+
+        inserted_items = []
+        if item_records:
+            item_payload = [
+                {"observation_id": observation["id"], **record}
+                for record in item_records
+            ]
+            inserted_items = (
+                self.db.table("inventory_observation_items")
+                .insert(item_payload)
+                .select(
+                    "id,product_item_id,detected_name,quantity,confidence,match_status"
+                )
+                .execute()
+            ).data or []
+
+        matched_count = 0
+        for row in inserted_items:
+            if row.get("match_status") != "matched" or not row.get("product_item_id"):
+                continue
+
+            matched_count += 1
+            self.db.table("product_inventory_snapshots").upsert(
+                {
+                    "product_item_id": row["product_item_id"],
+                    "observation_item_id": row["id"],
+                    "remaining_quantity": row["quantity"],
+                    "confidence": row["confidence"],
+                    "source_detected_name": row["detected_name"],
+                    "observed_at": observation["observed_at"],
+                },
+                on_conflict="product_item_id",
+            ).execute()
+
+        return {
+            "ok": True,
+            "observation_id": observation["id"],
+            "detected_count": len(item_records),
+            "matched_count": matched_count,
+        }

--- a/hardware/MIDAS/inventory_sync.py
+++ b/hardware/MIDAS/inventory_sync.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from typing import Any
 import os
@@ -73,6 +74,30 @@ def _safe_confidence(value: Any) -> float:
     except (TypeError, ValueError):
         confidence = 0.0
     return max(0.0, min(confidence, 1.0))
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def is_product_due_for_vision(product: dict[str, Any], observed_at: Any) -> bool:
+    if not product.get("vision_tracking_enabled"):
+        return False
+
+    interval_minutes = _safe_int(product.get("vision_measure_interval_minutes")) or 360
+    last_measured_at = _parse_timestamp(product.get("vision_last_measured_at"))
+    if last_measured_at is None:
+        return True
+
+    observed = _parse_timestamp(observed_at) or datetime.now(timezone.utc)
+    return observed >= last_measured_at + timedelta(minutes=interval_minutes)
 
 
 def _match_score(detected: str, candidate: str) -> float:
@@ -183,13 +208,30 @@ class InventorySync:
         self.min_match_score = min_match_score
 
     def load_catalog(self) -> list[dict[str, Any]]:
-        query = self.db.table("product_items").select("id,name,brand,user_id,group_id")
+        query = self.db.table("product_items").select(
+            "id,name,brand,user_id,group_id,"
+            "vision_tracking_enabled,vision_measure_interval_minutes,"
+            "vision_last_measured_at"
+        )
         if self.owner.group_id:
             query = query.eq("group_id", self.owner.group_id)
         else:
             query = query.eq("user_id", self.owner.user_id)
+        query = query.eq("vision_tracking_enabled", True)
         response = query.execute()
-        return list(response.data or [])
+        return [
+            product
+            for product in list(response.data or [])
+            if product.get("vision_tracking_enabled") is True
+        ]
+
+    def load_due_catalog(self, observed_at: Any | None = None) -> list[dict[str, Any]]:
+        now = observed_at or datetime.now(timezone.utc)
+        return [
+            product
+            for product in self.load_catalog()
+            if is_product_due_for_vision(product, now)
+        ]
 
     def persist_analysis(
         self,
@@ -224,9 +266,11 @@ class InventorySync:
         ).data
         observation = observation_rows[0]
 
+        catalog = self.load_catalog()
+        product_by_id = {str(product["id"]): product for product in catalog}
         item_records = build_detected_item_records(
             items=list(analysis_result.get("items") or []),
-            catalog=self.load_catalog(),
+            catalog=catalog,
             min_confidence=self.min_confidence,
             min_match_score=self.min_match_score,
         )
@@ -247,11 +291,18 @@ class InventorySync:
             ).data or []
 
         matched_count = 0
+        snapshot_updated_count = 0
+        measurement_skipped_count = 0
         for row in inserted_items:
             if row.get("match_status") != "matched" or not row.get("product_item_id"):
                 continue
 
             matched_count += 1
+            product = product_by_id.get(str(row["product_item_id"]))
+            if not product or not is_product_due_for_vision(product, observation["observed_at"]):
+                measurement_skipped_count += 1
+                continue
+
             self.db.table("product_inventory_snapshots").upsert(
                 {
                     "product_item_id": row["product_item_id"],
@@ -263,10 +314,16 @@ class InventorySync:
                 },
                 on_conflict="product_item_id",
             ).execute()
+            self.db.table("product_items").update(
+                {"vision_last_measured_at": observation["observed_at"]}
+            ).eq("id", row["product_item_id"]).execute()
+            snapshot_updated_count += 1
 
         return {
             "ok": True,
             "observation_id": observation["id"],
             "detected_count": len(item_records),
             "matched_count": matched_count,
+            "snapshot_updated_count": snapshot_updated_count,
+            "measurement_skipped_count": measurement_skipped_count,
         }

--- a/hardware/MIDAS/requirements.txt
+++ b/hardware/MIDAS/requirements.txt
@@ -1,0 +1,4 @@
+flask
+python-dotenv
+openai
+supabase

--- a/hardware/MIDAS/server.py
+++ b/hardware/MIDAS/server.py
@@ -1,0 +1,434 @@
+from flask import Flask, request, jsonify, send_from_directory
+from datetime import datetime
+from dotenv import load_dotenv
+from openai import OpenAI
+from collections import Counter
+import os
+import json
+import base64
+import re
+from inventory_sync import (
+    InventorySync,
+    make_client_from_env,
+    optional_float,
+    owner_from_env,
+)
+
+# ── 환경 변수 로드 ─────────────────────────────
+load_dotenv()
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.5")
+
+if not OPENAI_API_KEY:
+    raise RuntimeError("OPENAI_API_KEY가 설정되지 않았습니다. .env 파일을 확인하세요.")
+
+client = OpenAI(api_key=OPENAI_API_KEY)
+supabase_db = make_client_from_env()
+inventory_owner = owner_from_env()
+
+if supabase_db is None:
+    print("[WARN] Supabase sync disabled: SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is missing")
+if inventory_owner is None:
+    print("[WARN] Supabase sync disabled: BUYLOG_CAPTURE_USER_ID or BUYLOG_CAPTURE_GROUP_ID is missing")
+
+app = Flask(__name__)
+
+# ── 폴더 설정 ─────────────────────────────
+UPLOAD_DIR = "uploads"
+RESULT_DIR = "results"
+
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+os.makedirs(RESULT_DIR, exist_ok=True)
+
+
+# ── 이미지를 base64 data URL로 변환 ─────────
+def image_to_data_url(image_path):
+    with open(image_path, "rb") as f:
+        image_bytes = f.read()
+
+    encoded = base64.b64encode(image_bytes).decode("utf-8")
+    return f"data:image/jpeg;base64,{encoded}"
+
+
+# ── GPT 응답에서 JSON만 추출 ─────────────────
+def extract_json(text):
+    """
+    GPT가 혹시 ```json ... ``` 형태로 응답해도 JSON 부분만 파싱하기 위한 함수
+    """
+    text = text.strip()
+
+    # ```json ... ``` 제거
+    if text.startswith("```"):
+        text = re.sub(r"^```json\s*", "", text)
+        text = re.sub(r"^```\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # 본문 중 {...} 또는 [...] 부분만 추출 시도
+    match = re.search(r"(\{.*\}|\[.*\])", text, re.DOTALL)
+    if match:
+        return json.loads(match.group(1))
+
+    raise ValueError("GPT 응답에서 JSON을 파싱할 수 없습니다.")
+
+
+# ── GPT Vision 객체 인식 함수 ─────────────────
+def analyze_fridge_image_with_gpt(image_path):
+    image_data_url = image_to_data_url(image_path)
+
+    prompt = """
+너는 재고 파악 시스템의 이미지 분석 모델이다.
+
+이미지를 보고 창고 안에 보이는 물품을 분석해라.
+
+목표:
+- 물품 종류를 한국어로 출력
+- 같은 물품은 개수를 합산
+- 확실하지 않은 물체는 제외하거나 confidence를 낮게 설정
+- 너무 세부적인 브랜드명보다 일반 물품명으로 정리
+  예: 서울우유 → 우유, 삼다수 → 생수병, 코카콜라 → 탄산음료
+
+반드시 아래 JSON 형식만 출력해라.
+설명 문장, 마크다운, 코드블록은 출력하지 마라.
+
+{
+  "items": [
+    {
+      "item_name": "우유",
+      "quantity": 1,
+      "confidence": 0.85,
+      "note": "우유팩으로 보임"
+    }
+  ],
+  "summary": "냉장고 안에 우유 1개가 보임"
+}
+
+주의:
+- quantity는 정수로 출력
+- confidence는 0.0부터 1.0 사이 숫자
+- 보이지 않는 물품은 추측하지 말 것
+- 잘 모르겠으면 item_name을 '확인불가'로 하지 말고 제외할 것
+"""
+
+    response = client.responses.create(
+        model=OPENAI_MODEL,
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": prompt
+                    },
+                    {
+                        "type": "input_image",
+                        "image_url": image_data_url
+                    }
+                ]
+            }
+        ],
+    )
+
+    output_text = response.output_text
+    parsed = extract_json(output_text)
+
+    items = parsed.get("items", [])
+    summary = parsed.get("summary", "")
+
+    # 데이터 정리
+    cleaned_items = []
+
+    for item in items:
+        item_name = str(item.get("item_name", "")).strip()
+        if not item_name:
+            continue
+
+        try:
+            quantity = int(item.get("quantity", 1))
+        except Exception:
+            quantity = 1
+
+        try:
+            confidence = float(item.get("confidence", 0.0))
+        except Exception:
+            confidence = 0.0
+
+        note = str(item.get("note", "")).strip()
+
+        cleaned_items.append({
+            "item_name": item_name,
+            "quantity": max(quantity, 1),
+            "confidence": max(0.0, min(confidence, 1.0)),
+            "note": note
+        })
+
+    return {
+        "items": cleaned_items,
+        "summary": summary,
+        "raw_text": output_text
+    }
+
+
+# ── txt 저장 함수 ─────────────────────────
+def save_gpt_result_txt(txt_path, image_filename, analysis_result):
+    items = analysis_result.get("items", [])
+    summary = analysis_result.get("summary", "")
+
+    with open(txt_path, "w", encoding="utf-8") as f:
+        f.write("GPT API 냉장고 객체 인식 결과\n")
+        f.write("====================================\n")
+        f.write(f"이미지 파일: {image_filename}\n")
+        f.write(f"분석 시간: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        f.write("\n")
+
+        f.write("[요약]\n")
+        if summary:
+            f.write(summary + "\n")
+        else:
+            f.write("요약 없음\n")
+
+        f.write("\n")
+        f.write("[검출된 물품]\n")
+
+        if not items:
+            f.write("검출된 물품 없음\n")
+        else:
+            for item in items:
+                f.write(
+                    f"- {item['item_name']}: "
+                    f"{item['quantity']}개 "
+                    f"(신뢰도: {item['confidence']:.2f})"
+                )
+
+                if item.get("note"):
+                    f.write(f" / 비고: {item['note']}")
+
+                f.write("\n")
+
+        f.write("\n")
+        f.write("[JSON 원본]\n")
+        f.write(json.dumps(analysis_result, ensure_ascii=False, indent=2))
+
+
+# ── 메인 페이지 ─────────────────────────
+@app.route("/")
+def index():
+    image_files = sorted(
+        [f for f in os.listdir(UPLOAD_DIR) if f.lower().endswith(".jpg")],
+        reverse=True
+    )
+
+    html = """
+    <!DOCTYPE html>
+    <html lang="ko">
+    <head>
+        <meta charset="UTF-8">
+        <title>ESP32 냉장고 GPT 인식 서버</title>
+        <style>
+            body {
+                font-family: Arial, sans-serif;
+                background: #111827;
+                color: white;
+                padding: 20px;
+            }
+            h1 {
+                color: #60a5fa;
+            }
+            .card {
+                background: #1f2937;
+                padding: 16px;
+                margin-bottom: 16px;
+                border-radius: 12px;
+            }
+            img {
+                width: 320px;
+                max-width: 100%;
+                border-radius: 8px;
+                display: block;
+                margin-bottom: 10px;
+            }
+            a {
+                color: #93c5fd;
+                text-decoration: none;
+                margin-right: 12px;
+            }
+            .empty {
+                color: #d1d5db;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>ESP32 냉장고 GPT 인식 서버</h1>
+    """
+
+    if not image_files:
+        html += "<p class='empty'>아직 업로드된 이미지가 없습니다.</p>"
+
+    for image_file in image_files:
+        txt_file = image_file.replace(".jpg", ".txt")
+
+        html += f"""
+        <div class="card">
+            <h2>{image_file}</h2>
+            <img src="/uploads/{image_file}">
+            <a href="/uploads/{image_file}" target="_blank">이미지 보기</a>
+            <a href="/results/{txt_file}" target="_blank">GPT 인식 결과 txt 보기</a>
+        </div>
+        """
+
+    html += """
+    </body>
+    </html>
+    """
+
+    return html
+
+
+def persist_inventory_upload(
+    *,
+    device_id,
+    image_filename,
+    txt_filename,
+    gpt_ok,
+    analysis_result,
+    sensor_id,
+    weight_g,
+    delta_g,
+):
+    if supabase_db is None or inventory_owner is None:
+        return {
+            "ok": False,
+            "skipped": True,
+            "error": "Supabase inventory sync is not configured",
+        }
+
+    sync = InventorySync(db=supabase_db, owner=inventory_owner)
+    return sync.persist_analysis(
+        device_id=device_id,
+        image_file=image_filename,
+        txt_file=txt_filename,
+        gpt_ok=gpt_ok,
+        analysis_result=analysis_result,
+        sensor_id=sensor_id,
+        weight_g=optional_float(weight_g),
+        delta_g=optional_float(delta_g),
+    )
+
+
+# ── ESP32 이미지 업로드 엔드포인트 ─────────
+@app.route("/upload", methods=["POST"])
+def upload():
+    image_data = request.data
+
+    if not image_data:
+        return jsonify({
+            "ok": False,
+            "error": "No image data received"
+        }), 400
+
+    device_id = request.headers.get("X-Device-Id", "fridge_cam_01")
+    photo_count = request.headers.get("X-Photo-Count", "0")
+
+    # ESP-NOW 무게 이벤트 정보를 나중에 같이 보낼 경우 대비
+    sensor_id = request.headers.get("X-Sensor-Id", "")
+    weight_g = request.headers.get("X-Weight-G", "")
+    delta_g = request.headers.get("X-Delta-G", "")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    image_filename = f"{device_id}_{timestamp}_{photo_count}.jpg"
+    txt_filename = f"{device_id}_{timestamp}_{photo_count}.txt"
+
+    image_path = os.path.join(UPLOAD_DIR, image_filename)
+    txt_path = os.path.join(RESULT_DIR, txt_filename)
+
+    # 1. 이미지 저장
+    with open(image_path, "wb") as f:
+        f.write(image_data)
+
+    print(f"[OK] 이미지 수신: {image_filename}")
+    print(f"     크기: {len(image_data) / 1024:.1f} KB")
+
+    # 2. GPT API로 이미지 분석
+    try:
+        analysis_result = analyze_fridge_image_with_gpt(image_path)
+        gpt_ok = True
+        print("[OK] GPT 이미지 분석 완료")
+
+    except Exception as e:
+        gpt_ok = False
+        analysis_result = {
+            "items": [],
+            "summary": "GPT 이미지 분석 실패",
+            "error": str(e)
+        }
+        print(f"[FAIL] GPT 이미지 분석 실패: {e}")
+
+    # 3. txt 저장
+    save_gpt_result_txt(
+        txt_path=txt_path,
+        image_filename=image_filename,
+        analysis_result=analysis_result
+    )
+
+    print(f"[OK] txt 저장: {txt_filename}")
+
+    try:
+        inventory_sync_result = persist_inventory_upload(
+            device_id=device_id,
+            image_filename=image_filename,
+            txt_filename=txt_filename,
+            gpt_ok=gpt_ok,
+            analysis_result=analysis_result,
+            sensor_id=sensor_id,
+            weight_g=weight_g,
+            delta_g=delta_g,
+        )
+        if inventory_sync_result.get("ok"):
+            print(
+                "[OK] Supabase inventory sync: "
+                f"{inventory_sync_result.get('matched_count', 0)} matched"
+            )
+        else:
+            print(f"[WARN] Supabase inventory sync skipped: {inventory_sync_result.get('error')}")
+    except Exception as e:
+        inventory_sync_result = {"ok": False, "skipped": False, "error": str(e)}
+        print(f"[FAIL] Supabase inventory sync failed: {e}")
+
+    # 4. 응답
+    return jsonify({
+        "ok": True,
+        "gpt_ok": gpt_ok,
+        "image_file": image_filename,
+        "txt_file": txt_filename,
+        "device_id": device_id,
+        "sensor_id": sensor_id,
+        "weight_g": weight_g,
+        "delta_g": delta_g,
+        "items": analysis_result.get("items", []),
+        "summary": analysis_result.get("summary", ""),
+        "supabase_ok": bool(inventory_sync_result.get("ok")),
+        "inventory_sync": inventory_sync_result,
+    })
+
+
+# ── 이미지 파일 제공 ─────────────────────
+@app.route("/uploads/<filename>")
+def uploaded_file(filename):
+    return send_from_directory(UPLOAD_DIR, filename)
+
+
+# ── txt 결과 파일 제공 ───────────────────
+@app.route("/results/<filename>")
+def result_file(filename):
+    return send_from_directory(RESULT_DIR, filename)
+
+
+# ── 서버 실행 ───────────────────────────
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5001)

--- a/hardware/MIDAS/test_inventory_sync.py
+++ b/hardware/MIDAS/test_inventory_sync.py
@@ -1,0 +1,197 @@
+import unittest
+
+from inventory_sync import (
+    InventoryOwner,
+    InventorySync,
+    build_detected_item_records,
+    match_detected_item,
+    normalize_name,
+    optional_float,
+)
+
+
+class FakeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeTable:
+    def __init__(self, name, db):
+        self.name = name
+        self.db = db
+        self.operation = None
+        self.payload = None
+        self.filters = []
+        self.select_value = None
+
+    def select(self, value):
+        self.select_value = value
+        return self
+
+    def eq(self, key, value):
+        self.filters.append((key, value))
+        return self
+
+    def insert(self, payload):
+        self.operation = "insert"
+        self.payload = payload
+        self.db.calls.append((self.name, "insert", payload))
+        return self
+
+    def upsert(self, payload, on_conflict=None):
+        self.operation = "upsert"
+        self.payload = payload
+        self.db.calls.append((self.name, "upsert", payload, on_conflict))
+        return self
+
+    def execute(self):
+        if self.name == "product_items" and self.operation is None:
+            return FakeResponse(self.db.product_rows)
+        if self.name == "inventory_observations":
+            return FakeResponse([{"id": "observation-1", "observed_at": "2026-05-29T06:12:00Z"}])
+        if self.name == "inventory_observation_items":
+            rows = []
+            for index, row in enumerate(self.payload):
+                copied = dict(row)
+                copied["id"] = f"observation-item-{index + 1}"
+                rows.append(copied)
+            return FakeResponse(rows)
+        return FakeResponse([])
+
+
+class FakeSupabase:
+    def __init__(self):
+        self.calls = []
+        self.product_rows = [
+            {
+                "id": "item-1",
+                "name": "Milk",
+                "brand": "Seoul",
+                "user_id": "user-1",
+                "group_id": None,
+            },
+            {
+                "id": "item-2",
+                "name": "Water",
+                "brand": "Samdasoo",
+                "user_id": "user-1",
+                "group_id": None,
+            },
+        ]
+
+    def table(self, name):
+        return FakeTable(name, self)
+
+
+class InventorySyncTest(unittest.TestCase):
+    def test_normalize_name_removes_spaces_case_and_punctuation(self):
+        self.assertEqual(normalize_name("  Seoul Milk 1L "), "seoulmilk1l")
+        self.assertEqual(normalize_name("Milk-1L!"), "milk1l")
+        self.assertEqual(normalize_name(" 서울 우유! "), "서울우유")
+
+    def test_optional_float_parses_blank_and_invalid_values_as_none(self):
+        self.assertIsNone(optional_float(""))
+        self.assertIsNone(optional_float(None))
+        self.assertIsNone(optional_float("abc"))
+        self.assertEqual(optional_float("12.5"), 12.5)
+
+    def test_match_detected_item_prefers_exact_normalized_name(self):
+        catalog = [
+            {"id": "item-1", "name": "Milk", "brand": "Seoul"},
+            {"id": "item-2", "name": "Water", "brand": "Samdasoo"},
+        ]
+
+        match = match_detected_item(
+            detected_name="Milk",
+            catalog=catalog,
+            confidence=0.91,
+            min_confidence=0.6,
+            min_match_score=0.82,
+        )
+
+        self.assertEqual(match.status, "matched")
+        self.assertEqual(match.product_item_id, "item-1")
+        self.assertEqual(match.score, 1.0)
+
+    def test_match_detected_item_rejects_low_confidence(self):
+        match = match_detected_item(
+            detected_name="Milk",
+            catalog=[{"id": "item-1", "name": "Milk", "brand": "Seoul"}],
+            confidence=0.4,
+            min_confidence=0.6,
+            min_match_score=0.82,
+        )
+
+        self.assertEqual(match.status, "low_confidence")
+        self.assertIsNone(match.product_item_id)
+
+    def test_build_detected_item_records_keeps_unmatched_items_for_audit(self):
+        records = build_detected_item_records(
+            items=[
+                {"item_name": "Milk", "quantity": 2, "confidence": 0.91, "note": "two bottles"},
+                {"item_name": "Unknown", "quantity": 1, "confidence": 0.2, "note": ""},
+            ],
+            catalog=[{"id": "item-1", "name": "Milk", "brand": "Seoul"}],
+            min_confidence=0.6,
+            min_match_score=0.82,
+        )
+
+        self.assertEqual(records[0]["product_item_id"], "item-1")
+        self.assertEqual(records[0]["match_status"], "matched")
+        self.assertIsNone(records[1]["product_item_id"])
+        self.assertEqual(records[1]["match_status"], "low_confidence")
+
+    def test_inventory_owner_requires_exactly_one_scope(self):
+        with self.assertRaises(ValueError):
+            InventoryOwner(user_id=None, group_id=None).to_observation_owner()
+        with self.assertRaises(ValueError):
+            InventoryOwner(user_id="user-1", group_id="group-1").to_observation_owner()
+        self.assertEqual(
+            InventoryOwner(user_id="user-1", group_id=None).to_observation_owner(),
+            {"user_id": "user-1", "group_id": None},
+        )
+
+    def test_persist_analysis_inserts_observation_items_and_snapshot(self):
+        fake = FakeSupabase()
+        sync = InventorySync(
+            db=fake,
+            owner=InventoryOwner(user_id="user-1", group_id=None),
+            min_confidence=0.6,
+            min_match_score=0.82,
+        )
+
+        result = sync.persist_analysis(
+            device_id="kitchen-cam-01",
+            image_file="kitchen-cam-01_1.jpg",
+            txt_file="kitchen-cam-01_1.txt",
+            gpt_ok=True,
+            analysis_result={
+                "items": [
+                    {
+                        "item_name": "Milk",
+                        "quantity": 2,
+                        "confidence": 0.91,
+                        "note": "two bottles",
+                    }
+                ],
+                "summary": "Milk 2",
+            },
+            sensor_id="",
+            weight_g=None,
+            delta_g=None,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["matched_count"], 1)
+        snapshot_calls = [
+            call
+            for call in fake.calls
+            if call[0] == "product_inventory_snapshots" and call[1] == "upsert"
+        ]
+        self.assertEqual(len(snapshot_calls), 1)
+        self.assertEqual(snapshot_calls[0][2]["product_item_id"], "item-1")
+        self.assertEqual(snapshot_calls[0][2]["remaining_quantity"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hardware/MIDAS/test_inventory_sync.py
+++ b/hardware/MIDAS/test_inventory_sync.py
@@ -44,6 +44,12 @@ class FakeTable:
         self.db.calls.append((self.name, "upsert", payload, on_conflict))
         return self
 
+    def update(self, payload):
+        self.operation = "update"
+        self.payload = payload
+        self.db.calls.append((self.name, "update", payload))
+        return self
+
     def execute(self):
         if self.name == "product_items" and self.operation is None:
             return FakeResponse(self.db.product_rows)
@@ -69,6 +75,9 @@ class FakeSupabase:
                 "brand": "Seoul",
                 "user_id": "user-1",
                 "group_id": None,
+                "vision_tracking_enabled": True,
+                "vision_measure_interval_minutes": 360,
+                "vision_last_measured_at": None,
             },
             {
                 "id": "item-2",
@@ -76,6 +85,9 @@ class FakeSupabase:
                 "brand": "Samdasoo",
                 "user_id": "user-1",
                 "group_id": None,
+                "vision_tracking_enabled": False,
+                "vision_measure_interval_minutes": 360,
+                "vision_last_measured_at": None,
             },
         ]
 
@@ -150,6 +162,59 @@ class InventorySyncTest(unittest.TestCase):
             InventoryOwner(user_id="user-1", group_id=None).to_observation_owner(),
             {"user_id": "user-1", "group_id": None},
         )
+
+    def test_load_catalog_only_returns_vision_enabled_items(self):
+        fake = FakeSupabase()
+        sync = InventorySync(
+            db=fake,
+            owner=InventoryOwner(user_id="user-1", group_id=None),
+        )
+
+        catalog = sync.load_catalog()
+
+        self.assertEqual([row["id"] for row in catalog], ["item-1"])
+
+    def test_persist_analysis_skips_snapshot_when_measurement_is_not_due(self):
+        fake = FakeSupabase()
+        fake.product_rows[0]["vision_last_measured_at"] = "2026-05-29T06:00:00Z"
+        fake.product_rows[0]["vision_measure_interval_minutes"] = 360
+        sync = InventorySync(
+            db=fake,
+            owner=InventoryOwner(user_id="user-1", group_id=None),
+            min_confidence=0.6,
+            min_match_score=0.82,
+        )
+
+        result = sync.persist_analysis(
+            device_id="kitchen-cam-01",
+            image_file="kitchen-cam-01_1.jpg",
+            txt_file="kitchen-cam-01_1.txt",
+            gpt_ok=True,
+            analysis_result={
+                "items": [
+                    {
+                        "item_name": "Milk",
+                        "quantity": 2,
+                        "confidence": 0.91,
+                        "note": "two bottles",
+                    }
+                ],
+                "summary": "Milk 2",
+            },
+            sensor_id="",
+            weight_g=None,
+            delta_g=None,
+        )
+
+        snapshot_calls = [
+            call
+            for call in fake.calls
+            if call[0] == "product_inventory_snapshots" and call[1] == "upsert"
+        ]
+        self.assertEqual(len(snapshot_calls), 0)
+        self.assertEqual(result["matched_count"], 1)
+        self.assertEqual(result["snapshot_updated_count"], 0)
+        self.assertEqual(result["measurement_skipped_count"], 1)
 
     def test_persist_analysis_inserts_observation_items_and_snapshot(self):
         fake = FakeSupabase()

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -17,6 +17,10 @@ class ConsumableItem {
   final String? registeredBy;
   final String? registeredByDisplayName;
   final String? registeredByEmail;
+  final int? remainingQuantity;
+  final DateTime? inventoryObservedAt;
+  final double? inventoryConfidence;
+  final String? inventorySourceName;
 
   const ConsumableItem({
     required this.id,
@@ -35,6 +39,10 @@ class ConsumableItem {
     this.registeredBy,
     this.registeredByDisplayName,
     this.registeredByEmail,
+    this.remainingQuantity,
+    this.inventoryObservedAt,
+    this.inventoryConfidence,
+    this.inventorySourceName,
   });
 
   String? get registeredByLabel {
@@ -52,6 +60,12 @@ class ConsumableItem {
     return id == null || id.isEmpty ? null : id;
   }
 
+  String? get remainingQuantityLabel {
+    final quantity = remainingQuantity;
+    if (quantity == null) return null;
+    return '현재 $quantity개';
+  }
+
   /// Supabase product_items 행 + 관련 데이터로 ConsumableItem 생성
   ///
   /// [data]         product_items 행
@@ -63,6 +77,7 @@ class ConsumableItem {
     required String categoryName,
     required List<Map<String, dynamic>> purchases,
     Map<String, dynamic>? aiPrediction,
+    Map<String, dynamic>? inventorySnapshot,
   }) {
     final cycleDays = (data['replacement_cycle_days'] as int?) ?? 30;
 
@@ -85,6 +100,12 @@ class ConsumableItem {
     final registeredDisplayName = (registeredUser?['display_name'] as String?)
         ?.trim();
     final registeredEmail = (registeredUser?['email'] as String?)?.trim();
+    final inventoryObservedAtRaw = inventorySnapshot?['observed_at'];
+    final inventoryObservedAt = inventoryObservedAtRaw is DateTime
+        ? inventoryObservedAtRaw
+        : inventoryObservedAtRaw is String
+        ? DateTime.parse(inventoryObservedAtRaw)
+        : null;
 
     return ConsumableItem(
       id: data['id'] as String,
@@ -106,6 +127,13 @@ class ConsumableItem {
           : null,
       aiPredictedDays: aiPrediction?['predicted_cycle_days'] as int?,
       aiConfidence: (aiPrediction?['confidence'] as num?)?.toDouble(),
+      remainingQuantity: (inventorySnapshot?['remaining_quantity'] as num?)
+          ?.toInt(),
+      inventoryObservedAt: inventoryObservedAt,
+      inventoryConfidence: (inventorySnapshot?['confidence'] as num?)
+          ?.toDouble(),
+      inventorySourceName:
+          inventorySnapshot?['source_detected_name'] as String?,
       purchaseHistory: sorted
           .map(
             (p) => PurchaseRecord(

--- a/lib/models/item.dart
+++ b/lib/models/item.dart
@@ -21,6 +21,9 @@ class ConsumableItem {
   final DateTime? inventoryObservedAt;
   final double? inventoryConfidence;
   final String? inventorySourceName;
+  final bool visionTrackingEnabled;
+  final int visionMeasureIntervalMinutes;
+  final DateTime? visionLastMeasuredAt;
 
   const ConsumableItem({
     required this.id,
@@ -43,6 +46,9 @@ class ConsumableItem {
     this.inventoryObservedAt,
     this.inventoryConfidence,
     this.inventorySourceName,
+    this.visionTrackingEnabled = false,
+    this.visionMeasureIntervalMinutes = 360,
+    this.visionLastMeasuredAt,
   });
 
   String? get registeredByLabel {
@@ -64,6 +70,14 @@ class ConsumableItem {
     final quantity = remainingQuantity;
     if (quantity == null) return null;
     return '현재 $quantity개';
+  }
+
+  String get visionMeasureIntervalLabel {
+    final minutes = visionMeasureIntervalMinutes;
+    if (minutes % 60 == 0) {
+      return '${minutes ~/ 60}시간마다';
+    }
+    return '$minutes분마다';
   }
 
   /// Supabase product_items 행 + 관련 데이터로 ConsumableItem 생성
@@ -106,6 +120,12 @@ class ConsumableItem {
         : inventoryObservedAtRaw is String
         ? DateTime.parse(inventoryObservedAtRaw)
         : null;
+    final visionLastMeasuredAtRaw = data['vision_last_measured_at'];
+    final visionLastMeasuredAt = visionLastMeasuredAtRaw is DateTime
+        ? visionLastMeasuredAtRaw
+        : visionLastMeasuredAtRaw is String
+        ? DateTime.parse(visionLastMeasuredAtRaw)
+        : null;
 
     return ConsumableItem(
       id: data['id'] as String,
@@ -134,6 +154,11 @@ class ConsumableItem {
           ?.toDouble(),
       inventorySourceName:
           inventorySnapshot?['source_detected_name'] as String?,
+      visionTrackingEnabled:
+          (data['vision_tracking_enabled'] as bool?) ?? false,
+      visionMeasureIntervalMinutes:
+          (data['vision_measure_interval_minutes'] as int?) ?? 360,
+      visionLastMeasuredAt: visionLastMeasuredAt,
       purchaseHistory: sorted
           .map(
             (p) => PurchaseRecord(

--- a/lib/screens/add_item_screen.dart
+++ b/lib/screens/add_item_screen.dart
@@ -50,6 +50,8 @@ class AddItemScreen extends StatefulWidget {
 }
 
 class _AddItemScreenState extends State<AddItemScreen> {
+  static const List<int> _visionIntervalOptions = [60, 180, 360, 720, 1440];
+
   final _formKey = GlobalKey<FormState>();
 
   // 기본 정보 컨트롤러
@@ -65,6 +67,8 @@ class _AddItemScreenState extends State<AddItemScreen> {
   // 이미지 상태
   Uint8List? _imageBytes; // 새로 선택한 이미지 bytes
   bool _isSaving = false;
+  bool _visionTrackingEnabled = false;
+  int _visionMeasureIntervalMinutes = 360;
 
   bool get _hasImageSelected =>
       _imageBytes != null || (_isEditing && widget.editItem!.imageUrl != null);
@@ -101,6 +105,8 @@ class _AddItemScreenState extends State<AddItemScreen> {
       // 편집 모드: 기존 제품 데이터로 초기화
       _nameCtrl = TextEditingController(text: edit.name);
       _brandCtrl = TextEditingController(text: edit.brand);
+      _visionTrackingEnabled = edit.visionTrackingEnabled;
+      _visionMeasureIntervalMinutes = edit.visionMeasureIntervalMinutes;
       // 기존 카테고리가 드롭다운 목록에 없으면 첫 번째 항목으로 폴백
       _selectedCategory = categoryDefaultDays.containsKey(edit.category)
           ? edit.category
@@ -352,6 +358,10 @@ class _AddItemScreenState extends State<AddItemScreen> {
               aiPredictedDays: duplicate.aiPredictedDays,
               aiConfidence: duplicate.aiConfidence,
               imageUrl: imageUrl ?? duplicate.imageUrl,
+              visionTrackingEnabled: duplicate.visionTrackingEnabled,
+              visionMeasureIntervalMinutes:
+                  duplicate.visionMeasureIntervalMinutes,
+              visionLastMeasuredAt: duplicate.visionLastMeasuredAt,
               purchaseHistory: [...duplicate.purchaseHistory, ...newPurchases],
             );
             await ItemStore.instance.update(merged, scope: _effectiveScope);
@@ -382,6 +392,11 @@ class _AddItemScreenState extends State<AddItemScreen> {
         aiPredictedDays: _isEditing ? widget.editItem!.aiPredictedDays : null,
         aiConfidence: _isEditing ? widget.editItem!.aiConfidence : null,
         imageUrl: imageUrl,
+        visionTrackingEnabled: _visionTrackingEnabled,
+        visionMeasureIntervalMinutes: _visionMeasureIntervalMinutes,
+        visionLastMeasuredAt: _isEditing
+            ? widget.editItem!.visionLastMeasuredAt
+            : null,
         purchaseHistory: purchases,
       );
 
@@ -461,6 +476,10 @@ class _AddItemScreenState extends State<AddItemScreen> {
               _sectionTitle('기본 정보'),
               const SizedBox(height: 12),
               _buildBasicInfoSection(),
+              const SizedBox(height: 24),
+              _sectionTitle('Vision 추적'),
+              const SizedBox(height: 12),
+              _buildVisionTrackingSection(),
               const SizedBox(height: 24),
               _sectionTitle('구매 이력'),
               const SizedBox(height: 4),
@@ -749,6 +768,92 @@ class _AddItemScreenState extends State<AddItemScreen> {
         _buildCycleDaysField(),
       ],
     );
+  }
+
+  Widget _buildVisionTrackingSection() {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.visibility_outlined,
+                size: 20,
+                color: AppColors.primary,
+              ),
+              const SizedBox(width: 10),
+              const Expanded(
+                child: Text(
+                  'Vision 추적',
+                  style: TextStyle(
+                    fontSize: 15,
+                    color: AppColors.text,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              Switch(
+                key: const ValueKey('vision_tracking_switch'),
+                value: _visionTrackingEnabled,
+                activeThumbColor: AppColors.primary,
+                onChanged: (value) {
+                  setState(() => _visionTrackingEnabled = value);
+                },
+              ),
+            ],
+          ),
+          if (_visionTrackingEnabled) ...[
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final minutes in _visionIntervalOptions)
+                  ChoiceChip(
+                    key: ValueKey('vision_interval_$minutes'),
+                    label: Text(_visionIntervalLabel(minutes)),
+                    selected: _visionMeasureIntervalMinutes == minutes,
+                    onSelected: (_) {
+                      setState(() => _visionMeasureIntervalMinutes = minutes);
+                    },
+                    selectedColor: AppColors.primary,
+                    labelStyle: TextStyle(
+                      color: _visionMeasureIntervalMinutes == minutes
+                          ? Colors.white
+                          : AppColors.textSecondary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(999),
+                      side: BorderSide(
+                        color: _visionMeasureIntervalMinutes == minutes
+                            ? AppColors.primary
+                            : AppColors.border,
+                        width: 0.5,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _visionIntervalLabel(int minutes) {
+    if (minutes % 60 == 0) {
+      return '${minutes ~/ 60}시간';
+    }
+    return '$minutes분';
   }
 
   Widget _labeledField({

--- a/lib/screens/item_detail_screen.dart
+++ b/lib/screens/item_detail_screen.dart
@@ -215,6 +215,10 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
             _buildProductHeader(),
             const SizedBox(height: 24),
             _buildReplacementCycle(),
+            if (_item.remainingQuantity != null) ...[
+              const SizedBox(height: 20),
+              _buildCurrentInventory(),
+            ],
             const SizedBox(height: 20),
             _buildPriceComparison(),
             const SizedBox(height: 20),
@@ -449,6 +453,76 @@ class _ItemDetailScreenState extends State<ItemDetailScreen> {
                 ),
               ),
             ],
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCurrentInventory() {
+    final confidence = _item.inventoryConfidence;
+    final observedAt = _item.inventoryObservedAt;
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Row(
+            children: [
+              Icon(
+                Icons.inventory_2_outlined,
+                size: 18,
+                color: AppColors.primary,
+              ),
+              SizedBox(width: 8),
+              Text(
+                '현재 남은 수량',
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.text,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '${_item.remainingQuantity}개',
+                style: const TextStyle(
+                  fontSize: 28,
+                  fontWeight: FontWeight.w800,
+                  color: AppColors.text,
+                ),
+              ),
+              const SizedBox(width: 10),
+              if (confidence != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(
+                    '신뢰도 ${(confidence * 100).round()}%',
+                    style: const TextStyle(
+                      fontSize: 12,
+                      color: AppColors.textMuted,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          if (observedAt != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              '마지막 확인 ${observedAt.year}.${observedAt.month.toString().padLeft(2, '0')}.${observedAt.day.toString().padLeft(2, '0')}',
+              style: const TextStyle(fontSize: 12, color: AppColors.textMuted),
+            ),
           ],
         ],
       ),

--- a/lib/screens/items_screen.dart
+++ b/lib/screens/items_screen.dart
@@ -219,6 +219,12 @@ class ItemRow extends StatelessWidget {
     final registeredByLabel = item.groupId == null
         ? null
         : item.registeredByLabel;
+    final quantityLabel = item.remainingQuantityLabel;
+    final detailParts = <String>[
+      if (item.brand.trim().isNotEmpty) item.brand,
+      ?quantityLabel,
+      '주기 $cyclePart일',
+    ];
 
     return Material(
       color: Colors.transparent,
@@ -270,7 +276,7 @@ class ItemRow extends StatelessWidget {
                     ),
                     const SizedBox(height: 2),
                     Text(
-                      '${item.brand} · 주기 $cyclePart일',
+                      detailParts.join(' · '),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: const TextStyle(

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -297,6 +297,8 @@ class SupabaseService {
         'brand': item.brand,
         'image_url': item.imageUrl,
         'replacement_cycle_days': item.cycleDays,
+        'vision_tracking_enabled': item.visionTrackingEnabled,
+        'vision_measure_interval_minutes': item.visionMeasureIntervalMinutes,
       });
 
       // id가 null인 신규 구매 이력만 삽입
@@ -572,6 +574,9 @@ class SupabaseItemDatabaseGateway implements ItemDatabaseGateway {
           brand,
           image_url,
           replacement_cycle_days,
+          vision_tracking_enabled,
+          vision_measure_interval_minutes,
+          vision_last_measured_at,
           created_at,
           categories ( id, name ),
           purchases ( id, purchase_date, price, store_name ),

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -245,13 +245,27 @@ class SupabaseService {
             ?.cast<Map<String, dynamic>>() ??
         <Map<String, dynamic>>[];
     final ai = aiList.isNotEmpty ? aiList.last : null;
+    final inventorySnapshot = _singleInventorySnapshot(
+      row['product_inventory_snapshots'],
+    );
 
     return ConsumableItem.fromSupabase(
       data: row,
       categoryName: categoryName,
       purchases: purchases,
       aiPrediction: ai,
+      inventorySnapshot: inventorySnapshot,
     );
+  }
+
+  static Map<String, dynamic>? _singleInventorySnapshot(Object? value) {
+    if (value is Map<String, dynamic>) {
+      return value;
+    }
+    if (value is List && value.isNotEmpty && value.first is Map) {
+      return Map<String, dynamic>.from(value.first as Map);
+    }
+    return null;
   }
 
   /// ConsumableItem을 Supabase에 upsert합니다.
@@ -561,7 +575,13 @@ class SupabaseItemDatabaseGateway implements ItemDatabaseGateway {
           created_at,
           categories ( id, name ),
           purchases ( id, purchase_date, price, store_name ),
-          ai_predictions ( predicted_cycle_days, confidence )
+          ai_predictions ( predicted_cycle_days, confidence ),
+          product_inventory_snapshots (
+            remaining_quantity,
+            confidence,
+            source_detected_name,
+            observed_at
+          )
         ''';
 
   @override

--- a/lib/widgets/item_card.dart
+++ b/lib/widgets/item_card.dart
@@ -73,8 +73,10 @@ class ItemCard extends StatelessWidget {
             ),
             const SizedBox(height: 6),
             Text(
-              '${item.cycleDays}일 주기',
+              item.remainingQuantityLabel ?? '${item.cycleDays}일 주기',
               style: const TextStyle(fontSize: 11, color: AppColors.textMuted),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
           ],
         ),

--- a/supabase/migrations/20260529061626_add_inventory_observations.sql
+++ b/supabase/migrations/20260529061626_add_inventory_observations.sql
@@ -1,0 +1,199 @@
+begin;
+
+create schema if not exists private;
+
+create or replace function private.current_buylog_user_id()
+returns uuid
+language sql
+stable
+set search_path = ''
+as $$
+  select coalesce(
+    (select auth.uid()),
+    '08cccfe3-766f-43bd-b06c-8d909e0f9fe8'::uuid
+  );
+$$;
+
+create or replace function private.can_access_product_item(
+  target_product_item_id uuid,
+  target_user_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.product_items as pi
+    where pi.id = target_product_item_id
+      and (
+        pi.user_id = target_user_id
+        or (
+          pi.group_id is not null
+          and exists (
+            select 1
+            from public.group_members as gm
+            where gm.group_id = pi.group_id
+              and gm.user_id = target_user_id
+          )
+        )
+      )
+  );
+$$;
+
+revoke all on function private.current_buylog_user_id() from public;
+revoke all on function private.can_access_product_item(uuid, uuid) from public;
+grant execute on function private.current_buylog_user_id() to anon, authenticated;
+grant execute on function private.can_access_product_item(uuid, uuid) to anon, authenticated;
+
+create table public.inventory_observations (
+  id uuid primary key default gen_random_uuid(),
+  device_id text not null,
+  user_id uuid references public.users(id) on delete cascade,
+  group_id uuid references public.groups(id) on delete cascade,
+  image_file text not null,
+  txt_file text,
+  summary text,
+  raw_result jsonb not null default '{}'::jsonb,
+  gpt_ok boolean not null default false,
+  sensor_id text,
+  weight_g numeric,
+  delta_g numeric,
+  observed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  constraint inventory_observations_owner_check check (
+    (user_id is not null and group_id is null) or
+    (user_id is null and group_id is not null)
+  )
+);
+
+create table public.inventory_observation_items (
+  id uuid primary key default gen_random_uuid(),
+  observation_id uuid not null references public.inventory_observations(id) on delete cascade,
+  product_item_id uuid references public.product_items(id) on delete set null,
+  detected_name text not null,
+  normalized_name text not null,
+  quantity int not null check (quantity >= 0),
+  confidence numeric(4, 3) not null check (confidence >= 0 and confidence <= 1),
+  note text,
+  match_status text not null check (
+    match_status in ('matched', 'unmatched', 'low_confidence', 'ambiguous')
+  ),
+  match_score numeric(5, 4) check (
+    match_score is null or (match_score >= 0 and match_score <= 1)
+  ),
+  created_at timestamptz not null default now()
+);
+
+create table public.product_inventory_snapshots (
+  product_item_id uuid primary key references public.product_items(id) on delete cascade,
+  observation_item_id uuid references public.inventory_observation_items(id) on delete set null,
+  remaining_quantity int not null check (remaining_quantity >= 0),
+  confidence numeric(4, 3) not null check (confidence >= 0 and confidence <= 1),
+  source_detected_name text not null,
+  observed_at timestamptz not null,
+  updated_at timestamptz not null default now()
+);
+
+create or replace function private.can_access_inventory_observation(
+  target_observation_id uuid,
+  target_user_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+    from public.inventory_observations as io
+    where io.id = target_observation_id
+      and (
+        io.user_id = target_user_id
+        or (
+          io.group_id is not null
+          and exists (
+            select 1
+            from public.group_members as gm
+            where gm.group_id = io.group_id
+              and gm.user_id = target_user_id
+          )
+        )
+      )
+  );
+$$;
+
+revoke all on function private.can_access_inventory_observation(uuid, uuid) from public;
+grant execute on function private.can_access_inventory_observation(uuid, uuid) to anon, authenticated;
+
+comment on table public.inventory_observations is
+  'Camera/GPT inventory recognition runs received from MIDAS hardware.';
+comment on table public.inventory_observation_items is
+  'Detected items from a single inventory observation, including matching status.';
+comment on table public.product_inventory_snapshots is
+  'Latest known remaining quantity per registered product item.';
+
+create index inventory_observations_owner_observed_at_idx
+on public.inventory_observations (user_id, group_id, observed_at desc);
+
+create index inventory_observation_items_observation_idx
+on public.inventory_observation_items (observation_id);
+
+create index inventory_observation_items_product_idx
+on public.inventory_observation_items (product_item_id, created_at desc)
+where product_item_id is not null;
+
+create trigger trg_product_inventory_snapshots_updated_at
+  before update on public.product_inventory_snapshots
+  for each row execute function update_updated_at();
+
+grant select on table public.inventory_observations to anon, authenticated;
+grant select on table public.inventory_observation_items to anon, authenticated;
+grant select on table public.product_inventory_snapshots to anon, authenticated;
+
+grant select, insert on table public.inventory_observations to service_role;
+grant select, insert on table public.inventory_observation_items to service_role;
+grant select, insert, update on table public.product_inventory_snapshots to service_role;
+
+alter table public.inventory_observations enable row level security;
+alter table public.inventory_observation_items enable row level security;
+alter table public.product_inventory_snapshots enable row level security;
+
+create policy "Users can view accessible inventory observations"
+on public.inventory_observations
+for select
+to anon, authenticated
+using (
+  user_id = private.current_buylog_user_id()
+  or (
+    group_id is not null
+    and private.is_group_member(group_id, private.current_buylog_user_id())
+  )
+);
+
+create policy "Users can view accessible inventory observation items"
+on public.inventory_observation_items
+for select
+to anon, authenticated
+using (
+  private.can_access_inventory_observation(
+    observation_id,
+    private.current_buylog_user_id()
+  )
+);
+
+create policy "Users can view accessible product inventory snapshots"
+on public.product_inventory_snapshots
+for select
+to anon, authenticated
+using (
+  private.can_access_product_item(
+    product_item_id,
+    private.current_buylog_user_id()
+  )
+);
+
+commit;

--- a/supabase/migrations/20260529064734_add_product_vision_tracking_settings.sql
+++ b/supabase/migrations/20260529064734_add_product_vision_tracking_settings.sql
@@ -1,0 +1,19 @@
+begin;
+
+alter table public.product_items
+  add column vision_tracking_enabled boolean not null default false,
+  add column vision_measure_interval_minutes int not null default 360,
+  add column vision_last_measured_at timestamptz,
+  add constraint product_items_vision_measure_interval_minutes_check
+    check (
+      vision_measure_interval_minutes in (60, 180, 360, 720, 1440)
+    );
+
+comment on column public.product_items.vision_tracking_enabled is
+  'Whether MIDAS camera vision inventory tracking is enabled for this product.';
+comment on column public.product_items.vision_measure_interval_minutes is
+  'Minimum minutes between vision inventory snapshot updates for this product.';
+comment on column public.product_items.vision_last_measured_at is
+  'Last observation timestamp that updated this product from vision tracking.';
+
+commit;

--- a/test/screens/add_item_screen_test.dart
+++ b/test/screens/add_item_screen_test.dart
@@ -138,6 +138,53 @@ void main() {
 
     expect(find.text('우리 가족에 추가 중'), findsOneWidget);
   });
+
+  testWidgets('vision tracking is off by default when adding an item', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const AddItemScreen()));
+
+    expect(
+      tester
+          .widget<Switch>(find.byKey(const ValueKey('vision_tracking_switch')))
+          .value,
+      isFalse,
+    );
+
+    await _submitMinimalItem(tester);
+
+    expect(gateway.upsertedItemPayload?['vision_tracking_enabled'], isFalse);
+    expect(
+      gateway.upsertedItemPayload?['vision_measure_interval_minutes'],
+      360,
+    );
+  });
+
+  testWidgets('vision tracking interval can be selected before saving', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_wrap(const AddItemScreen()));
+
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('vision_tracking_switch')),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('vision_tracking_switch')));
+    await tester.pump();
+    await tester.ensureVisible(
+      find.byKey(const ValueKey('vision_interval_720')),
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('vision_interval_720')));
+    await tester.pump();
+    await _submitMinimalItem(tester);
+
+    expect(gateway.upsertedItemPayload?['vision_tracking_enabled'], isTrue);
+    expect(
+      gateway.upsertedItemPayload?['vision_measure_interval_minutes'],
+      720,
+    );
+  });
 }
 
 Widget _wrap(Widget child) {

--- a/test/screens/item_detail_screen_test.dart
+++ b/test/screens/item_detail_screen_test.dart
@@ -118,6 +118,37 @@ void main() {
 
     expect(find.text('최저가 정보를 찾지 못했습니다.'), findsOneWidget);
   });
+
+  testWidgets(
+    'item detail shows current inventory section when snapshot exists',
+    (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          item: _item(
+            id: 'item-inventory',
+            remainingQuantity: 2,
+            inventoryConfidence: 0.91,
+            inventorySourceName: 'Milk',
+            inventoryObservedAt: DateTime.parse('2026-05-29T06:12:00.000Z'),
+          ),
+          priceComparisonGateway:
+              ({required brand, required display, required itemName}) async {
+                return const PriceComparisonFetchResult(
+                  comparisons: [],
+                  source: PriceComparisonSource.proxy,
+                );
+              },
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.text('현재 남은 수량'), findsOneWidget);
+      expect(find.text('2개'), findsOneWidget);
+      expect(find.textContaining('신뢰도 91%'), findsOneWidget);
+      expect(find.textContaining('2026.05.29'), findsOneWidget);
+    },
+  );
 }
 
 Widget _wrap({
@@ -139,6 +170,10 @@ ConsumableItem _item({
   String? registeredBy,
   String? registeredByDisplayName,
   String? registeredByEmail,
+  int? remainingQuantity,
+  double? inventoryConfidence,
+  String? inventorySourceName,
+  DateTime? inventoryObservedAt,
 }) {
   return ConsumableItem(
     id: id,
@@ -153,5 +188,9 @@ ConsumableItem _item({
     registeredBy: registeredBy,
     registeredByDisplayName: registeredByDisplayName,
     registeredByEmail: registeredByEmail,
+    remainingQuantity: remainingQuantity,
+    inventoryConfidence: inventoryConfidence,
+    inventorySourceName: inventorySourceName,
+    inventoryObservedAt: inventoryObservedAt,
   );
 }

--- a/test/services/supabase_service_test.dart
+++ b/test/services/supabase_service_test.dart
@@ -182,6 +182,7 @@ Map<String, dynamic> _itemRow({
       },
     ],
     'ai_predictions': <Map<String, dynamic>>[],
+    'product_inventory_snapshots': <Map<String, dynamic>>[],
   };
 }
 
@@ -566,6 +567,53 @@ void main() {
         expect(items.single.registeredByLabel, 'minseo@example.com');
       },
     );
+
+    test('maps latest inventory snapshot for personal items', () async {
+      final gateway = _RecordingItemDatabaseGateway()
+        ..loadItemsResult = <Map<String, dynamic>>[
+          _itemRow(id: 'personal-1', userId: SupabaseService.currentUserId)
+            ..['product_inventory_snapshots'] = <Map<String, dynamic>>[
+              <String, dynamic>{
+                'remaining_quantity': 3,
+                'confidence': 0.91,
+                'source_detected_name': 'Milk',
+                'observed_at': '2026-05-29T06:12:00.000Z',
+              },
+            ],
+        ];
+      SupabaseService.debugItemDatabaseGateway = gateway;
+
+      final items = await SupabaseService.loadItemsForScope(
+        const ItemScope.personal(),
+      );
+
+      expect(items.single.remainingQuantity, 3);
+      expect(items.single.inventoryConfidence, 0.91);
+      expect(items.single.inventorySourceName, 'Milk');
+      expect(
+        items.single.inventoryObservedAt,
+        DateTime.parse('2026-05-29T06:12:00.000Z'),
+      );
+      expect(items.single.remainingQuantityLabel, '현재 3개');
+    });
+
+    test('leaves inventory fields null when no snapshot exists', () async {
+      final gateway = _RecordingItemDatabaseGateway()
+        ..loadItemsResult = <Map<String, dynamic>>[
+          _itemRow(id: 'personal-1', userId: SupabaseService.currentUserId),
+        ];
+      SupabaseService.debugItemDatabaseGateway = gateway;
+
+      final items = await SupabaseService.loadItemsForScope(
+        const ItemScope.personal(),
+      );
+
+      expect(items.single.remainingQuantity, isNull);
+      expect(items.single.inventoryObservedAt, isNull);
+      expect(items.single.inventoryConfidence, isNull);
+      expect(items.single.inventorySourceName, isNull);
+      expect(items.single.remainingQuantityLabel, isNull);
+    });
   });
 
   group('SupabaseService.saveItem scoped ownership', () {

--- a/test/services/supabase_service_test.dart
+++ b/test/services/supabase_service_test.dart
@@ -171,6 +171,9 @@ Map<String, dynamic> _itemRow({
     'brand': '브랜드',
     'image_url': null,
     'replacement_cycle_days': 30,
+    'vision_tracking_enabled': false,
+    'vision_measure_interval_minutes': 360,
+    'vision_last_measured_at': null,
     'created_at': '2026-05-26T00:00:00.000Z',
     'categories': <String, dynamic>{'id': 'category-1', 'name': '주방/세제'},
     'purchases': <Map<String, dynamic>>[
@@ -614,6 +617,28 @@ void main() {
       expect(items.single.inventorySourceName, isNull);
       expect(items.single.remainingQuantityLabel, isNull);
     });
+
+    test('maps vision tracking settings from product rows', () async {
+      final gateway = _RecordingItemDatabaseGateway()
+        ..loadItemsResult = <Map<String, dynamic>>[
+          _itemRow(id: 'personal-1', userId: SupabaseService.currentUserId)
+            ..['vision_tracking_enabled'] = true
+            ..['vision_measure_interval_minutes'] = 720
+            ..['vision_last_measured_at'] = '2026-05-29T03:00:00.000Z',
+        ];
+      SupabaseService.debugItemDatabaseGateway = gateway;
+
+      final items = await SupabaseService.loadItemsForScope(
+        const ItemScope.personal(),
+      );
+
+      expect(items.single.visionTrackingEnabled, isTrue);
+      expect(items.single.visionMeasureIntervalMinutes, 720);
+      expect(
+        items.single.visionLastMeasuredAt,
+        DateTime.parse('2026-05-29T03:00:00.000Z'),
+      );
+    });
   });
 
   group('SupabaseService.saveItem scoped ownership', () {
@@ -686,6 +711,32 @@ void main() {
         SupabaseService.currentUserId,
       );
       expect(gateway.upsertedItemPayload?['group_id'], isNull);
+    });
+
+    test('saves vision tracking settings with product items', () async {
+      final gateway = _RecordingItemDatabaseGateway();
+      SupabaseService.debugItemDatabaseGateway = gateway;
+
+      await SupabaseService.saveItem(
+        ConsumableItem(
+          id: 'item-1',
+          name: 'Milk',
+          brand: 'Seoul',
+          category: 'Kitchen',
+          icon: ConsumableItem.iconForCategory('Kitchen'),
+          daysRemaining: 30,
+          cycleDays: 30,
+          progress: 0,
+          visionTrackingEnabled: true,
+          visionMeasureIntervalMinutes: 720,
+        ),
+      );
+
+      expect(gateway.upsertedItemPayload?['vision_tracking_enabled'], isTrue);
+      expect(
+        gateway.upsertedItemPayload?['vision_measure_interval_minutes'],
+        720,
+      );
     });
   });
 

--- a/test/widgets/item_row_test.dart
+++ b/test/widgets/item_row_test.dart
@@ -45,12 +45,28 @@ void main() {
 
     expect(find.textContaining('추가:'), findsNothing);
   });
+
+  testWidgets('item row shows current remaining quantity when available', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.lightTheme,
+        home: Scaffold(
+          body: ItemRow(item: _item(remainingQuantity: 3), onTap: () {}),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('현재 3개'), findsOneWidget);
+  });
 }
 
 ConsumableItem _item({
   String? groupId,
   String? registeredByDisplayName,
   String? registeredByEmail,
+  int? remainingQuantity,
 }) {
   return ConsumableItem(
     id: 'item-1',
@@ -65,5 +81,6 @@ ConsumableItem _item({
     registeredBy: 'user-1',
     registeredByDisplayName: registeredByDisplayName,
     registeredByEmail: registeredByEmail,
+    remainingQuantity: remainingQuantity,
   );
 }


### PR DESCRIPTION
## 변경 사항
- MIDAS 분석 결과를 Supabase 재고 관측/스냅샷 테이블에 저장하도록 추가했습니다.
- 앱의 물품 목록/상세 화면에서 현재 남은 수량과 마지막 측정 시간을 표시하도록 연결했습니다.
- 물품 등록/수정 화면에 Vision 추적 설정과 측정 주기 선택을 추가했습니다.
- Supabase migration 기록 동기화 후 원격 DB에 재고/비전 설정 migration을 적용했습니다.
- 최신 `develop` 변경 사항을 반영하면서 AI 예측 fallback과 재고 스냅샷 매핑을 함께 유지했습니다.
- Supabase CLI 임시 파일이 git에 잡히지 않도록 `supabase/.temp/`를 ignore 처리했습니다.

## 변경 이유
- 졸업작품 시연에서 MIDAS 서버가 인식한 물품 잔량을 앱에서 확인할 수 있어야 합니다.

## 테스트
- `dart analyze`
- `flutter test`
- `python -m unittest test_inventory_sync.py`
- `python -m py_compile server.py inventory_sync.py test_inventory_sync.py`
- `npx supabase db push`